### PR TITLE
Fix PR 4 Windows and lint failures

### DIFF
--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -58,6 +58,13 @@ class MultiWalletTest(BitcoinTestFramework):
             help='Test data with wallet directories (default: %(default)s)',
         )
 
+    def wait_pqc_key_validation_ready(self, wallet):
+        def ready():
+            validation = wallet.getwalletinfo().get("pqc_key_validation", {})
+            return validation.get("status") in ("not_required", "complete") and not validation.get("signing_blocked", True)
+
+        self.wait_until(ready, timeout=180)
+
     def run_test(self):
         node = self.nodes[0]
 
@@ -358,6 +365,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
         # Successfully unload the wallet referenced by the request endpoint
         # Also ensure unload works during walletpassphrase timeout
+        self.wait_pqc_key_validation_ready(w2)
         w2.encryptwallet('test')
         w2.walletpassphrase('test', 1)
         w2.unloadwallet()

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -95,14 +95,17 @@ maintained:
 * for `src/crc32c`: https://github.com/bitcoin-core/crc32c-subtree.git (branch bitcoin-fork)
 * for `src/crypto/ctaes`: https://github.com/bitcoin-core/ctaes.git (branch master)
 * for `src/ipc/libmultiprocess`: https://github.com/bitcoin-core/libmultiprocess (branch master)
-* for `src/libbitcoinpqc`: https://github.com/<owner>/libbitcoinpqc-qbit.git (branch qbit-subtree)
 * for `src/leveldb`: https://github.com/bitcoin-core/leveldb-subtree.git (branch bitcoin-fork)
 * for `src/minisketch`: https://github.com/bitcoin-core/minisketch.git (branch master)
 * for `src/secp256k1`: https://github.com/bitcoin-core/secp256k1.git (branch master)
 
 Keep this list in sync with `fn get_subtrees()` in the lint runner.
 
-For the qbit-specific libbitcoinpqc subtree workflow, see
+The qbit-specific `src/libbitcoinpqc` vendored source is excluded from generic
+file linters, but public release snapshot branches may not carry
+`git-subtree` metadata until the public `Qbit-Org/libbitcoinpqc-qbit`
+repository is available. For the libbitcoinpqc subtree workflow and provenance
+checks, see
 [`doc/subtrees/libbitcoinpqc.md`](../../doc/subtrees/libbitcoinpqc.md).
 
 To do so, add the upstream repository as remote:

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -210,7 +210,6 @@ fn get_subtrees() -> Vec<&'static str> {
         "src/crc32c",
         "src/crypto/ctaes",
         "src/ipc/libmultiprocess",
-        "src/libbitcoinpqc",
         "src/leveldb",
         "src/minisketch",
         "src/secp256k1",
@@ -222,6 +221,9 @@ fn get_pathspecs_default_excludes() -> Vec<String> {
     get_subtrees()
         .iter()
         .chain(&[
+            // qbit-specific vendored source. Public release snapshot branches may not
+            // carry git-subtree metadata until the public upstream repository exists.
+            "src/libbitcoinpqc",
             "doc/release-notes/release-notes-*", // archived notes
             "contrib/photon/src/vendor/",        // externally sourced vendored code
         ])


### PR DESCRIPTION
## Summary
- wait for PQC wallet key validation before the multiwallet encryption step that failed on Windows
- keep `src/libbitcoinpqc` excluded as vendored source, but stop the generic subtree lint from requiring git-subtree metadata on public source snapshot branches
- document the temporary public-snapshot lint behavior without adding any internal repository URL

## Validation
- `RUST_BACKTRACE=1 cargo run --manifest-path ./test/lint/test_runner/Cargo.toml`
- `ulimit -n 10240; build/test/functional/test_runner.py wallet_multiwallet.py`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784842808&installation_id=141183937&pr_number=6&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F6&signature=8214b7b9c1054f346cff3e47680b04656238ea1da778fd345696eabb8cf01c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->