### PR TITLE
Add scheduled performance workflows

### DIFF
--- a/.github/workflows/ci-nightly-heavy.yml
+++ b/.github/workflows/ci-nightly-heavy.yml
@@ -58,7 +58,7 @@ jobs:
   nightly-matrix:
     if: ${{ (github.event_name == 'schedule' && vars.CI_NIGHTLY_HEAVY_RUN_TEST_MATRIX != 'false') || (github.event_name == 'workflow_dispatch' && inputs.run_test_matrix) }}
     name: ${{ matrix.name }}
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ${{ github.repository == 'Qbit-Org/qbit' && fromJSON('["self-hosted", "linux", "x64", "qbit-trusted-ci"]') || fromJSON('["self-hosted", "linux", "x64"]') }}
     timeout-minutes: ${{ matrix.timeout-minutes }}
     env:
       DANGER_CI_ON_HOST_FOLDERS: 1
@@ -94,7 +94,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
+          ref: ${{ github.event_name == 'schedule' && '0.1.x' || github.ref }}
           fetch-depth: 0
 
       - name: Configure environment
@@ -118,7 +118,7 @@ jobs:
   scanner-readiness:
     if: ${{ (github.event_name == 'schedule' && vars.CI_NIGHTLY_HEAVY_RUN_SCANNERS != 'false') || (github.event_name == 'workflow_dispatch' && inputs.run_scanners) }}
     name: Scanner
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ${{ github.repository == 'Qbit-Org/qbit' && fromJSON('["self-hosted", "linux", "x64", "qbit-trusted-ci"]') || fromJSON('["self-hosted", "linux", "x64"]') }}
     timeout-minutes: 240
     env:
       SCANNER_SET: ${{ inputs.scanner_set || 'minimum' }}
@@ -128,7 +128,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
+          ref: ${{ github.event_name == 'schedule' && '0.1.x' || github.ref }}
           fetch-depth: 0
 
       - name: Install scanner tools

