### PR TITLE
Adjust AuxPoW commitment activation height

### DIFF
--- a/doc/release-notes-0.1.1-testnet4.md
+++ b/doc/release-notes-0.1.1-testnet4.md
@@ -67,7 +67,7 @@ commitment byte order and the activation height so pool software can follow the
 node result instead of inferring the encoding.
 
 The AuxPoW display-commitment change is a scheduled testnet4 consensus rule
-transition at height `27700`. Nodes and mining software that remain on older
+transition at height `20500`. Nodes and mining software that remain on older
 rules after that height may be unable to follow corrected AuxPoW blocks.
 
 | Item | Value |
@@ -77,7 +77,7 @@ rules after that height may be unable to follow corrected AuxPoW blocks.
 | Default RPC/REST port | `48352` |
 | Address HRP | `tq` |
 | AuxPoW chain ID | `31430` |
-| AuxPoW display-commitment activation height | `27700` |
+| AuxPoW display-commitment activation height | `20500` |
 
 Notable changes
 ===============
@@ -87,8 +87,8 @@ Notable changes
 - Corrected the AuxPoW parent-coinbase commitment byte order used by merged
   mining templates and validation.
 - Preserved existing testnet4 AuxPoW history by validating the original
-  internal byte order before height `27700` and the corrected display byte
-  order at and after height `27700`.
+  internal byte order before height `20500` and the corrected display byte
+  order at and after height `20500`.
 - Added `commitmentorder` and `commitmentactivationheight` fields to
   `createauxblock` results. Before activation the commitment order is
   `internal`; at activation and later it is `display`.

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -39,7 +39,7 @@ auto consteval_ctor(auto&& input) { return input; }
 
 static constexpr int QBIT_PUBLIC_TESTNET_AUXPOW_CHAIN_ID{31430};
 static constexpr int QBIT_TEST_CHAIN_AUXPOW_CHAIN_ID{QBIT_PUBLIC_TESTNET_AUXPOW_CHAIN_ID};
-static constexpr int QBIT_TESTNET4_AUXPOW_DISPLAY_COMMITMENT_HEIGHT{27'700};
+static constexpr int QBIT_TESTNET4_AUXPOW_DISPLAY_COMMITMENT_HEIGHT{20'500};
 
 // Mainnet is not launched. This placeholder intentionally matches public
 // testnet only while mainnet params are still development scaffolding. Replace

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -477,11 +477,11 @@ BOOST_AUTO_TEST_CASE(auxpow_commitment_validation_modes_match_activation_plan)
 BOOST_AUTO_TEST_CASE(auxpow_commitment_validation_height_helper)
 {
     auto consensus = CreateChainParams(*m_node.args, ChainType::MAIN)->GetConsensus();
-    consensus.nAuxpowDisplayCommitmentHeight = 27'700;
+    consensus.nAuxpowDisplayCommitmentHeight = 20'500;
 
-    BOOST_CHECK(auxpow::CommitmentValidationForHeight(consensus, 27'699) == auxpow::CommitmentValidation::INTERNAL);
-    BOOST_CHECK(auxpow::CommitmentValidationForHeight(consensus, 27'700) == auxpow::CommitmentValidation::DISPLAY);
-    BOOST_CHECK(auxpow::CommitmentValidationForHeight(consensus, 27'701) == auxpow::CommitmentValidation::DISPLAY);
+    BOOST_CHECK(auxpow::CommitmentValidationForHeight(consensus, 20'499) == auxpow::CommitmentValidation::INTERNAL);
+    BOOST_CHECK(auxpow::CommitmentValidationForHeight(consensus, 20'500) == auxpow::CommitmentValidation::DISPLAY);
+    BOOST_CHECK(auxpow::CommitmentValidationForHeight(consensus, 20'501) == auxpow::CommitmentValidation::DISPLAY);
 }
 
 BOOST_AUTO_TEST_CASE(auxpow_rejects_commitment_shape_failures)


### PR DESCRIPTION
## Summary

- Move the testnet4 AuxPoW display-commitment activation height from 27700 to 20500.
- Update the release notes to publish the new activation height.
- Keep the AuxPoW commitment height helper unit test aligned with the new boundary.

## Validation

- `git diff --check`
- Scoped search for stale `27700` activation-height references in `src`, `doc`, and `test` excluding vendored/test-vector data

A built test binary was not present in this workspace, so the focused unit test was not run locally.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784903373&installation_id=141183937&pr_number=9&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F9&signature=72625f19143739123def96cdc647c497e2d5493468603f2ad2bc7bcea5b4e5ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a testnet4 consensus schedule change; nodes and mining software must agree on height 20500 or they may reject blocks after activation.
> 
> **Overview**
> Moves the **testnet4** scheduled AuxPoW display-commitment consensus transition from block height **27700** to **20500**.
> 
> The change updates `QBIT_TESTNET4_AUXPOW_DISPLAY_COMMITMENT_HEIGHT` in chain params (which drives `consensus.nAuxpowDisplayCommitmentHeight` for testnet4), the **v0.1.1-testnet4** release notes (upgrade guidance, network table, and internal vs display byte-order boundary), and the `auxpow_commitment_validation_height_helper` unit test expectations at heights 20499/20500/20501.
> 
> No validation logic changes—only **when** testnet4 switches from internal to display commitment byte order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29980e06c02d2294ad27fc655fbf7d8ed6dadf5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->