### PR TITLE
test: wait for PQC key validation before wallet signing

### DIFF
--- a/test/functional/feature_integration_wallet_history.py
+++ b/test/functional/feature_integration_wallet_history.py
@@ -76,9 +76,6 @@ class IntegrationWalletHistoryTest(BitcoinTestFramework):
             for entry in entries
         )
 
-    def wait_pqc_key_validation_ready(self, wallet):
-        self.wait_until(lambda: not wallet.getwalletinfo()["pqc_key_validation"]["signing_blocked"])
-
     def run_test(self):
         archive_node = self.nodes[0]
         pruned_node = self.nodes[1]

--- a/test/functional/feature_rpc_perf.py
+++ b/test/functional/feature_rpc_perf.py
@@ -555,6 +555,7 @@ class RPCPerfTest(BitcoinTestFramework):
                     "importpubkeydb_counter": 0,
                 }
             )
+        self.wait_pqc_key_validation_ready(wallet)
 
     def reset_fixture_for_cold_sample(self, benchmark: BenchmarkCase, context: FixtureContext):
         if benchmark.fixture_reset_mode == "restart_node":

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -891,6 +891,16 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
     def wait_until(self, test_function, timeout=60, check_interval=0.05):
         return wait_until_helper_internal(test_function, timeout=timeout, timeout_factor=self.options.timeout_factor, check_interval=check_interval)
 
+    def wait_pqc_key_validation_ready(self, wallet, timeout=180):
+        def ready():
+            validation = wallet.getwalletinfo().get("pqc_key_validation")
+            return validation is None or (
+                validation.get("status") in ("not_required", "complete")
+                and not validation.get("signing_blocked", True)
+            )
+
+        self.wait_until(ready, timeout=timeout)
+
     # Private helper methods. These should not be accessed by the subclass test scripts.
 
     def _start_logging(self):

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -366,6 +366,7 @@ class ToolWalletTest(BitcoinTestFramework):
         self.ensure_mature_coinbase(self.nodes[0])
 
         def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.wait_pqc_key_validation_ready(def_wallet)
         while def_wallet.getbalance() < 15:
             self.generatetoaddress(self.nodes[0], 1, def_wallet.getnewaddress())
 
@@ -429,6 +430,7 @@ class ToolWalletTest(BitcoinTestFramework):
         # to make a very big transaction.
         self.ensure_mature_coinbase(self.nodes[0])
         def_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.wait_pqc_key_validation_ready(def_wallet)
         while def_wallet.getbalance() < 6:
             self.generatetoaddress(self.nodes[0], 1, def_wallet.getnewaddress())
         outputs = {}
@@ -436,6 +438,7 @@ class ToolWalletTest(BitcoinTestFramework):
             outputs[wallet.getnewaddress(address_type="p2sh-segwit")] = 0.01
         def_wallet.sendmany(amounts=outputs)
         self.generate(self.nodes[0], 1)
+        self.wait_pqc_key_validation_ready(wallet)
         send_res = wallet.sendall([def_wallet.getnewaddress()])
         self.generate(self.nodes[0], 1)
         assert_equal(send_res["complete"], True)

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -163,6 +163,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         # Remove using high relay fee again
         self.restart_node(0, extra_args=["-minrelaytxfee=0.0001"])
         alice = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.wait_pqc_key_validation_ready(alice)
         assert self.nodes[0].getmempoolinfo()['loaded']
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         newbalance = alice.getbalance()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -63,13 +63,6 @@ class WalletTest(BitcoinTestFramework):
         """Scale historical 50 BTC-baseline test amounts to the active subsidy."""
         return (Decimal(str(amount)) * self.subsidy_scale).quantize(Decimal("0.00000001"))
 
-    def wait_pqc_key_validation_ready(self, wallet):
-        def ready():
-            validation = wallet.getwalletinfo().get("pqc_key_validation", {})
-            return validation.get("status") in ("not_required", "complete") and not validation.get("signing_blocked", True)
-
-        self.wait_until(ready, timeout=180)
-
     def run_test(self):
 
         # Check that there's no UTXO on none of the nodes
@@ -427,6 +420,7 @@ class WalletTest(BitcoinTestFramework):
         self.connect_nodes(1, 2)
         self.connect_nodes(0, 2)
         self.sync_all(self.nodes[0:3])
+        self.wait_pqc_key_validation_ready(self.nodes[0])
 
         broadcast_amount = min(self.scale_amount(2), (self.nodes[0].getbalance() / Decimal("10")).quantize(Decimal("0.00000001")))
         assert broadcast_amount > 0
@@ -454,6 +448,7 @@ class WalletTest(BitcoinTestFramework):
         self.connect_nodes(1, 2)
         self.connect_nodes(0, 2)
         self.sync_blocks(self.nodes[0:3])
+        self.wait_pqc_key_validation_ready(self.nodes[0])
 
         self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_blocks(self.nodes[0:3]))
         node_2_bal += broadcast_amount
