### PR TITLE
Require aggregate checks in public rulesets

### DIFF
--- a/.github/rulesets/0.1.x.json
+++ b/.github/rulesets/0.1.x.json
@@ -28,6 +28,21 @@
       "type": "non_fast_forward"
     },
     {
+      "type": "required_status_checks",
+      "parameters": {
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "Core Checks Gate"
+          },
+          {
+            "context": "Full Validation Gate"
+          }
+        ],
+        "strict_required_status_checks_policy": true
+      }
+    },
+    {
       "type": "pull_request",
       "parameters": {
         "allowed_merge_methods": [

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -25,6 +25,21 @@
       "type": "non_fast_forward"
     },
     {
+      "type": "required_status_checks",
+      "parameters": {
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "Core Checks Gate"
+          },
+          {
+            "context": "Full Validation Gate"
+          }
+        ],
+        "strict_required_status_checks_policy": true
+      }
+    },
+    {
       "type": "pull_request",
       "parameters": {
         "allowed_merge_methods": [

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,45 @@
+# CI Scripts
+
+This directory contains scripts for each build step in each build stage.
+
+## CI Names And Trust Gate
+
+Use neutral workflow names when discussing GitHub checks:
+
+- `Core Checks`: baseline PR checks, backed by `core-checks.yml`.
+- `Core Checks Gate`: the aggregated fail-closed gate for the baseline checks.
+- `Full Validation`: self-hosted validation, backed by `ci.yml`.
+- `Full Validation Gate`: the maintainer-controlled merge gate for Full
+  Validation results.
+- `Nightly CI`: scheduled and manually dispatched heavy validation, backed by
+  `ci-nightly-heavy.yml`.
+
+Fresh external pull requests into `main` are not auto-closed, auto-commented,
+or auto-labeled. `Core Checks` run for those PRs first. Self-hosted
+`Full Validation` waits until a maintainer applies the `ci:qbit-trusted` label;
+contributors should not add or ask automation to add that label themselves.
+
+The `ci:qbit-trusted` label persists across later pushes to the same pull
+request, and `pull_request`-triggered runs cannot remove it because fork PR
+runs hold a read-only token by design. After labeling a fork PR, maintainers
+must re-review any new commits, and remove the label if a trusted fork PR is
+updated with unreviewed changes so the next push does not re-run self-hosted
+jobs on unreviewed code.
+
+Branch rulesets require the two aggregated gates, `Core Checks Gate` and
+`Full Validation Gate`, instead of raw jobs. Do not require `build smoke`,
+`focused unit suites`, `ci-matrix`, `lint`, `windows-cross`,
+`test-each-commit`, or other raw jobs directly; those are internal inputs to
+the gates and some are skipped when a fork PR is not trusted. Both gates fail
+closed: a skipped, cancelled, or failed input job makes the gate fail, so an
+untrusted fork PR cannot pass `Full Validation Gate`.
+
+Raw `Full Validation` self-hosted jobs select their runner pool by repository:
+in the public `Qbit-Org/qbit` repo they require the
+`self-hosted, linux, x64, qbit-trusted-ci` labels, and everywhere else they use
+the standard `self-hosted, linux, x64` pool. The same workflow therefore runs
+full validation in the public repo with no per-repo edits, and in the public
+repo the qbit-tools autoscaler uses the `qbit-trusted-ci` label to count and
+scale only trusted CI work. Fork-PR safety is enforced by the trust-gate
+conditions, independent of the runner pool.
+

--- a/doc/development/public-branch-and-rulesets.md
+++ b/doc/development/public-branch-and-rulesets.md
@@ -1,0 +1,111 @@
+# Public Branch and Ruleset Model
+
+This document defines the public repository branch, tag, and ruleset model for
+qbit v0.1.x testnet releases.
+
+## Public Branch Set
+
+The public repository keeps a small branch surface:
+
+| Ref | Purpose | Creation timing |
+| --- | --- | --- |
+| `main` | Default public pull request target and active public integration branch. | Exists at public repository launch. |
+| `0.1.x` | Maintenance branch for v0.1.x testnet backports. | Create from the `v0.1.0-testnet4` tag target when the first v0.1.x patch, reset, or backport is needed. |
+| `0.2.x` | Future maintenance/development line after v0.2.x opens. | Do not create during v0.1.x launch unless maintainers explicitly open that line. |
+| `upstream/bitcoin-v30.2` | Optional locked Bitcoin Core reference branch. | Create only if maintainers want a public upstream reference. |
+
+Temporary public branches are allowed only for bounded operations:
+
+| Pattern | Purpose |
+| --- | --- |
+| `sync/public-snapshot/<date-or-version>` | Staging sanitized public snapshots before they are merged to `main`. |
+| `backport/<topic>-to-0.1.x` | Preparing a public maintenance backport. |
+| `release/v<version>` | Preparing release-only adjustments for a specific public tag. |
+
+Do not publish private integration branches, review branches, agent branches,
+tracker branches, or internal staging branches to the public repository.
+
+## Tag Model
+
+Public release tags use signed, annotated `v*` tags:
+
+| Tag pattern | Purpose |
+| --- | --- |
+| `v0.1.0-testnet4-rcN` | Public release candidates for v0.1.0 testnet4. |
+| `v0.1.0-testnet4` | Final v0.1.0 testnet4 release tag. |
+| `v0.1.N-testnet4` | Future v0.1.x patch or reset tags, when needed. |
+
+Tag updates and deletions are not part of normal release operations. If a tag
+must be corrected before announcement, delete and recreate it only through the
+release-maintainer path, and record the replacement rationale in the release
+checklist.
+
+## Ruleset Templates
+
+Ruleset JSON templates are the public-safe files below:
+
+| Template | Target | Baseline behavior |
+| --- | --- | --- |
+| `.github/rulesets/main.json` | `refs/heads/main` | Require pull requests, one approval, resolved conversations, merge commits only, `Core Checks Gate`, `Full Validation Gate`, block deletion, and block non-fast-forward updates. |
+| `.github/rulesets/0.1.x.json` | `refs/heads/0.1.x` | Restrict branch creation to bypass actors, require pull requests, one approval, resolved conversations, merge commits only, `Core Checks Gate`, `Full Validation Gate`, block deletion, and block non-fast-forward updates. |
+| `.github/rulesets/release-tags-v.json` | `refs/tags/v*` | Restrict tag creation, updates, and deletion to bypass actors. |
+| `.github/rulesets/upstream-refs.json` | `refs/heads/upstream/**` | Lock optional upstream reference branches so only bypass actors can create, update, or delete them. |
+
+Templates that restrict ref creation, update, or deletion intentionally use
+`OrganizationAdmin` as the only portable bypass actor. Before applying them to
+the public repository, maintainers should replace or supplement that bypass
+with the final public release-maintainer team, user, or repository-role actor
+IDs.
+
+GitHub's ruleset `required_signatures` rule checks commit signatures, not the
+release tag object. Do not rely on rulesets alone for the signed annotated tag
+policy. The public release path must verify tag objects directly:
+
+- `.github/workflows/release-publish.yml` rejects lightweight tags and requires
+  GitHub-verified annotated tag signatures before publication.
+- `ci/release/validate_release_artifacts.py --verify-tag-signature` verifies the
+  release tag against the active qbit release-key policy for workflow and local
+  publication paths.
+
+Apply a template with the repository rulesets API after confirming the target
+repository and bypass actors:
+
+```sh
+gh api \
+  --method PATCH \
+  -H "Accept: application/vnd.github+json" \
+  repos/Qbit-Org/qbit/rulesets/<ruleset-id> \
+  --input .github/rulesets/main.json
+```
+
+Use the same command with the other template paths after reviewing their target
+refs and ruleset IDs.
+
+## Operational Notes
+
+Required status checks are encoded only as the aggregate `Core Checks Gate` and
+`Full Validation Gate`. Do not protect public branches with raw job names,
+because raw jobs are internal inputs to the gates and some are skipped until a
+fork pull request is trusted by a maintainer.
+
+Merge queue is not enabled in these templates. Enable it only after public CI
+supports `merge_group` events.
+
+Code-owner review is disabled in these templates because public owner and team
+IDs are not frozen here. Enable `require_code_owner_review` only after a public
+`CODEOWNERS` file exists and the referenced owners are valid in the public
+repository.
+
+## Backport Metadata
+
+Backports to `0.1.x` should be maintainer-directed and should state:
+
+- the original public pull request or commit
+- the reason the change is needed on v0.1.x
+- whether the change affects consensus, wallet behavior, P2P behavior, release
+  artifacts, or documentation only
+- the validation run against `0.1.x`
+
+If the `0.1.x` branch has not been created yet, create it from the final
+`v0.1.0-testnet4` tag target before opening the first backport pull request.
+


### PR DESCRIPTION
## Summary

- require `Core Checks Gate` and `Full Validation Gate` in the public `main` and `0.1.x` ruleset templates
- add public CI trust-gate documentation for `ci:qbit-trusted` and aggregate gate names
- add the public branch, tag, and ruleset model used during release cutover

## Validation

- `jq empty .github/rulesets/main.json .github/rulesets/0.1.x.json .github/rulesets/release-tags-v.json .github/rulesets/upstream-refs.json`
- `git diff --check`

## Notes

The existing in-repo branch/tag creation and bypass rules were already sufficient for the live ruleset deltas. This PR addresses the remaining source-side gap: branch ruleset templates did not yet encode the two aggregate required checks.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784839203&installation_id=141183937&pr_number=5&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F5&signature=9cd145609a3a5db5b47f62bd4e657380fb9c2813a38d5396f955cb831d09fe70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->