### PR TITLE
Add RPC benchmark endpoint coverage

### DIFF
--- a/test/functional/data/rpc_perf_manifest.json
+++ b/test/functional/data/rpc_perf_manifest.json
@@ -842,6 +842,176 @@
       "fixture_reset_mode": "none"
     },
     {
+      "id": "shared.modified.getwalletinfo.default",
+      "description": "Read metadata for the prepared wallet fixture.",
+      "endpoint": "getwalletinfo",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_getwalletinfo",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.getbalance.default",
+      "description": "Read the prepared wallet's confirmed balance.",
+      "endpoint": "getbalance",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_getbalance",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.getbalances.default",
+      "description": "Read detailed balance buckets for the prepared wallet fixture.",
+      "endpoint": "getbalances",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_getbalances",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listunspent.default",
+      "description": "List spendable outputs in the prepared wallet fixture.",
+      "endpoint": "listunspent",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_listunspent",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listtransactions.default",
+      "description": "List recent wallet transactions for the prepared wallet fixture.",
+      "endpoint": "listtransactions",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_listtransactions",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listwallets.loaded",
+      "description": "List loaded wallets after preparing the wallet fixture.",
+      "endpoint": "listwallets",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "static_params",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listwalletdir.default",
+      "description": "List available wallet directories after preparing the wallet fixture.",
+      "endpoint": "listwalletdir",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "static_params",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.getaddressesbylabel.receive",
+      "description": "List wallet addresses for the prepared receive label.",
+      "endpoint": "getaddressesbylabel",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_getaddressesbylabel",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listlabels.default",
+      "description": "List labels in the prepared wallet fixture.",
+      "endpoint": "listlabels",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_listlabels",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.listlockunspent.default",
+      "description": "List locked wallet outputs in the prepared wallet fixture.",
+      "endpoint": "listlockunspent",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_listlockunspent",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
       "id": "shared.modified.listdescriptors.default",
       "description": "List wallet descriptors while recording qbit P2MR descriptor shape.",
       "endpoint": "listdescriptors",

--- a/test/functional/data/rpc_perf_manifest.json
+++ b/test/functional/data/rpc_perf_manifest.json
@@ -1046,6 +1046,176 @@
       "fixture_reset_mode": "none"
     },
     {
+      "id": "shared.modified.createrawtransaction.wallet_output",
+      "description": "Create an unsigned raw transaction paying the prepared wallet receive address.",
+      "endpoint": "createrawtransaction",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_createrawtransaction",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.createpsbt.wallet_output",
+      "description": "Create an unsigned PSBT paying the prepared wallet receive address.",
+      "endpoint": "createpsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_createpsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.fundrawtransaction.wallet",
+      "description": "Fund a prepared unsigned raw transaction with wallet inputs and a fixed change address.",
+      "endpoint": "fundrawtransaction",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_fundrawtransaction",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 3
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.walletcreatefundedpsbt.wallet",
+      "description": "Create and fund a wallet PSBT with a fixed change address.",
+      "endpoint": "walletcreatefundedpsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_walletcreatefundedpsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 3
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.finalizepsbt.incomplete",
+      "description": "Finalize the prepared unsigned wallet PSBT without extracting a transaction.",
+      "endpoint": "finalizepsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_finalizepsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.decoderawtransaction.wallet",
+      "description": "Decode the prepared unsigned wallet raw transaction.",
+      "endpoint": "decoderawtransaction",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_decoderawtransaction",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.decodescript.receive",
+      "description": "Decode the prepared receive address scriptPubKey.",
+      "endpoint": "decodescript",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_decodescript",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.utxoupdatepsbt.wallet",
+      "description": "Update the prepared wallet PSBT from available UTXO data.",
+      "endpoint": "utxoupdatepsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_utxoupdatepsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.combinepsbt.single",
+      "description": "Run the PSBT combiner over the prepared wallet PSBT.",
+      "endpoint": "combinepsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_combinepsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
+      "id": "shared.modified.converttopsbt.raw",
+      "description": "Convert the prepared unsigned raw transaction into PSBT format.",
+      "endpoint": "converttopsbt",
+      "fixture": "wallet_ready",
+      "lane": "shared_name_qbit_modified",
+      "call_builder": "wallet_converttopsbt",
+      "target_support": [
+        "qbit",
+        "reference"
+      ],
+      "modes": {
+        "warm": 5
+      },
+      "comparison_mode": "latency_only",
+      "fixture_reset_mode": "none"
+    },
+    {
       "id": "shared.modified.decodepsbt.wallet",
       "description": "Decode a wallet-funded PSBT and record qbit PQC/P2MR response-shape differences.",
       "endpoint": "decodepsbt",

--- a/test/functional/feature_rpc_perf.py
+++ b/test/functional/feature_rpc_perf.py
@@ -516,7 +516,8 @@ class RPCPerfTest(BitcoinTestFramework):
         mining_address = wallet.getnewaddress()
         node.generatetoaddress(COINBASE_MATURITY + WALLET_READY_MATURE_OUTPUTS, mining_address, called_by_framework=True)
 
-        receive_address = wallet.getnewaddress()
+        receive_label = "rpc-perf-receive"
+        receive_address = wallet.getnewaddress(receive_label)
         raw_tx = wallet.createrawtransaction([], [{receive_address: Decimal("0.10000000")}])
         funded_tx = wallet.fundrawtransaction(raw_tx)
         psbt = wallet.walletcreatefundedpsbt([], [{receive_address: Decimal("0.10000000")}])["psbt"]
@@ -528,6 +529,7 @@ class RPCPerfTest(BitcoinTestFramework):
             {
                 "wallet_name": wallet_name,
                 "wallet_rpc": wallet,
+                "receive_label": receive_label,
                 "receive_address": receive_address,
                 "raw_tx": raw_tx,
                 "funded_tx": funded_tx["hex"],
@@ -916,6 +918,30 @@ class RPCPerfTest(BitcoinTestFramework):
 
     def build_wallet_getaddressinfo(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
         return context.state["wallet_rpc"], "getaddressinfo", [context.state["receive_address"]]
+
+    def build_wallet_getwalletinfo(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "getwalletinfo", []
+
+    def build_wallet_getbalance(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "getbalance", []
+
+    def build_wallet_getbalances(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "getbalances", []
+
+    def build_wallet_listunspent(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "listunspent", []
+
+    def build_wallet_listtransactions(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "listtransactions", []
+
+    def build_wallet_getaddressesbylabel(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "getaddressesbylabel", [context.state["receive_label"]]
+
+    def build_wallet_listlabels(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "listlabels", []
+
+    def build_wallet_listlockunspent(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "listlockunspent", []
 
     def build_wallet_listdescriptors(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
         return context.state["wallet_rpc"], "listdescriptors", []

--- a/test/functional/feature_rpc_perf.py
+++ b/test/functional/feature_rpc_perf.py
@@ -518,6 +518,7 @@ class RPCPerfTest(BitcoinTestFramework):
 
         receive_label = "rpc-perf-receive"
         receive_address = wallet.getnewaddress(receive_label)
+        receive_script_pubkey = wallet.getaddressinfo(receive_address)["scriptPubKey"]
         raw_tx = wallet.createrawtransaction([], [{receive_address: Decimal("0.10000000")}])
         funded_tx = wallet.fundrawtransaction(raw_tx)
         psbt = wallet.walletcreatefundedpsbt([], [{receive_address: Decimal("0.10000000")}])["psbt"]
@@ -531,6 +532,7 @@ class RPCPerfTest(BitcoinTestFramework):
                 "wallet_rpc": wallet,
                 "receive_label": receive_label,
                 "receive_address": receive_address,
+                "receive_script_pubkey": receive_script_pubkey,
                 "raw_tx": raw_tx,
                 "funded_tx": funded_tx["hex"],
                 "psbt": psbt,
@@ -949,6 +951,44 @@ class RPCPerfTest(BitcoinTestFramework):
     def build_wallet_createwalletdescriptor(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
         descriptor_type = "p2mr" if context.plan.target == QBIT_TARGET else "bech32m"
         return context.state["wallet_rpc"], "createwalletdescriptor", [descriptor_type]
+
+    def build_wallet_createrawtransaction(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return "createrawtransaction", [[], [{context.state["receive_address"]: Decimal("0.10000000")}]]
+
+    def build_wallet_createpsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return "createpsbt", [[], [{context.state["receive_address"]: Decimal("0.10000000")}]]
+
+    def build_wallet_fundrawtransaction(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "fundrawtransaction", [
+            context.state["raw_tx"],
+            {"changeAddress": context.state["receive_address"], "changePosition": 1},
+        ]
+
+    def build_wallet_walletcreatefundedpsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str):
+        return context.state["wallet_rpc"], "walletcreatefundedpsbt", [
+            [],
+            [{context.state["receive_address"]: Decimal("0.10000000")}],
+            0,
+            {"changeAddress": context.state["receive_address"], "changePosition": 1},
+        ]
+
+    def build_wallet_finalizepsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "finalizepsbt", [context.state["psbt"], False]
+
+    def build_wallet_decoderawtransaction(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "decoderawtransaction", [context.state["raw_tx"]]
+
+    def build_wallet_decodescript(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "decodescript", [context.state["receive_script_pubkey"]]
+
+    def build_wallet_utxoupdatepsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "utxoupdatepsbt", [context.state["psbt"]]
+
+    def build_wallet_combinepsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "combinepsbt", [[context.state["psbt"]]]
+
+    def build_wallet_converttopsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
+        return "converttopsbt", [context.state["raw_tx"]]
 
     def build_wallet_decodepsbt(self, benchmark: BenchmarkCase, context: FixtureContext, sample_index: int, mode: str) -> tuple[str, list[Any]]:
         return "decodepsbt", [context.state["psbt"]]


### PR DESCRIPTION
## Summary

- Add wallet read RPC benchmark cases for low-risk wallet and wallet-listing endpoints.
- Add raw transaction and PSBT construction benchmark cases.
- Reuse stable wallet fixture inputs so repeated samples avoid address/keypool mutation.

## Validation

- `jq empty test/functional/data/rpc_perf_manifest.json`
- `python3 -m py_compile test/functional/feature_rpc_perf.py`
- Manifest builder and duplicate-id check
- `git diff --check`
- `./test/functional/feature_rpc_perf.py --help`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785000035&installation_id=141183937&pr_number=16&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F16&signature=2302929d9600a54daa94368875b253ba1e5ef4abe94307459fdfd36043c7fd3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to functional RPC perf test data and harness code; no node, wallet, or RPC implementation behavior is modified.
> 
> **Overview**
> Expands the RPC performance harness with **wallet read**, **listing**, and **raw tx/PSBT** benchmarks on the existing `wallet_ready` fixture, all in the `shared_name_qbit_modified` lane with **latency-only** comparison against reference.
> 
> **`rpc_perf_manifest.json`** gains many new `shared.modified.*` cases (e.g. `getwalletinfo`, `getbalance`, `listunspent`, `createrawtransaction`, `fundrawtransaction`, `decodepsbt` neighbors like `decoderawtransaction`, `converttopsbt`) wired to new `wallet_*` call builders.
> 
> **`prepare_wallet_ready`** now labels the receive address (`rpc-perf-receive`), stores `receive_script_pubkey` for `decodescript`, and keeps reusing prebuilt `raw_tx` / `psbt` so warm runs do not churn the keypool or addresses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9020b73ce275eeb513bb99bcb0a00a34ff16da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->