### PR TITLE
Prevent AuxPoW signalling in permissionless GBT

### DIFF
--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -144,6 +144,10 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock()
     // -blockversion=N to test forking scenarios
     if (chainparams.MineBlocksOnDemand()) {
         pblock->nVersion = gArgs.GetIntArg("-blockversion", pblock->nVersion);
+        // Permissionless templates do not carry an AuxPoW payload.
+        if (pblock->SignalsAuxpow()) {
+            pblock->nVersion = MakeVersion(/*chain_id=*/0, /*auxpow=*/false, pblock->GetVersionBits());
+        }
     }
 
     pblock->nTime = TicksSinceEpoch<std::chrono::seconds>(NodeClock::now());

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1085,12 +1085,11 @@ static RPCHelpMan getblocktemplate()
 
     // Keep explicit -blockversion regtest overrides intact (they may not use the
     // BIP9 top-bit shape); only canonicalize versions already in BIP9 layout.
+    // Permissionless getblocktemplate candidates never include an AuxPoW
+    // payload, so the returned version must not signal AuxPoW. The dedicated
+    // createauxblock/submitauxblock path sets AuxPoW versions explicitly.
     if (HasBIP9TopBitsShape(block.nVersion)) {
-        const bool auxpow_version{block.SignalsAuxpow()};
-        CHECK_NONFATAL(consensusParams.nAuxpowChainId >= 0);
-        CHECK_NONFATAL(consensusParams.nAuxpowChainId <= std::numeric_limits<uint16_t>::max());
-        const uint16_t chain_id{auxpow_version ? static_cast<uint16_t>(consensusParams.nAuxpowChainId) : uint16_t{0}};
-        block.nVersion = MakeVersion(chain_id, auxpow_version, block.GetVersionBits());
+        block.nVersion = MakeVersion(/*chain_id=*/0, /*auxpow=*/false, block.GetVersionBits());
     }
     const uint32_t version_rolling_mask{GetPermissionlessVersionRollingMask(block.nVersion)};
 

--- a/test/functional/mining_version_field.py
+++ b/test/functional/mining_version_field.py
@@ -167,6 +167,27 @@ class MiningVersionFieldTest(BitcoinTestFramework):
         self.restart_node(0)
         node = self.nodes[0]
 
+        self.log.info("Preserve version rolling for non-AuxPoW BIP9 -blockversion overrides")
+        bip9_override = make_version(version_bits=0x39)
+        self.restart_node(0, extra_args=[f"-blockversion={bip9_override}"])
+        node = self.nodes[0]
+        bip9_override_tmpl = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
+        assert_equal(bip9_override_tmpl["version"], bip9_override)
+        assert_equal(bip9_override_tmpl["versionrollingmask"], f"{BLOCK_VERSION_PERMISSIONLESS_ROLLING_MASK:08x}")
+        self.restart_node(0)
+        node = self.nodes[0]
+
+        self.log.info("Sanitize AuxPoW-signalling BIP9 -blockversion overrides for permissionless templates")
+        auxpow_override = make_version(auxpow=True)
+        assert_equal(auxpow_override, 0x20000100)
+        self.restart_node(0, extra_args=[f"-blockversion={auxpow_override}"])
+        node = self.nodes[0]
+        auxpow_override_tmpl = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
+        assert_equal(auxpow_override_tmpl["version"], make_version(auxpow=False))
+        assert_equal(auxpow_override_tmpl["versionrollingmask"], f"{BLOCK_VERSION_PERMISSIONLESS_ROLLING_MASK:08x}")
+        self.restart_node(0)
+        node = self.nodes[0]
+
         self.log.info("Reject versions with non-BIP9 top bits")
         bad_top_bits = 0x40000000 | signal_bits
         bad_top_bits_block = self.create_candidate_block(version=bad_top_bits)


### PR DESCRIPTION
## Summary
- Sanitize regtest permissionless `-blockversion` overrides that set the AuxPoW flag.
- Keep permissionless `getblocktemplate` responses canonical with `chain_id=0`, `auxpow=false`, and low versionbits preserved.
- Add functional regression coverage for `-blockversion=0x20000100` while preserving benign BIP9 override behavior.

## Root Cause
Permissionless block templates can be built without an AuxPoW payload, but a regtest `-blockversion` override could set an AuxPoW-signalling BIP9-shaped version. `getblocktemplate` then exposed a version that normal `submitblock` or proposal flow could not decode without an AuxPoW payload.

## Validation
- Docker lint image: `docker run --rm ... bitcoin-linter`
- `cmake --build build --target qbitd qbit-cli test_qbit -j4`
- `ulimit -n 1024; build/bin/test_qbit --run_test=blockversion_tests`
- `ulimit -n 1024; build/bin/test_qbit --run_test=cadence_tests`
- `ulimit -n 1024; build/bin/test_qbit --run_test=testnet4_miner_tests`
- `ulimit -n 1024; build/test/functional/test_runner.py mining_version_field.py feature_cadence_activation.py mining_basic.py`
- `ulimit -n 1024; build/test/functional/test_runner.py feature_auxpow.py`
- Direct RPC smoke check: permissionless GBT returned `0x20000000`, reconstructed `createauxblock` returned AuxPoW version `0x2f58c100`, and `submitauxblock` returned `null`.

Fixes #18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-adjacent mining RPC and template version semantics; behavior change is narrow but affects how miners interpret GBT `version` and regtest overrides.
> 
> **Overview**
> Permissionless **getblocktemplate** and regtest block assembly no longer expose block versions that signal **AuxPoW** or carry a non-zero chain ID. BIP9-shaped template versions are always canonicalized to `chain_id=0` and `auxpow=false` while keeping the low deployment bits; regtest **`-blockversion`** overrides that set the AuxPoW flag get the same sanitization in the miner. **AuxPoW** mining stays on **`createauxblock`** / **`submitauxblock`**, which set AuxPoW versions explicitly.
> 
> Functional coverage was added for benign BIP9 **`-blockversion`** overrides (version rolling preserved) and for **`0x20000100`**-style overrides (sanitized to a non-AuxPoW BIP9 version).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cddb2d00a56f6b429dcb5202d968f69ef8554266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->