@@ -524,6 +519,7 @@ class WalletTest(BitcoinTestFramework):
         # reindex will leave rpc warm up "early"; Wait for it to finish
         self.wait_until(lambda: [block_count] * 3 == [self.nodes[i].getblockcount() for i in range(3)])
         assert_equal(balance_nodes, [self.nodes[i].getbalance() for i in range(3)])
+        self.wait_pqc_key_validation_ready(self.nodes[0])
 
         # Exercise listsinceblock with the last two blocks
         coinbase_tx_1 = self.nodes[0].listsinceblock(blocks[0])
@@ -569,6 +565,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Prevent potential race condition when calling wallet RPCs right after restart
         self.nodes[0].syncwithvalidationinterfacequeue()
+        self.wait_pqc_key_validation_ready(self.nodes[0])
 
         node0_balance = self.nodes[0].getbalance()
         # With walletrejectlongchains we will not create the tx and store it in our wallet.
@@ -686,6 +683,8 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[0].createwallet(wallet_name="zeroconf", load_on_startup=True)
         zeroconf_wallet = self.nodes[0].get_wallet_rpc("zeroconf")
         default_wallet = self.nodes[0].get_wallet_rpc(self.default_wallet_name)
+        self.wait_pqc_key_validation_ready(default_wallet)
+        self.wait_pqc_key_validation_ready(zeroconf_wallet)
         default_wallet.sendtoaddress(zeroconf_wallet.getnewaddress(), Decimal('1.0'))
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)
         utxos = zeroconf_wallet.listunspent(minconf=0)

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -711,6 +711,7 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[0].syncwithvalidationinterfacequeue()
 
         zeroconf_wallet = self.nodes[0].get_wallet_rpc("zeroconf")
+        self.wait_pqc_key_validation_ready(zeroconf_wallet)
         utxos = zeroconf_wallet.listunspent(minconf=0)
         assert_equal(len(utxos), 1)
         assert_equal(utxos[0]['confirmations'], 0)

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -58,6 +58,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
         for fee_setting in ['-minrelaytxfee=0.01', '-mintxfee=0.01', '-paytxfee=0.01']:
             self.log.info('Check maxtxfee in combination with {}'.format(fee_setting))
             self.restart_node(0, extra_args=[fee_setting])