--- a/.github/workflows/ibd-perf-manual.yml
+++ b/.github/workflows/ibd-perf-manual.yml
@@ -1,0 +1,630 @@
+name: IBD Performance Benchmark
+run-name: >-
+  IBD perf (${{ github.event_name == 'schedule' && 'nightly' || inputs.profile }},
+  branch=${{ github.event_name == 'schedule' && '0.1.x' || github.ref_name }})
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: Benchmark profile to run
+        required: true
+        default: smoke
+        type: choice
+        options:
+          - smoke
+          - phase1-baseline
+          - phase1-baseline-full
+          - phase2-network
+          - phase2-network-full-month
+      runs_per_lane:
+        description: Optional runs-per-lane override; leave blank for the selected profile default
+        required: false
+        default: ""
+        type: string
+      blocks:
+        description: Optional measured-block override; leave blank for the selected profile default
+        required: false
+        default: ""
+        type: string
+      txs_per_block:
+        description: Optional MiniWallet proxy transactions per measured block; blank means 1
+        required: false
+        default: ""
+        type: string
+      p2mr_spends_per_block:
+        description: Optional W2 P2MR wallet spends per measured block; blank means 1
+        required: false
+        default: ""
+        type: string
+      tail_blocks:
+        description: Optional extra empty tail blocks after the measured history; blank means 0
+        required: false
+        default: ""
+        type: string
+      fastprune:
+        description: Use the selected profile default or explicitly set -fastprune
+        required: true
+        default: profile
+        type: choice
+        options:
+          - profile
+          - "true"
+          - "false"
+      enable_network_ibd:
+        description: Use the selected profile default or explicitly run the W3 localhost network IBD lane
+        required: true
+        default: profile
+        type: choice
+        options:
+          - profile
+          - "true"
+          - "false"
+      enable_tracing:
+        description: Capture optional ConnectBlock bpftrace artifacts for representative lanes
+        required: true
+        default: false
+        type: boolean
+      trace_threshold_ms:
+        description: Threshold in milliseconds for optional ConnectBlock tracing
+        required: true
+        default: "25"
+        type: string
+      bench_min_time_ms:
+        description: Optional minimum runtime for each hotspot benchmark in milliseconds; blank means 5000
+        required: false
+        default: ""
+        type: string
+      REPLAY_TIMEOUT:
+        description: Reserved for PR B --replay-timeout harness flag; leave blank until supported
+        required: false
+        default: ""
+        type: string
+      NETWORK_HEADERS_TIMEOUT:
+        description: Reserved for PR B --network-headers-timeout harness flag; leave blank until supported
+        required: false
+        default: ""
+        type: string
+      NETWORK_TIP_TIMEOUT:
+        description: Reserved for PR B --network-tip-timeout harness flag; leave blank until supported
+        required: false
+        default: ""
+        type: string
+      NETWORK_IBD_EXIT_TIMEOUT:
+        description: Reserved for PR B --network-ibd-exit-timeout harness flag; leave blank until supported
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: ibd-perf-${{ github.event_name == 'schedule' && 'nightly-0.1.x' || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  ibd-perf:
+    name: IBD perf
+    runs-on: ${{ github.repository == 'Qbit-Org/qbit' && fromJSON('["self-hosted", "linux", "x64", "qbit-trusted-ci"]') || fromJSON('["self-hosted", "linux", "x64"]') }}
+    timeout-minutes: 720
+    env:
+      RUN_MODE: ${{ github.event_name == 'schedule' && 'nightly' || 'manual' }}
+      CHECKOUT_REF: ${{ github.event_name == 'schedule' && '0.1.x' || github.ref }}
+      BENCHMARK_REF_NAME: ${{ github.event_name == 'schedule' && '0.1.x' || github.ref_name }}
+      PERF_BUILD_DIR: ${{ github.workspace }}/build-perf
+      PERF_ARTIFACT_ROOT: ${{ github.workspace }}/build-perf-artifacts/ibd-perf-${{ github.run_id }}
+      SELECTED_PROFILE: ${{ github.event_name == 'schedule' && 'nightly-smoke' || inputs.profile }}
+      RUNS_PER_LANE: ${{ github.event_name != 'schedule' && inputs.runs_per_lane || '' }}
+      BLOCKS: ${{ github.event_name != 'schedule' && inputs.blocks || '' }}
+      TXS_PER_BLOCK: ${{ github.event_name != 'schedule' && inputs.txs_per_block || '' }}
+      P2MR_SPENDS_PER_BLOCK: ${{ github.event_name != 'schedule' && inputs.p2mr_spends_per_block || '' }}
+      TAIL_BLOCKS: ${{ github.event_name != 'schedule' && inputs.tail_blocks || '' }}
+      FASTPRUNE: ${{ github.event_name == 'schedule' && 'profile' || inputs.fastprune }}
+      ENABLE_HOTSPOT_BENCHES: true
+      ENABLE_REPLAY_LANES: true
+      ENABLE_NETWORK_IBD: ${{ github.event_name == 'schedule' && 'profile' || inputs.enable_network_ibd }}
+      ENABLE_TRACING: ${{ github.event_name == 'schedule' && 'false' || (inputs.enable_tracing && 'true' || 'false') }}
+      TRACE_THRESHOLD_MS: ${{ github.event_name != 'schedule' && inputs.trace_threshold_ms || '' }}
+      BENCH_MIN_TIME_MS: ${{ github.event_name != 'schedule' && inputs.bench_min_time_ms || '' }}
+      REPLAY_TIMEOUT: ${{ github.event_name != 'schedule' && inputs.REPLAY_TIMEOUT || '' }}
+      NETWORK_HEADERS_TIMEOUT: ${{ github.event_name != 'schedule' && inputs.NETWORK_HEADERS_TIMEOUT || '' }}
+      NETWORK_TIP_TIMEOUT: ${{ github.event_name != 'schedule' && inputs.NETWORK_TIP_TIMEOUT || '' }}
+      NETWORK_IBD_EXIT_TIMEOUT: ${{ github.event_name != 'schedule' && inputs.NETWORK_IBD_EXIT_TIMEOUT || '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Resolve benchmark profile
+        run: |
+          set -euo pipefail
+
+          override_if_set() {
+            local target="$1"
+            local value="$2"
+            if [ -n "$value" ]; then
+              printf -v "$target" '%s' "$value"
+            fi
+          }
+
+          apply_bool_override() {
+            local target="$1"
+            local value="$2"
+            case "$value" in
+              ""|profile)
+                ;;
+              true|false)
+                printf -v "$target" '%s' "$value"
+                ;;
+              *)
+                echo "Unsupported boolean override '$value' for $target" >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          effective_runs_per_lane="1"
+          effective_blocks="1001"
+          effective_txs_per_block="1"
+          effective_p2mr_spends_per_block="1"
+          effective_tail_blocks="0"
+          effective_fastprune="true"
+          effective_enable_hotspot_benches="true"
+          effective_enable_replay_lanes="true"
+          effective_enable_network_ibd="true"
+          effective_trace_threshold_ms="25"
+          effective_bench_min_time_ms="5000"
+          full_profile="false"
+
+          case "$SELECTED_PROFILE" in
+            smoke)
+              ;;
+            nightly-smoke)
+              effective_runs_per_lane="3"
+              ;;
+            phase1-baseline)
+              effective_runs_per_lane="1"
+              effective_blocks="10000"
+              effective_fastprune="false"
+              effective_enable_hotspot_benches="true"
+              effective_enable_replay_lanes="true"
+              effective_enable_network_ibd="false"
+              ;;
+            phase1-baseline-full)
+              effective_runs_per_lane="5"
+              effective_blocks="262800"
+              effective_fastprune="false"
+              effective_enable_hotspot_benches="true"
+              effective_enable_replay_lanes="true"
+              effective_enable_network_ibd="false"
+              full_profile="true"
+              ;;
+            phase2-network)
+              effective_runs_per_lane="1"
+              effective_blocks="10000"
+              effective_fastprune="false"
+              effective_enable_hotspot_benches="false"
+              effective_enable_replay_lanes="false"
+              effective_enable_network_ibd="true"
+              ;;
+            phase2-network-full-month)
+              effective_runs_per_lane="5"
+              effective_blocks="43200"
+              effective_fastprune="false"
+              effective_enable_hotspot_benches="false"
+              effective_enable_replay_lanes="false"
+              effective_enable_network_ibd="true"
+              full_profile="true"
+              ;;
+            *)
+              echo "Unsupported IBD benchmark profile: $SELECTED_PROFILE" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ "$full_profile" != "true" ]; then
+            override_if_set effective_runs_per_lane "$RUNS_PER_LANE"
+            override_if_set effective_blocks "$BLOCKS"
+            apply_bool_override effective_fastprune "$FASTPRUNE"
+            apply_bool_override effective_enable_network_ibd "$ENABLE_NETWORK_IBD"
+          fi
+          override_if_set effective_txs_per_block "$TXS_PER_BLOCK"
+          override_if_set effective_p2mr_spends_per_block "$P2MR_SPENDS_PER_BLOCK"
+          override_if_set effective_tail_blocks "$TAIL_BLOCKS"
+          override_if_set effective_trace_threshold_ms "$TRACE_THRESHOLD_MS"
+          override_if_set effective_bench_min_time_ms "$BENCH_MIN_TIME_MS"
+
+          {
+            printf '%s\n' "RUNS_PER_LANE=$effective_runs_per_lane"
+            printf '%s\n' "BLOCKS=$effective_blocks"
+            printf '%s\n' "TXS_PER_BLOCK=$effective_txs_per_block"
+            printf '%s\n' "P2MR_SPENDS_PER_BLOCK=$effective_p2mr_spends_per_block"
+            printf '%s\n' "TAIL_BLOCKS=$effective_tail_blocks"
+            printf '%s\n' "FASTPRUNE=$effective_fastprune"
+            printf '%s\n' "ENABLE_HOTSPOT_BENCHES=$effective_enable_hotspot_benches"
+            printf '%s\n' "ENABLE_REPLAY_LANES=$effective_enable_replay_lanes"
+            printf '%s\n' "ENABLE_NETWORK_IBD=$effective_enable_network_ibd"
+            printf '%s\n' "TRACE_THRESHOLD_MS=$effective_trace_threshold_ms"
+            printf '%s\n' "BENCH_MIN_TIME_MS=$effective_bench_min_time_ms"
+          } >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        env:
+          INSTALL_BPFTRACE: ${{ env.ENABLE_TRACING }}
+        run: |
+          ci/install-perf-dependencies.sh
+
+      - name: Capture host metadata
+        run: |
+          mkdir -p "$PERF_ARTIFACT_ROOT"/bench "$PERF_ARTIFACT_ROOT"/replay "$PERF_ARTIFACT_ROOT"/network "$PERF_ARTIFACT_ROOT"/summary
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "git_commit=$(git rev-parse HEAD)"
+            echo "github_repository=${GITHUB_REPOSITORY}"
+            echo "github_workflow=${GITHUB_WORKFLOW}"
+            echo "github_run_id=${GITHUB_RUN_ID}"
+            echo "github_run_number=${GITHUB_RUN_NUMBER}"
+            echo "github_run_attempt=${GITHUB_RUN_ATTEMPT}"
+            echo "workflow_event=${GITHUB_EVENT_NAME}"
+            echo "benchmark_mode=${RUN_MODE}"
+            echo "github_ref=${GITHUB_REF}"
+            echo "github_ref_name=${GITHUB_REF_NAME}"
+            echo "checkout_ref=${CHECKOUT_REF}"
+            echo "benchmark_ref_name=${BENCHMARK_REF_NAME}"
+            echo "profile=${SELECTED_PROFILE}"
+            echo "runs_per_lane=${RUNS_PER_LANE}"
+            echo "blocks=${BLOCKS}"
+            echo "txs_per_block=${TXS_PER_BLOCK}"
+            echo "p2mr_spends_per_block=${P2MR_SPENDS_PER_BLOCK}"
+            echo "tail_blocks=${TAIL_BLOCKS}"
+            echo "fastprune=${FASTPRUNE}"
+            echo "enable_hotspot_benches=${ENABLE_HOTSPOT_BENCHES}"
+            echo "enable_replay_lanes=${ENABLE_REPLAY_LANES}"
+            echo "enable_network_ibd=${ENABLE_NETWORK_IBD}"
+            echo "enable_tracing=${ENABLE_TRACING}"
+            echo "trace_threshold_ms=${TRACE_THRESHOLD_MS}"
+            echo "bench_min_time_ms=${BENCH_MIN_TIME_MS}"
+            echo "replay_timeout=${REPLAY_TIMEOUT}"
+            echo "network_headers_timeout=${NETWORK_HEADERS_TIMEOUT}"
+            echo "network_tip_timeout=${NETWORK_TIP_TIMEOUT}"
+            echo "network_ibd_exit_timeout=${NETWORK_IBD_EXIT_TIMEOUT}"
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo "kernel=$(uname -srmo)"
+          } > "$PERF_ARTIFACT_ROOT/summary/host.env"
+          {
+            uname -a
+            echo
+            cat /etc/os-release || true
+            echo
+            lscpu || true
+            echo
+            free -h || true
+            echo
+            df -h || true
+          } > "$PERF_ARTIFACT_ROOT/summary/host.txt"
+
+      - name: Configure build
+        run: |
+          CC=clang-16 CXX='clang++-16 -stdlib=libc++' \
+          cmake -B "$PERF_BUILD_DIR" -G Ninja \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DBUILD_BENCH=ON \
+            -DENABLE_IPC=OFF \
+            -DWITH_USDT=ON
+
+      - name: Build perf targets
+        run: |
+          cmake --build "$PERF_BUILD_DIR" -j"$(nproc)" \
+            --target qbitd qbit-cli bench_bitcoin
+
+      - name: Prepare tracing compatibility path
+        if: ${{ env.ENABLE_TRACING == 'true' }}
+        run: |
+          mkdir -p build/bin
+          ln -sf "$PERF_BUILD_DIR/bin/qbitd" build/bin/qbitd
+
+      - name: Run perf harness validation
+        run: |
+          python3 test/functional/feature_ibd_perf_validation.py \
+            --configfile="$PERF_BUILD_DIR/test/config.ini"
+
+      - name: Run hotspot microbenchmarks
+        run: |
+          set -euo pipefail
+          if [ "$ENABLE_HOTSPOT_BENCHES" != "true" ]; then
+            echo "Hotspot microbenchmarks disabled for profile $SELECTED_PROFILE"
+            exit 0
+          fi
+
+          for run in $(seq 1 "$RUNS_PER_LANE"); do
+            "$PERF_BUILD_DIR"/bin/bench_qbit \
+              -filter='PQCVerify|VerifyScriptP2MRChecksigPQC' \
+              -min-time="$BENCH_MIN_TIME_MS" \
+              -output-json="$PERF_ARTIFACT_ROOT/bench/hotspots-run${run}.json" \
+              -output-csv="$PERF_ARTIFACT_ROOT/bench/hotspots-run${run}.csv"
+          done
+
+      - name: Run IBD lanes
+        run: |
+          set -euo pipefail
+          ulimit -n 10240
+
+          effective_witness_tail="$TAIL_BLOCKS"
+          required_tail=$((1002 - BLOCKS))
+          if [ "$required_tail" -gt "$effective_witness_tail" ]; then
+            effective_witness_tail="$required_tail"
+          fi
+          if [ "$effective_witness_tail" -lt 0 ]; then
+            effective_witness_tail=0
+          fi
+          echo "effective_witness_tail_blocks=$effective_witness_tail" \
+            > "$PERF_ARTIFACT_ROOT/summary/replay-parameters.env"
+
+          run_replay() {
+            local workload="$1"
+            local history_mode="$2"
+            local reindex_mode="$3"
+            local run_id="$4"
+            local tail_blocks="$TAIL_BLOCKS"
+            local report_name="${workload}-${history_mode}-${reindex_mode}-run${run_id}.json"
+            local trace_file=""
+            local cmd=()
+
+            if [ "$history_mode" = "witness-pruned" ]; then
+              tail_blocks="$effective_witness_tail"
+            fi
+
+            if [ "$ENABLE_TRACING" = "true" ] && [ "$workload" = "w2-replay-mixed" ] && [ "$reindex_mode" = "full" ]; then
+              trace_file="$PERF_ARTIFACT_ROOT/replay/${workload}-${history_mode}-${reindex_mode}-run${run_id}.trace.txt"
+            fi
+
+            echo "=== replay ${workload} ${history_mode} ${reindex_mode} run ${run_id} ==="
+            cmd=(
+              python3 test/functional/feature_ibd_perf_replay.py
+              --configfile="$PERF_BUILD_DIR/test/config.ini"
+              --blocks="$BLOCKS"
+              --workload="$workload"
+              --txs-per-block="$TXS_PER_BLOCK"
+              --p2mr-spends-per-block="$P2MR_SPENDS_PER_BLOCK"
+              --tail-blocks="$tail_blocks"
+              --history-mode="$history_mode"
+              --reindex-mode="$reindex_mode"
+              --report-file="$PERF_ARTIFACT_ROOT/replay/$report_name"
+              --connectblock-threshold-ms="$TRACE_THRESHOLD_MS"
+            )
+            if [ -n "$trace_file" ]; then
+              cmd+=(--connectblock-trace-file="$trace_file")
+            fi
+            if [ "$FASTPRUNE" = "true" ]; then
+              cmd+=(--fastprune)
+            fi
+            "${cmd[@]}"
+          }
+
+          run_network() {
+            local workload="$1"
+            local run_id="$2"
+            local report_name="w3-network-${workload}-run${run_id}.json"
+            local trace_file=""
+            local cmd=()
+
+            if [ "$ENABLE_TRACING" = "true" ]; then
+              trace_file="$PERF_ARTIFACT_ROOT/network/${workload}-run${run_id}.trace.txt"
+            fi
+
+            mkdir -p "$PERF_ARTIFACT_ROOT/network"
+            echo "=== network ${workload} run ${run_id} ==="
+            cmd=(
+              python3 test/functional/feature_ibd_perf_network.py
+              --configfile="$PERF_BUILD_DIR/test/config.ini"
+              --blocks="$BLOCKS"
+              --workload="$workload"
+              --txs-per-block="$TXS_PER_BLOCK"
+              --p2mr-spends-per-block="$P2MR_SPENDS_PER_BLOCK"
+              --lane-name="w3-network-mixed"
+              --report-file="$PERF_ARTIFACT_ROOT/network/$report_name"
+              --connectblock-threshold-ms="$TRACE_THRESHOLD_MS"
+            )
+            if [ -n "$trace_file" ]; then
+              cmd+=(--connectblock-trace-file="$trace_file")
+            fi
+            if [ "$FASTPRUNE" = "true" ]; then
+              cmd+=(--fastprune)
+            fi
+            "${cmd[@]}"
+          }
+
+          for run in $(seq 1 "$RUNS_PER_LANE"); do
+            if [ "$ENABLE_REPLAY_LANES" = "true" ]; then
+              run_replay w1-replay-floor archive chainstate "$run"
+              run_replay w1-replay-floor archive full "$run"
+              run_replay w1-replay-floor witness-pruned chainstate "$run"
+              run_replay w2-replay-mixed archive chainstate "$run"
+              run_replay w2-replay-mixed archive full "$run"
+              run_replay w2-replay-mixed witness-pruned chainstate "$run"
+            fi
+            if [ "$ENABLE_NETWORK_IBD" = "true" ]; then
+              run_network w2-replay-mixed "$run"
+            fi
+          done
+
+      - name: Summarize perf results
+        run: |
+          python3 contrib/devtools/summarize_ibd_perf.py "$PERF_ARTIFACT_ROOT"
+          cp "$PERF_ARTIFACT_ROOT/summary/ibd-baseline-summary.md" \
+            "$PERF_ARTIFACT_ROOT/summary/perf-summary.md"
+          cp "$PERF_ARTIFACT_ROOT/summary/ibd-baseline-summary.md" \
+            "$PERF_ARTIFACT_ROOT/summary/replay-summary.md"
+          cat "$PERF_ARTIFACT_ROOT/summary/perf-summary.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Record perf artifact manifest
+        if: always()
+        run: |
+          set -euo pipefail
+          mkdir -p "$PERF_ARTIFACT_ROOT/summary"
+          manifest="$PERF_ARTIFACT_ROOT/summary/artifact-manifest.txt"
+          {
+            echo "# IBD perf artifact manifest"
+            echo "generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "artifact_root=$PERF_ARTIFACT_ROOT"
+            echo
+            echo "## top-level sizes"
+            du -sh "$PERF_ARTIFACT_ROOT" \
+              "$PERF_ARTIFACT_ROOT"/summary \
+              "$PERF_ARTIFACT_ROOT"/bench \
+              "$PERF_ARTIFACT_ROOT"/replay \
+              "$PERF_ARTIFACT_ROOT"/network 2>/dev/null || true
+            echo
+            echo "## file counts"
+            for dir in summary bench replay network; do
+              path="$PERF_ARTIFACT_ROOT/$dir"
+              if [ -d "$path" ]; then
+                printf '%s\t%s\n' "$dir" "$(find "$path" -type f | wc -l)"
+              else
+                printf '%s\t0\n' "$dir"
+              fi
+            done
+            echo
+            echo "## all artifact files"
+            if [ -d "$PERF_ARTIFACT_ROOT" ]; then
+              du -ah "$PERF_ARTIFACT_ROOT" | sort -h
+            fi
+          } | tee "$manifest"
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            {
+              echo
+              echo "## Artifact upload manifest"
+              echo
+              echo "Artifact uploads are best-effort; if GitHub artifact storage stalls, use this summary and the manifest log for the benchmark evidence."
+              echo
+              echo '```'
+              awk '/^## all artifact files$/ { exit } { print }' "$manifest"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload perf summary artifact
+        id: upload_perf_summary_artifact
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ibd-perf-${{ github.run_id }}-summary
+          path: |
+            ${{ env.PERF_ARTIFACT_ROOT }}/*
+            !${{ env.PERF_ARTIFACT_ROOT }}/bench
+            !${{ env.PERF_ARTIFACT_ROOT }}/bench/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/replay
+            !${{ env.PERF_ARTIFACT_ROOT }}/replay/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/network
+            !${{ env.PERF_ARTIFACT_ROOT }}/network/**
+          if-no-files-found: error
+          retention-days: 30
+          overwrite: true
+
+      - name: Upload perf benchmark artifacts
+        id: upload_perf_benchmark_artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ibd-perf-${{ github.run_id }}-bench
+          path: |
+            ${{ env.PERF_ARTIFACT_ROOT }}/*
+            !${{ env.PERF_ARTIFACT_ROOT }}/summary
+            !${{ env.PERF_ARTIFACT_ROOT }}/summary/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/replay
+            !${{ env.PERF_ARTIFACT_ROOT }}/replay/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/network
+            !${{ env.PERF_ARTIFACT_ROOT }}/network/**
+          if-no-files-found: ignore
+          retention-days: 30
+          overwrite: true
+
+      - name: Upload perf replay artifacts
+        id: upload_perf_replay_artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ibd-perf-${{ github.run_id }}-replay
+          path: |
+            ${{ env.PERF_ARTIFACT_ROOT }}/*
+            !${{ env.PERF_ARTIFACT_ROOT }}/summary
+            !${{ env.PERF_ARTIFACT_ROOT }}/summary/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/bench
+            !${{ env.PERF_ARTIFACT_ROOT }}/bench/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/network
+            !${{ env.PERF_ARTIFACT_ROOT }}/network/**
+          if-no-files-found: ignore
+          retention-days: 30
+          overwrite: true
+
+      - name: Retry perf replay artifact upload
+        id: retry_perf_replay_artifacts
+        if: always() && steps.upload_perf_replay_artifacts.outcome != 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ibd-perf-${{ github.run_id }}-replay
+          path: |
+            ${{ env.PERF_ARTIFACT_ROOT }}/*
+            !${{ env.PERF_ARTIFACT_ROOT }}/summary
+            !${{ env.PERF_ARTIFACT_ROOT }}/summary/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/bench
+            !${{ env.PERF_ARTIFACT_ROOT }}/bench/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/network
+            !${{ env.PERF_ARTIFACT_ROOT }}/network/**
+          if-no-files-found: ignore
+          retention-days: 30
+          overwrite: true
+
+      - name: Upload perf network artifacts
+        id: upload_perf_network_artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: ibd-perf-${{ github.run_id }}-network
+          path: |
+            ${{ env.PERF_ARTIFACT_ROOT }}/*
+            !${{ env.PERF_ARTIFACT_ROOT }}/summary
+            !${{ env.PERF_ARTIFACT_ROOT }}/summary/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/bench
+            !${{ env.PERF_ARTIFACT_ROOT }}/bench/**
+            !${{ env.PERF_ARTIFACT_ROOT }}/replay
+            !${{ env.PERF_ARTIFACT_ROOT }}/replay/**
+          if-no-files-found: ignore
+          retention-days: 30
+          overwrite: true
+
+      - name: Record perf artifact upload status
+        if: always()
+        run: |
+          {
+            echo
+            echo "## Artifact upload status"
+            echo
+            echo "| artifact | status |"
+            echo "| --- | --- |"
+            echo "| summary | ${{ steps.upload_perf_summary_artifact.outcome }} |"
+            echo "| bench | ${{ steps.upload_perf_benchmark_artifacts.outcome }} |"
+            echo "| replay | ${{ steps.upload_perf_replay_artifacts.outcome }} |"
+            echo "| replay retry | ${{ steps.retry_perf_replay_artifacts.outcome }} |"
+            echo "| network | ${{ steps.upload_perf_network_artifacts.outcome }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.upload_perf_replay_artifacts.outcome }}" != "success" ] &&
+             [ "${{ steps.retry_perf_replay_artifacts.outcome }}" != "success" ]; then
+            echo "::warning title=Replay artifact upload unavailable::Replay evidence upload failed after retry; use the job summary and manifest log as preserved benchmark evidence."
+          fi

--- a/.github/workflows/lint-image-prewarm.yml
+++ b/.github/workflows/lint-image-prewarm.yml
@@ -1,0 +1,59 @@
+# Copyright (c) 2026-present The qbit core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+name: Lint Image Prewarm
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .python-version
+      - ci/lint_imagefile
+      - ci/test/00_setup_env_base_image.sh
+      - ci/lint/**
+      - ci/retry/retry
+      - .github/actions/configure-docker/**
+      - .github/workflows/lint-image-prewarm.yml
+  schedule:
+    - cron: '45 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: lint-image-prewarm-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CONTAINER_NAME: "bitcoin-linter-main"
+  CI_IMAGE_REGISTRY_PREFIX: qbit-ci-autoscaler:5000/qbit-cache
+  CI_ENFORCE_INTERNAL_REGISTRY: 1
+
+jobs:
+  prewarm:
+    name: Prewarm lint image cache
+    if: ${{ github.ref_name == github.event.repository.default_branch }}
+    runs-on: ${{ github.repository == 'Qbit-Org/qbit' && fromJSON('["self-hosted", "linux", "x64", "qbit-trusted-ci"]') || fromJSON('["self-hosted", "linux", "x64"]') }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Configure Docker
+        uses: ./.github/actions/configure-docker
+        with:
+          cache-provider: gha
+          cache-from-scopes: bitcoin-linter-main
+          cache-to-scopes: bitcoin-linter-main
+          cache-write-policy: always
+          load-image: false
+
+      - name: Build lint image cache
+        run: |
+          set -o xtrace
+          source ./ci/test/00_setup_env_base_image.sh
+          ci_set_base_image_name_tag "ubuntu:24.04"
+          read -r -a docker_build_cache_args <<< "$DOCKER_BUILD_CACHE_ARG"
+          docker buildx build -t "$CONTAINER_NAME" "${docker_build_cache_args[@]}" --build-arg "CI_IMAGE_NAME_TAG=${CI_IMAGE_NAME_TAG}" --file "./ci/lint_imagefile" .

--- a/.github/workflows/rpc-perf-manual.yml
+++ b/.github/workflows/rpc-perf-manual.yml
@@ -1,0 +1,224 @@
+name: RPC Performance Benchmark
+run-name: >-
+  RPC perf (${{ github.event_name == 'schedule' && 'nightly' || 'manual' }},
+  scale=${{ github.event_name == 'schedule' && '1.0' || inputs.run_scale }},
+  ref=${{ github.event_name == 'schedule' && 'v30.2' || inputs.reference_ref }},
+  branch=${{ github.event_name == 'schedule' && '0.1.x' || github.ref_name }})
+
+on:
+  schedule:
+    - cron: '30 4 * * *'
+  workflow_dispatch:
+    inputs:
+      run_scale:
+        description: Scale manifest run counts for smoke runs or deeper sampling
+        required: true
+        default: "1.0"
+        type: string
+      benchmark_filter:
+        description: Optional regex to select benchmark ids
+        required: false
+        default: ""
+        type: string
+      include_reference:
+        description: Build Bitcoin Core v30.2 and run the shared-endpoint comparison lane
+        required: true
+        default: true
+        type: boolean
+      reference_ref:
+        description: Bitcoin Core tag or branch to benchmark against
+        required: true
+        default: "v30.2"
+        type: string
+
+concurrency:
+  group: rpc-perf-${{ github.event_name == 'schedule' && 'nightly-0.1.x' || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  rpc-perf:
+    name: RPC perf
+    runs-on: ${{ github.repository == 'Qbit-Org/qbit' && fromJSON('["self-hosted", "linux", "x64", "qbit-trusted-ci"]') || fromJSON('["self-hosted", "linux", "x64"]') }}
+    timeout-minutes: 720
+    env:
+      RUN_MODE: ${{ github.event_name == 'schedule' && 'nightly' || 'manual' }}
+      CHECKOUT_REF: ${{ github.event_name == 'schedule' && '0.1.x' || github.ref }}
+      BENCHMARK_REF_NAME: ${{ github.event_name == 'schedule' && '0.1.x' || github.ref_name }}
+      PERF_BUILD_DIR: ${{ github.workspace }}/build-rpc-perf
+      PERF_ARTIFACT_ROOT: ${{ github.workspace }}/build-rpc-perf-artifacts/rpc-perf-${{ github.run_id }}
+      REFERENCE_REPO: https://github.com/bitcoin/bitcoin.git
+      REFERENCE_ROOT: ${{ github.workspace }}/build-rpc-perf-reference/bitcoin-core-reference
+      REFERENCE_BUILD_DIR: ${{ github.workspace }}/build-rpc-perf-reference/bitcoin-core-reference/build
+      RUN_SCALE: ${{ github.event_name == 'schedule' && '1.0' || inputs.run_scale }}
+      BENCHMARK_FILTER: ${{ github.event_name != 'schedule' && inputs.benchmark_filter || '' }}
+      INCLUDE_REFERENCE: ${{ github.event_name == 'schedule' && 'true' || inputs.include_reference }}
+      REFERENCE_REF: ${{ github.event_name == 'schedule' && 'v30.2' || inputs.reference_ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: ci/install-perf-dependencies.sh
+
+      - name: Capture host metadata
+        run: |
+          mkdir -p \
+            "$PERF_ARTIFACT_ROOT"/qbit-only \
+            "$PERF_ARTIFACT_ROOT"/compare \
+            "$PERF_ARTIFACT_ROOT"/summary
+          {
+            echo "timestamp_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "git_commit=$(git rev-parse HEAD)"
+            echo "github_repository=${GITHUB_REPOSITORY}"
+            echo "github_workflow=${GITHUB_WORKFLOW}"
+            echo "github_run_id=${GITHUB_RUN_ID}"
+            echo "github_run_number=${GITHUB_RUN_NUMBER}"
+            echo "github_run_attempt=${GITHUB_RUN_ATTEMPT}"
+            echo "workflow_event=${GITHUB_EVENT_NAME}"
+            echo "benchmark_mode=${RUN_MODE}"
+            echo "github_ref=${GITHUB_REF}"
+            echo "github_ref_name=${GITHUB_REF_NAME}"
+            echo "checkout_ref=${CHECKOUT_REF}"
+            echo "benchmark_ref_name=${BENCHMARK_REF_NAME}"
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo "kernel=$(uname -srmo)"
+            echo "manifest_sha256=$(sha256sum test/functional/data/rpc_perf_manifest.json | awk '{print $1}')"
+            echo "run_scale=${RUN_SCALE}"
+            echo "benchmark_filter=${BENCHMARK_FILTER}"
+            echo "include_reference=${INCLUDE_REFERENCE}"
+            echo "reference_ref=${REFERENCE_REF}"
+          } > "$PERF_ARTIFACT_ROOT/summary/host.env"
+          {
+            uname -a
+            echo
+            cat /etc/os-release || true
+            echo
+            lscpu || true
+            echo
+            free -h || true
+            echo
+            df -h || true
+          } > "$PERF_ARTIFACT_ROOT/summary/host.txt"
+
+      - name: Configure qbit build
+        run: |
+          CC=clang-16 CXX='clang++-16 -stdlib=libc++' \
+          cmake -B "$PERF_BUILD_DIR" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_IPC=OFF
+
+      - name: Build qbit RPC targets
+        run: |
+          cmake --build "$PERF_BUILD_DIR" -j"$(nproc)" \
+            --target qbitd qbit-cli
+          "$PERF_BUILD_DIR/bin/qbitd" -version > "$PERF_ARTIFACT_ROOT/summary/qbit-version.txt"
+
+      - name: Checkout Bitcoin Core reference
+        if: ${{ env.INCLUDE_REFERENCE == 'true' }}
+        run: |
+          if [ -e "$REFERENCE_ROOT" ]; then
+            mv "$REFERENCE_ROOT" "${REFERENCE_ROOT}.stale-$(date +%Y%m%d-%H%M%S)"
+          fi
+          git clone --branch "$REFERENCE_REF" --depth 1 --single-branch \
+            "$REFERENCE_REPO" "$REFERENCE_ROOT"
+
+      - name: Configure Bitcoin Core reference build
+        if: ${{ env.INCLUDE_REFERENCE == 'true' }}
+        run: |
+          CC=clang-16 CXX='clang++-16 -stdlib=libc++' \
+          cmake -S "$REFERENCE_ROOT" -B "$REFERENCE_BUILD_DIR" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_IPC=OFF \
+            -DBUILD_TESTS=OFF \
+            -DBUILD_GUI=OFF \
+            -DBUILD_BENCH=OFF \
+            -DBUILD_FUZZ_BINARY=OFF
+
+      - name: Build Bitcoin Core reference targets
+        if: ${{ env.INCLUDE_REFERENCE == 'true' }}
+        run: |
+          cmake --build "$REFERENCE_BUILD_DIR" -j"$(nproc)" \
+            --target bitcoind bitcoin-cli
+          "$REFERENCE_BUILD_DIR/bin/bitcoind" -version > "$PERF_ARTIFACT_ROOT/summary/reference-version.txt"
+
+      - name: Run qbit-only RPC benchmark
+        run: |
+          set -euo pipefail
+          ulimit -n 10240
+          filter_args=()
+          if [ -n "$BENCHMARK_FILTER" ]; then
+            filter_args+=(--benchmark-filter="$BENCHMARK_FILTER")
+          fi
+          python3 test/functional/feature_rpc_perf.py \
+            --configfile="$PERF_BUILD_DIR/test/config.ini" \
+            --run-scale="$RUN_SCALE" \
+            --no-reference \
+            "${filter_args[@]}" \
+            --report-file="$PERF_ARTIFACT_ROOT/qbit-only/feature-rpc-perf-report.json" \
+            --summary-file="$PERF_ARTIFACT_ROOT/qbit-only/feature-rpc-perf-summary.md" \
+            --inventory-file="$PERF_ARTIFACT_ROOT/qbit-only/feature-rpc-perf-inventory.json" \
+            --coverage-file="$PERF_ARTIFACT_ROOT/qbit-only/feature-rpc-perf-coverage.json"
+
+      - name: Run qbit vs Bitcoin Core RPC benchmark
+        if: ${{ env.INCLUDE_REFERENCE == 'true' }}
+        run: |
+          set -euo pipefail
+          ulimit -n 10240
+          filter_args=()
+          if [ -n "$BENCHMARK_FILTER" ]; then
+            filter_args+=(--benchmark-filter="$BENCHMARK_FILTER")
+          fi
+          python3 test/functional/feature_rpc_perf.py \
+            --configfile="$PERF_BUILD_DIR/test/config.ini" \
+            --run-scale="$RUN_SCALE" \
+            --reference-bin-dir="$REFERENCE_BUILD_DIR/bin" \
+            --reference-srcdir="$REFERENCE_ROOT" \
+            --reference-label="bitcoin-core-${REFERENCE_REF}" \
+            "${filter_args[@]}" \
+            --report-file="$PERF_ARTIFACT_ROOT/compare/feature-rpc-perf-report.json" \
+            --summary-file="$PERF_ARTIFACT_ROOT/compare/feature-rpc-perf-summary.md" \
+            --inventory-file="$PERF_ARTIFACT_ROOT/compare/feature-rpc-perf-inventory.json" \
+            --coverage-file="$PERF_ARTIFACT_ROOT/compare/feature-rpc-perf-coverage.json"
+
+      - name: Append benchmark summaries
+        if: always()
+        run: |
+          {
+            echo "# RPC Performance Benchmark"
+            echo ""
+            echo "## Qbit Only"
+            if [ -f "$PERF_ARTIFACT_ROOT/qbit-only/feature-rpc-perf-summary.md" ]; then
+              tail -n +2 "$PERF_ARTIFACT_ROOT/qbit-only/feature-rpc-perf-summary.md"
+            else
+              echo "qbit-only summary missing"
+            fi
+            if [ "$INCLUDE_REFERENCE" = "true" ] && [ -f "$PERF_ARTIFACT_ROOT/compare/feature-rpc-perf-summary.md" ]; then
+              echo ""
+              echo "## Qbit vs Bitcoin Core ${REFERENCE_REF}"
+              tail -n +2 "$PERF_ARTIFACT_ROOT/compare/feature-rpc-perf-summary.md"
+            elif [ "$INCLUDE_REFERENCE" = "true" ]; then
+              echo ""
+              echo "## Qbit vs Bitcoin Core ${REFERENCE_REF}"
+              echo "comparison summary missing"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload RPC perf artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpc-perf-${{ github.run_id }}
+          path: ${{ env.PERF_ARTIFACT_ROOT }}
+          retention-days: 30

--- a/ci/scanners/README.md
+++ b/ci/scanners/README.md
@@ -42,8 +42,8 @@ python3 ci/scanners/run-scanners.py \
 
 Git-history scanners are intentionally bounded. The runner resolves
 `merge-base(--source-commit, --history-diff-base-ref)..--source-commit`; with
-the default `origin/main` base, scheduled `develop` runs scan the qbit
-`main...develop` history window instead of inherited upstream `main` history.
+the default `origin/main` base, scheduled `0.1.x` runs scan the qbit
+`main...0.1.x` history window instead of inherited upstream `main` history.
 
 ## Artifact Policy
 

--- a/test/functional/data/rpc_perf_manifest.json
+++ b/test/functional/data/rpc_perf_manifest.json
@@ -842,6 +842,176 @@
       "fixture_reset_mode": "none"
     },
     {
+      "id": "shared.modified.getwalletinfo.default",
+      "description": "Read metadata for the prepared wallet fixture.",
+      "endpoint": "getwalletinfo",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_getwalletinfo",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.getbalance.default",
+      "description": "Read the prepared wallet's confirmed balance.",
+      "endpoint": "getbalance",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_getbalance",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.getbalances.default",
+      "description": "Read detailed balance buckets for the prepared wallet fixture.",
+      "endpoint": "getbalances",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_getbalances",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listunspent.default",
+      "description": "List spendable outputs in the prepared wallet fixture.",
+      "endpoint": "listunspent",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_listunspent",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listtransactions.default",
+      "description": "List recent wallet transactions for the prepared wallet fixture.",
+      "endpoint": "listtransactions",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_listtransactions",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listwallets.loaded",
+      "description": "List loaded wallets after preparing the wallet fixture.",
+      "endpoint": "listwallets",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "static_params",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listwalletdir.default",
+      "description": "List available wallet directories after preparing the wallet fixture.",
+      "endpoint": "listwalletdir",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "static_params",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.getaddressesbylabel.receive",
+      "description": "List wallet addresses for the prepared receive label.",
+      "endpoint": "getaddressesbylabel",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_getaddressesbylabel",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listlabels.default",
+      "description": "List labels in the prepared wallet fixture.",
+      "endpoint": "listlabels",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_listlabels",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listlockunspent.default",
+      "description": "List locked wallet outputs in the prepared wallet fixture.",
+      "endpoint": "listlockunspent",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_listlockunspent",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
       "id": "shared.modified.listdescriptors.default",
       "description": "List wallet descriptors while recording qbit P2MR descriptor shape.",
       "endpoint": "listdescriptors",
@@ -865,6 +1035,176 @@
       "fixture": "wallet_ready",
       "lane": "shared_name_qbit_modified",
       "call_builder": "wallet_createwalletdescriptor",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.createrawtransaction.wallet_output",
+      "description": "Create an unsigned raw transaction paying the prepared wallet receive address.",
+      "endpoint": "createrawtransaction",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_createrawtransaction",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.createpsbt.wallet_output",
+      "description": "Create an unsigned PSBT paying the prepared wallet receive address.",
+      "endpoint": "createpsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_createpsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.fundrawtransaction.wallet",
+      "description": "Fund a prepared unsigned raw transaction with wallet inputs and a fixed change address.",
+      "endpoint": "fundrawtransaction",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_fundrawtransaction",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 3
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.walletcreatefundedpsbt.wallet",
+      "description": "Create and fund a wallet PSBT with a fixed change address.",
+      "endpoint": "walletcreatefundedpsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_walletcreatefundedpsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 3
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.finalizepsbt.incomplete",
+      "description": "Finalize the prepared unsigned wallet PSBT without extracting a transaction.",
+      "endpoint": "finalizepsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_finalizepsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.decoderawtransaction.wallet",
+      "description": "Decode the prepared unsigned wallet raw transaction.",
+      "endpoint": "decoderawtransaction",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_decoderawtransaction",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.decodescript.receive",
+      "description": "Decode the prepared receive address scriptPubKey.",
+      "endpoint": "decodescript",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_decodescript",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.utxoupdatepsbt.wallet",
+      "description": "Update the prepared wallet PSBT from available UTXO data.",
+      "endpoint": "utxoupdatepsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_utxoupdatepsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.combinepsbt.single",
+      "description": "Run the PSBT combiner over the prepared wallet PSBT.",
+      "endpoint": "combinepsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_combinepsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.converttopsbt.raw",
+      "description": "Convert the prepared unsigned raw transaction into PSBT format.",
+      "endpoint": "converttopsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_converttopsbt",
       "target_support": [
         "qbit",
         "reference"

--- a/test/functional/feature_rpc_perf.py
+++ b/test/functional/feature_rpc_perf.py
@@ -516,7 +516,9 @@ class RPCPerfTest(BitcoinTestFramework):
         mining_address = wallet.getnewaddress()
         node.generatetoaddress(COINBASE_MATURITY + WALLET_READY_MATURE_OUTPUTS, mining_address, called_by_framework=True)
 
-        receive_address = wallet.getnewaddress()
+        receive_label = "rpc-perf-receive"
+        receive_address = wallet.getnewaddress(receive_label)
+        receive_script_pubkey = wallet.getaddressinfo(receive_address)["scriptPubKey"]
         raw_tx = wallet.createrawtransaction([], [{receive_address: Decimal("0.10000000")}])
         funded_tx = wallet.fundrawtransaction(raw_tx)
         psbt = wallet.walletcreatefundedpsbt([], [{receive_address: Decimal("0.10000000")}])["psbt"]
@@ -528,7 +530,9 @@ class RPCPerfTest(BitcoinTestFramework):
             {
                 "wallet_name": wallet_name,
                 "wallet_rpc": wallet,
+                "receive_label": receive_label,
                 "receive_address": receive_address,
+                "receive_script_pubkey": receive_script_pubkey,
                 "raw_tx": raw_tx,
                 "funded_tx": funded_tx["hex"],
                 "psbt": psbt,
@@ -917,12 +921,74 @@ class RPCPerfTest(BitcoinTestFramework):
     def build_wallet_getaddressinfo(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
         return context.state["wallet_rpc"], "getaddressinfo", [context.state["receive_address"]]
 
+    def build_wallet_getwalletinfo(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "getwalletinfo", []
+
+    def build_wallet_getbalance(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "getbalance", []
+
+    def build_wallet_getbalances(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "getbalances", []
+
+    def build_wallet_listunspent(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "listunspent", []
+
+    def build_wallet_listtransactions(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "listtransactions", []
+
+    def build_wallet_getaddressesbylabel(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "getaddressesbylabel", [context.state["receive_label"]]
+
+    def build_wallet_listlabels(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "listlabels", []
+
+    def build_wallet_listlockunspent(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "listlockunspent", []
+
     def build_wallet_listdescriptors(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
         return context.state["wallet_rpc"], "listdescriptors", []
 
     def build_wallet_createwalletdescriptor(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
         descriptor_type = "p2mr" if context.plan.target == QBIT_TARGET else "bech32m"
         return context.state["wallet_rpc"], "createwalletdescriptor", [descriptor_type]
+
+    def build_wallet_createrawtransaction(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return "createrawtransaction", [[], [{context.state["receive_address"]: Decimal("0.10000000")}]]
+
+    def build_wallet_createpsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return "createpsbt", [[], [{context.state["receive_address"]: Decimal("0.10000000")}]]
+
+    def build_wallet_fundrawtransaction(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "fundrawtransaction", [
+            context.state["raw_tx"],
+            {"changeAddress": context.state["receive_address"], "changePosition": 1},
+        ]
+
+    def build_wallet_walletcreatefundedpsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "walletcreatefundedpsbt", [
+            [],
+            [{context.state["receive_address"]: Decimal("0.10000000")}],
+            0,
+            {"changeAddress": context.state["receive_address"], "changePosition": 1},
+        ]
+
+    def build_wallet_finalizepsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "finalizepsbt", [context.state["psbt"], False]
+
+    def build_wallet_decoderawtransaction(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "decoderawtransaction", [context.state["raw_tx"]]
+
+    def build_wallet_decodescript(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "decodescript", [context.state["receive_script_pubkey"]]
+
+    def build_wallet_utxoupdatepsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "utxoupdatepsbt", [context.state["psbt"]]
+
+    def build_wallet_combinepsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "combinepsbt", [[context.state["psbt"]]]
+
+    def build_wallet_converttopsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "converttopsbt", [context.state["raw_tx"]]
 
     def build_wallet_decodepsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
         return "decodepsbt", [context.state["psbt"]]


### PR DESCRIPTION
## Summary

- Add scheduled/manual RPC performance and IBD performance workflows.
- Add lint image prewarm workflow.
- Point scheduled nightly checkouts at `0.1.x` and use the public repo trusted runner label when running in `Qbit-Org/qbit`.

## Validation

- `actionlint .github/workflows/rpc-perf-manual.yml .github/workflows/ibd-perf-manual.yml .github/workflows/lint-image-prewarm.yml .github/workflows/ci-nightly-heavy.yml`
- Docker-backed repo lint via `docker build -t bitcoin-linter --file ./ci/lint_imagefile .` and `docker run ... bitcoin-linter`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784998934&installation_id=141183937&pr_number=15&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F15&signature=6a16ad11364bf4bddce20a1bb5c57291acc844d569df9c9b3b0580ad21676388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New long-running self-hosted workflows and a nightly branch change affect CI cost and what code is tested; RPC manifest/harness changes are test-only but broaden benchmark surface area.
> 
> **Overview**
> Adds **scheduled and manual GitHub Actions** for **IBD performance** (replay/network lanes, hotspot benches, profile resolution, artifact uploads) and **RPC performance** (qbit-only and optional Bitcoin Core **v30.2** comparison on `0.1.x` for nightly runs). Introduces a **lint image prewarm** workflow on `main` path changes plus a daily cron.
> 
> **Nightly heavy CI** now checks out **`0.1.x`** instead of `develop` on schedule, uses the **`qbit-trusted-ci`** runner label when `github.repository == 'Qbit-Org/qbit'`, and scanner docs describe the **`main...0.1.x`** git-history window.
> 
> **RPC perf harness** gains many **`shared.modified.*` wallet/PSBT benchmarks** in `rpc_perf_manifest.json`, with **`feature_rpc_perf.py`** extended (receive label/scriptPubKey fixture state and matching `build_wallet_*` call builders) so the new workflow can exercise them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62fd1b6fb74c97a718dc4875ccf13ce5cf82171c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->