### PR TITLE
Require squash or rebase merges in public rulesets

### DIFF
--- a/.github/repository-settings/merge-methods.json
+++ b/.github/repository-settings/merge-methods.json
@@ -1,0 +1,5 @@
+{
+  "allow_squash_merge": true,
+  "allow_rebase_merge": true,
+  "allow_merge_commit": false
+}

--- a/.github/rulesets/0.1.x.json
+++ b/.github/rulesets/0.1.x.json
@@ -28,6 +28,9 @@
       "type": "non_fast_forward"
     },
     {
+      "type": "required_linear_history"
+    },
+    {
       "type": "required_status_checks",
       "parameters": {
         "do_not_enforce_on_create": true,
@@ -46,7 +49,8 @@
       "type": "pull_request",
       "parameters": {
         "allowed_merge_methods": [
-          "merge"
+          "squash",
+          "rebase"
         ],
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -25,6 +25,9 @@
       "type": "non_fast_forward"
     },
     {
+      "type": "required_linear_history"
+    },
+    {
       "type": "required_status_checks",
       "parameters": {
         "do_not_enforce_on_create": true,
@@ -43,7 +46,8 @@
       "type": "pull_request",
       "parameters": {
         "allowed_merge_methods": [
-          "merge"
+          "squash",
+          "rebase"
         ],
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": false,

--- a/doc/development/public-branch-and-rulesets.md
+++ b/doc/development/public-branch-and-rulesets.md
@@ -51,6 +51,23 @@ Ruleset JSON templates are the public-safe files below:
 | `.github/rulesets/release-tags-v.json` | `refs/tags/v*` | Restrict tag creation, updates, and deletion to bypass actors. |
 | `.github/rulesets/upstream-refs.json` | `refs/heads/upstream/**` | Lock optional upstream reference branches so only bypass actors can create, update, or delete them. |
 
+## Repository Merge Settings
+
+GitHub ruleset pull request merge-method restrictions apply to the target refs
+selected by each ruleset. Enforce the same no-merge-commit policy for every
+pull request by applying the repository-level merge-method settings template.
+These settings are repository-wide defaults rather than branch-scoped rules:
+
+| Template | Scope | Baseline behavior |
+| --- | --- | --- |
+| `.github/repository-settings/merge-methods.json` | All repository pull requests | Enable squash merges, keep rebase merges available as an optional linear method, and disable normal merge commits by default. |
+
+The normal merge-commit button should stay disabled in routine operation. If an
+unusual case needs a merge commit, a repository admin or release maintainer may
+temporarily set `allow_merge_commit` to `true`, perform the merge, record the
+reason in the relevant pull request or release checklist, and immediately
+restore this default template.
+
 Templates that restrict ref creation, update, or deletion intentionally use
 `OrganizationAdmin` as the only portable bypass actor. Before applying them to
 the public repository, maintainers should replace or supplement that bypass
@@ -72,7 +89,7 @@ repository and bypass actors:
 
 ```sh
 gh api \
-  --method PATCH \
+  --method PUT \
   -H "Accept: application/vnd.github+json" \
   repos/Qbit-Org/qbit/rulesets/<ruleset-id> \
   --input .github/rulesets/main.json
@@ -80,6 +97,16 @@ gh api \
 
 Use the same command with the other template paths after reviewing their target
 refs and ruleset IDs.
+
+Apply the repository-wide merge-method policy with the repository API:
+
+```sh
+gh api \
+  --method PATCH \
+  -H "Accept: application/vnd.github+json" \
+  repos/Qbit-Org/qbit \
+  --input .github/repository-settings/merge-methods.json
+```
 
 ## Operational Notes
 

--- a/doc/development/public-branch-and-rulesets.md
+++ b/doc/development/public-branch-and-rulesets.md
@@ -46,8 +46,8 @@ Ruleset JSON templates are the public-safe files below:
 
 | Template | Target | Baseline behavior |
 | --- | --- | --- |
-| `.github/rulesets/main.json` | `refs/heads/main` | Require pull requests, one approval, resolved conversations, merge commits only, `Core Checks Gate`, `Full Validation Gate`, block deletion, and block non-fast-forward updates. |
-| `.github/rulesets/0.1.x.json` | `refs/heads/0.1.x` | Restrict branch creation to bypass actors, require pull requests, one approval, resolved conversations, merge commits only, `Core Checks Gate`, `Full Validation Gate`, block deletion, and block non-fast-forward updates. |
+| `.github/rulesets/main.json` | `refs/heads/main` | Require pull requests, one approval, resolved conversations, squash/rebase merge methods only, linear history, `Core Checks Gate`, `Full Validation Gate`, block deletion, and block non-fast-forward updates. |
+| `.github/rulesets/0.1.x.json` | `refs/heads/0.1.x` | Restrict branch creation to bypass actors, require pull requests, one approval, resolved conversations, squash/rebase merge methods only, linear history, `Core Checks Gate`, `Full Validation Gate`, block deletion, and block non-fast-forward updates. |
 | `.github/rulesets/release-tags-v.json` | `refs/tags/v*` | Restrict tag creation, updates, and deletion to bypass actors. |
 | `.github/rulesets/upstream-refs.json` | `refs/heads/upstream/**` | Lock optional upstream reference branches so only bypass actors can create, update, or delete them. |
 


### PR DESCRIPTION
## Summary

- Update the public `main` and `0.1.x` ruleset templates to allow only squash and rebase merge methods.
- Add the `required_linear_history` rule to those branch rulesets so merge commits are rejected by policy.
- Update the public branch and ruleset model documentation to match the new policy.

## Target

This is stacked on PR #4 and targets its head branch, `0.1.1-testnet4`.

## Validation

- `jq empty .github/rulesets/main.json .github/rulesets/0.1.x.json .github/rulesets/release-tags-v.json .github/rulesets/upstream-refs.json`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784899789&installation_id=141183937&pr_number=7&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F7&signature=3b88bce7c20c5890d6c8b9f9e247e08da600e10a85fd8e0c7879399ea854c442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->