+            self.wait_pqc_key_validation_ready(self.nodes[0])
             assert_raises_rpc_error(
                 -6,
                 "Fee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)",
@@ -71,6 +72,7 @@ class CreateTxWalletTest(BitcoinTestFramework):
 
         self.log.info('Check maxtxfee in combination with settxfee')
         self.restart_node(0, expected_stderr='Warning: -paytxfee is deprecated and will be fully removed in v31.0.')
+        self.wait_pqc_key_validation_ready(self.nodes[0])
         self.nodes[0].settxfee(0.01)
         assert_raises_rpc_error(
             -6,

--- a/test/functional/wallet_fallbackfee.py
+++ b/test/functional/wallet_fallbackfee.py
@@ -23,6 +23,7 @@ class WalletRBFTest(BitcoinTestFramework):
 
         # test sending a tx with disabled fallback fee (must fail)
         self.restart_node(0, extra_args=["-fallbackfee=0"])
+        self.wait_pqc_key_validation_ready(self.nodes[0])
         assert_raises_rpc_error(-6, "Fee estimation failed", lambda: self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1))
         assert_raises_rpc_error(-4, "Fee estimation failed", lambda: self.nodes[0].fundrawtransaction(self.nodes[0].createrawtransaction([], {self.nodes[0].getnewaddress(): 1})))
         assert_raises_rpc_error(-6, "Fee estimation failed", lambda: self.nodes[0].sendmany("", {self.nodes[0].getnewaddress(): 1}))

--- a/test/functional/wallet_fundrawtransaction.py
+++ b/test/functional/wallet_fundrawtransaction.py
@@ -67,13 +67,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.connect_nodes(0, 2)
         self.connect_nodes(0, 3)
 
-    def wait_pqc_key_validation_ready(self, wallet):
-        def ready():
-            validation = wallet.getwalletinfo().get("pqc_key_validation", {})
-            return validation.get("status") in ("not_required", "complete") and not validation.get("signing_blocked", True)
-
-        self.wait_until(ready, timeout=180)
-
     def lock_outputs_type(self, wallet, outputtype):
         """
         Only allow UTXOs of the given type
@@ -1450,6 +1443,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.connect_nodes(0, 1)
         self.connect_nodes(0, 2)
         self.connect_nodes(0, 3)
+        self.wait_pqc_key_validation_ready(self.nodes[0])
 
     def test_feerate_rounding(self):
         self.log.info("Test that rounding of GetFee does not result in an assertion")

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -104,6 +104,7 @@ class WalletHDTest(BitcoinTestFramework):
         self.start_node(1, extra_args=self.extra_args[1])
         self.connect_nodes(0, 1)
         self.sync_all()
+        self.wait_pqc_key_validation_ready(self.nodes[1])
         # Wallet automatically scans blocks older than key on startup
         assert_equal(self.nodes[1].getbalance(), NUM_HD_ADDS + 1)
         out = self.nodes[1].rescanblockchain(0, 1)

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -235,6 +235,8 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.connect_nodes(0, 1)
         self.connect_nodes(1, 2)
         self.connect_nodes(2, 0)
+        self.wait_pqc_key_validation_ready(self.nodes[0])
+        self.wait_pqc_key_validation_ready(self.nodes[1])
 
         addr1 = self.nodes[0].getnewaddress("pizza1", 'legacy')
         addr2 = self.nodes[0].getnewaddress("pizza2", 'p2sh-segwit')

--- a/test/functional/wallet_migration.py
+++ b/test/functional/wallet_migration.py
@@ -235,6 +235,7 @@ class WalletMigrationTest(BitcoinTestFramework):
         self.restart_node(0)
         self.connect_nodes(0, 1)
         default = self.master_node.get_wallet_rpc(self.default_wallet_name)
+        self.wait_pqc_key_validation_ready(default)
         self.master_node.loadwallet("basic1")
         basic1 = self.master_node.get_wallet_rpc("basic1")
         assert_equal(basic1.getbalance(), bal)

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -58,13 +58,6 @@ class MultiWalletTest(BitcoinTestFramework):
             help='Test data with wallet directories (default: %(default)s)',
         )
 
-    def wait_pqc_key_validation_ready(self, wallet):
-        def ready():
-            validation = wallet.getwalletinfo().get("pqc_key_validation", {})
-            return validation.get("status") in ("not_required", "complete") and not validation.get("signing_blocked", True)
-
-        self.wait_until(ready, timeout=180)
-
     def run_test(self):
         node = self.nodes[0]
 
@@ -225,6 +218,8 @@ class MultiWalletTest(BitcoinTestFramework):
 
         wallets = [wallet(w) for w in wallet_names]
         wallet_bad = wallet("bad")
+        for wallet_rpc in wallets:
+            self.wait_pqc_key_validation_ready(wallet_rpc)
 
         # check wallet names and balances
         self.generatetoaddress(node, nblocks=1, address=wallets[0].getnewaddress(), sync_fun=self.no_op)

--- a/test/functional/wallet_p2mr_multisig_restart.py
+++ b/test/functional/wallet_p2mr_multisig_restart.py
@@ -155,6 +155,8 @@ class WalletP2MRMultisigRestartTest(BitcoinTestFramework):
         miner = node.get_wallet_rpc(self.default_wallet_name)
         signers = [node.get_wallet_rpc(f"ms_signer_{i}") for i in range(3)]
         coordinator = node.get_wallet_rpc("ms_coordinator")
+        for signer in signers:
+            self.wait_pqc_key_validation_ready(signer)
 
         self.log.info("Counters and spent-state survived the restart")
         assert_equal(self.pqc_count(signers[0], addr_a), 1)

--- a/test/functional/wallet_pqc_usage.py
+++ b/test/functional/wallet_pqc_usage.py
@@ -93,13 +93,6 @@ class WalletPQCUsageTest(BitcoinTestFramework):
         assert_equal(info["pqc_signature_count"], expected_count)
         return info
 
-    def wait_pqc_key_validation_ready(self, wallet):
-        def ready():
-            validation = wallet.getwalletinfo().get("pqc_key_validation", {})
-            return validation.get("status") in ("not_required", "complete") and not validation.get("signing_blocked", True)
-
-        self.wait_until(ready, timeout=180)
-
     def create_raw_spend(self, utxos, destination, fee=None):
         if isinstance(utxos, dict):
             utxos = [utxos]


### PR DESCRIPTION
## Summary
- Add a shared functional test helper that waits until wallet `pqc_key_validation` no longer blocks signing.
- Use that shared helper for the original failing restart/reload paths in `wallet_basic.py`, `wallet_listtransactions.py`, and `wallet_p2mr_multisig_restart.py`.
- Remove duplicated one-off PQC validation wait helpers from individual tests.
- Add preemptive waits at code-inspected same-wallet restart/load/restore sites before signing/send RPCs in wallet functional tests and the RPC perf wallet fixture.

## Why
PR 4 CI failures were caused by tests reaching wallet signing RPCs while plaintext PQC wallet key validation was still running in the background. This keeps the production validation gate intact and makes tests wait for persisted wallet readiness instead of bypassing validation.

## Validation
- `python3 -m py_compile test/functional/test_framework/test_framework.py test/functional/wallet_basic.py test/functional/wallet_create_tx.py test/functional/wallet_multiwallet.py test/functional/wallet_fundrawtransaction.py test/functional/feature_integration_wallet_history.py test/functional/wallet_pqc_usage.py test/functional/tool_wallet.py test/functional/feature_rpc_perf.py test/functional/wallet_fallbackfee.py test/functional/wallet_hd.py test/functional/wallet_abandonconflict.py test/functional/wallet_migration.py test/functional/wallet_listtransactions.py test/functional/wallet_p2mr_multisig_restart.py`
- `git diff --check`

Functional tests were not run locally because this workspace does not have a built `qbitd`/functional test runner available.
