### PR TITLE
Accept legacy AuxPoW RPC payloads

### DIFF
--- a/doc/integration/mining-pool-quickstart.md
+++ b/doc/integration/mining-pool-quickstart.md
@@ -148,6 +148,34 @@ Submit a solved AuxPoW payload:
 qbit-cli <chain option> submitauxblock "$AUX_HASH" "$AUXPOW_HEX"
 ```
 
+`AUXPOW_HEX` may use qbit's canonical AuxPoW layout:
+
+| Order | Field |
+|---:|---|
+| 1 | Parent coinbase transaction, serialized without witness |
+| 2 | Coinbase merkle branch |
+| 3 | Coinbase branch index, little-endian signed 32-bit integer |
+| 4 | Aux chain merkle branch |
+| 5 | Aux chain index, little-endian signed 32-bit integer |
+| 6 | Parent block header |
+
+For compatibility with Dogecoin/Namecoin-style AuxPoW serializers,
+`submitauxblock` also accepts this legacy layout:
+
+| Order | Field |
+|---:|---|
+| 1 | Parent coinbase transaction, serialized without witness |
+| 2 | Legacy `hashBlock` field |
+| 3 | Coinbase merkle branch |
+| 4 | Coinbase branch index, little-endian signed 32-bit integer |
+| 5 | Aux chain merkle branch |
+| 6 | Aux chain index, little-endian signed 32-bit integer |
+| 7 | Parent block header |
+
+The legacy `hashBlock` field must be zero or match the parent block header
+hash. qbit drops that compatibility field after RPC decoding, then stores,
+validates, and relays the block using qbit's canonical AuxPoW layout.
+
 `submitauxblock` returns `null` on acceptance. It returns a BIP22-style rejection string otherwise. A common stale result is `stale-prevblk`, which means the cached qbit candidate no longer builds on the active qbit tip, exceeded `-auxpowtemplateexpiry`, or was evicted by `-auxpowtemplatecachelimit`.
 
 ## Cadence lane resumption and monitoring

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1241,6 +1241,46 @@ void RemoveCachedAuxBlock(const uint256& aux_hash) LOCKS_EXCLUDED(g_aux_block_ca
     g_aux_block_cache.erase(aux_hash);
 }
 
+std::optional<CAuxPow> TryDecodeCanonicalAuxPow(std::span<const unsigned char> auxpow_data)
+{
+    DataStream stream{auxpow_data};
+    try {
+        CAuxPow auxpow{deserialize, stream};
+        if (!stream.empty()) {
+            return std::nullopt;
+        }
+        return auxpow;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+std::optional<CAuxPow> TryDecodeLegacyAuxPow(std::span<const unsigned char> auxpow_data)
+{
+    DataStream stream{auxpow_data};
+    try {
+        CAuxPow auxpow;
+        uint256 legacy_hash_block;
+        stream >> TX_NO_WITNESS(auxpow.coinbase_tx);
+        stream >> legacy_hash_block;
+        stream >> auxpow.coinbase_merkle_branch;
+        stream >> auxpow.coinbase_branch_index;
+        stream >> auxpow.chain_merkle_branch;
+        stream >> auxpow.chain_index;
+        stream >> auxpow.parent_block;
+        if (!stream.empty()) {
+            return std::nullopt;
+        }
+        if (!legacy_hash_block.IsNull() && legacy_hash_block != auxpow.parent_block.GetHash()) {
+            return std::nullopt;
+        }
+        return auxpow;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+} // namespace
+
 CAuxPow DecodeHexAuxPow(const std::string& hex_auxpow)
 {
     if (!IsHex(hex_auxpow)) {
@@ -1248,18 +1288,17 @@ CAuxPow DecodeHexAuxPow(const std::string& hex_auxpow)
     }
 
     const std::vector<unsigned char> auxpow_data{ParseHex(hex_auxpow)};
-    DataStream stream{std::span<const unsigned char>{auxpow_data.data(), auxpow_data.size()}};
-    try {
-        CAuxPow auxpow{deserialize, stream};
-        if (!stream.empty()) {
-            throw std::ios_base::failure("AuxPow decode failed");
-        }
-        return auxpow;
-    } catch (const std::exception&) {
-        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "AuxPow decode failed");
+    const std::span<const unsigned char> auxpow_span{auxpow_data.data(), auxpow_data.size()};
+    if (auto auxpow{TryDecodeCanonicalAuxPow(auxpow_span)}) {
+        return std::move(*auxpow);
     }
+    if (auto auxpow{TryDecodeLegacyAuxPow(auxpow_span)}) {
+        return std::move(*auxpow);
+    }
+    throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "AuxPow decode failed");
 }
 
+namespace {
 UniValue ProcessSubmittedBlock(ChainstateManager& chainman, const std::shared_ptr<CBlock>& blockptr)
 {
     bool new_block;
@@ -1380,7 +1419,7 @@ static RPCHelpMan submitauxblock()
         "Submit an AuxPoW payload for a cached merged-mining candidate block.\n",
         {
             {"hash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The aux block hash returned by createauxblock."},
-            {"auxpow_hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The serialized AuxPoW payload in hexadecimal."},
+            {"auxpow_hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The serialized AuxPoW payload in hexadecimal. Accepts qbit's canonical layout or a legacy Dogecoin-style payload."},
         },
         {
             RPCResult{"If the block was accepted", RPCResult::Type::NONE, "", ""},

--- a/src/rpc/mining.h
+++ b/src/rpc/mining.h
@@ -6,8 +6,13 @@
 #define QBIT_RPC_MINING_H
 
 #include <cstdint>
+#include <string>
 
+class CAuxPow;
 class CChain;
+
+/** Decode the AuxPoW hex layouts accepted by the submitauxblock RPC. */
+CAuxPow DecodeHexAuxPow(const std::string& hex_auxpow);
 
 /**
  * Return average network hashes per second based on the last `lookup` blocks,

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -12,10 +12,12 @@
 #include <node/kernel_notifications.h>
 #include <node/miner.h>
 #include <pow.h>
+#include <rpc/mining.h>
 #include <script/script.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <univalue.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
@@ -24,6 +26,7 @@
 #include <array>
 #include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 
 using node::BlockAssembler;
@@ -131,6 +134,43 @@ std::shared_ptr<const CAuxPow> MakeAuxpowPayload(const uint256& aux_block_hash, 
     return auxpow;
 }
 
+std::string HexStrFromStream(const DataStream& stream)
+{
+    return HexStr(stream);
+}
+
+std::string SerializeAuxpowHex(const CAuxPow& auxpow)
+{
+    DataStream stream;
+    stream << auxpow;
+    return HexStrFromStream(stream);
+}
+
+std::string SerializeLegacyAuxpowHex(const CAuxPow& auxpow, const uint256& legacy_hash_block)
+{
+    DataStream stream;
+    stream << TX_NO_WITNESS(auxpow.coinbase_tx);
+    stream << legacy_hash_block;
+    stream << auxpow.coinbase_merkle_branch;
+    stream << auxpow.coinbase_branch_index;
+    stream << auxpow.chain_merkle_branch;
+    stream << auxpow.chain_index;
+    stream << auxpow.parent_block;
+    return HexStrFromStream(stream);
+}
+
+void CheckAuxpowPayloadEqual(const CAuxPow& actual, const CAuxPow& expected)
+{
+    BOOST_REQUIRE(actual.coinbase_tx);
+    BOOST_REQUIRE(expected.coinbase_tx);
+    BOOST_CHECK_EQUAL(actual.coinbase_tx->GetHash(), expected.coinbase_tx->GetHash());
+    BOOST_CHECK(actual.coinbase_merkle_branch == expected.coinbase_merkle_branch);
+    BOOST_CHECK_EQUAL(actual.coinbase_branch_index, expected.coinbase_branch_index);
+    BOOST_CHECK(actual.chain_merkle_branch == expected.chain_merkle_branch);
+    BOOST_CHECK_EQUAL(actual.chain_index, expected.chain_index);
+    BOOST_CHECK_EQUAL(actual.parent_block.GetHash(), expected.parent_block.GetHash());
+}
+
 CBlockHeader MakeAuxpowHeader(const Consensus::Params& consensus)
 {
     CBlockHeader header;
@@ -234,6 +274,50 @@ BOOST_AUTO_TEST_CASE(auxpow_block_roundtrip_preserves_payload_and_merkle_root)
     BOOST_CHECK_EQUAL(decoded.hashMerkleRoot, block.hashMerkleRoot);
     BOOST_CHECK_EQUAL(decoded.vtx.size(), block.vtx.size());
     BOOST_CHECK_EQUAL(BlockMerkleRoot(decoded), decoded.hashMerkleRoot);
+}
+
+BOOST_AUTO_TEST_CASE(auxpow_rpc_decoder_accepts_canonical_payload)
+{
+    const auto consensus = CreateChainParams(*m_node.args, ChainType::MAIN)->GetConsensus();
+    const CBlockHeader header = MakeAuxpowHeader(consensus);
+
+    const CAuxPow decoded = DecodeHexAuxPow(SerializeAuxpowHex(*header.auxpow));
+
+    CheckAuxpowPayloadEqual(decoded, *header.auxpow);
+}
+
+BOOST_AUTO_TEST_CASE(auxpow_rpc_decoder_accepts_legacy_payload)
+{
+    const auto consensus = CreateChainParams(*m_node.args, ChainType::MAIN)->GetConsensus();
+    const CBlockHeader header = MakeAuxpowHeader(consensus);
+
+    const std::string canonical_hex = SerializeAuxpowHex(*header.auxpow);
+    const std::string legacy_hex = SerializeLegacyAuxpowHex(*header.auxpow, header.auxpow->parent_block.GetHash());
+    const CAuxPow decoded_with_parent_hash = DecodeHexAuxPow(legacy_hex);
+    CheckAuxpowPayloadEqual(decoded_with_parent_hash, *header.auxpow);
+    BOOST_CHECK_EQUAL(SerializeAuxpowHex(decoded_with_parent_hash), canonical_hex);
+    BOOST_CHECK_NE(SerializeAuxpowHex(decoded_with_parent_hash), legacy_hex);
+
+    const CAuxPow decoded_with_null_hash = DecodeHexAuxPow(SerializeLegacyAuxpowHex(*header.auxpow, uint256{}));
+    CheckAuxpowPayloadEqual(decoded_with_null_hash, *header.auxpow);
+}
+
+BOOST_AUTO_TEST_CASE(auxpow_rpc_decoder_rejects_malformed_legacy_payload)
+{
+    const auto consensus = CreateChainParams(*m_node.args, ChainType::MAIN)->GetConsensus();
+    const CBlockHeader header = MakeAuxpowHeader(consensus);
+
+    std::string truncated_legacy = SerializeLegacyAuxpowHex(*header.auxpow, header.auxpow->parent_block.GetHash());
+    truncated_legacy.resize(truncated_legacy.size() - 2);
+    BOOST_CHECK_THROW(DecodeHexAuxPow(truncated_legacy), UniValue);
+}
+
+BOOST_AUTO_TEST_CASE(auxpow_rpc_decoder_rejects_mismatched_legacy_hash_block)
+{
+    const auto consensus = CreateChainParams(*m_node.args, ChainType::MAIN)->GetConsensus();
+    const CBlockHeader header = MakeAuxpowHeader(consensus);
+
+    BOOST_CHECK_THROW(DecodeHexAuxPow(SerializeLegacyAuxpowHex(*header.auxpow, uint256{42})), UniValue);
 }
 
 BOOST_AUTO_TEST_CASE(auxpow_rejects_missing_and_unexpected_payload)

--- a/test/functional/feature_auxpow.py
+++ b/test/functional/feature_auxpow.py
@@ -111,12 +111,32 @@ class FeatureAuxPowTest(BitcoinTestFramework):
         self.log.info("submitauxblock rejects malformed AuxPoW hex")
         assert_raises_rpc_error(-22, "AuxPow decode failed", node.submitauxblock, aux_template["hash"], "zz")
 
+        self.log.info("submitauxblock rejects legacy AuxPoW payloads with mismatched hashBlock")
+        assert_raises_rpc_error(
+            -22,
+            "AuxPow decode failed",
+            node.submitauxblock,
+            aux_template["hash"],
+            self.make_auxpow(aux_template).to_legacy_hex(legacy_hash_block=42),
+        )
+
         self.log.info("Merged mining happy path: create, solve parent, submit")
         self.advance_mock_time()
         aux_template = node.createauxblock(payout_address)
         current_height = node.getblockcount()
         assert_equal(node.submitauxblock(aux_template["hash"], self.make_auxpow(aux_template).to_hex()), None)
         assert_equal(node.getblockcount(), current_height + 1)
+
+        self.log.info("submitauxblock accepts legacy AuxPoW payloads and stores canonical AuxPoW bytes")
+        self.advance_mock_time()
+        aux_template = node.createauxblock(payout_address)
+        legacy_auxpow = self.make_auxpow(aux_template)
+        current_height = node.getblockcount()
+        assert_equal(node.submitauxblock(aux_template["hash"], legacy_auxpow.to_legacy_hex()), None)
+        assert_equal(node.getblockcount(), current_height + 1)
+        raw_block = node.getblock(node.getbestblockhash(), 0)
+        assert legacy_auxpow.to_hex() in raw_block
+        assert legacy_auxpow.to_legacy_hex() not in raw_block
 
         self.log.info("getmininginfo.next follows the permissionless candidate after an AuxPoW tip")
         native_template = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)

--- a/test/functional/test_framework/auxpow.py
+++ b/test/functional/test_framework/auxpow.py
@@ -132,8 +132,24 @@ class AuxPowPayload:
             + self.parent_block.serialize()
         )
 
+    def serialize_legacy(self, *, legacy_hash_block=None):
+        if legacy_hash_block is None:
+            legacy_hash_block = self.parent_block.hash_int
+        return (
+            self.coinbase_tx.serialize_without_witness()
+            + ser_uint256(legacy_hash_block)
+            + ser_uint256_vector(self.coinbase_merkle_branch)
+            + self.coinbase_branch_index.to_bytes(4, "little", signed=True)
+            + ser_uint256_vector(self.chain_merkle_branch)
+            + self.chain_index.to_bytes(4, "little", signed=True)
+            + self.parent_block.serialize()
+        )
+
     def to_hex(self):
         return self.serialize().hex()
+
+    def to_legacy_hex(self, *, legacy_hash_block=None):
+        return self.serialize_legacy(legacy_hash_block=legacy_hash_block).hex()
 
     def update_parent_merkle_root(self):
         self.parent_block.hashMerkleRoot = check_merkle_branch(


### PR DESCRIPTION
## Summary
- add a submitauxblock compatibility decoder for legacy Dogecoin-style AuxPoW payloads
- normalize accepted legacy payloads into qbit's canonical CAuxPow layout before validation/storage
- document canonical and legacy AuxPoW field layouts for mining pool integrations

## Root Cause
Existing merged-mining coordinator tooling can emit a legacy CAuxPow shape that includes a 32-byte hashBlock field after the parent coinbase transaction. qbit's canonical CAuxPow layout does not include that field, so submitauxblock tried to parse those bytes as the coinbase merkle branch length.

## Validation
- cmake --build build --target test_bitcoin qbitd qbit-cli -j 8
- ulimit -n 1024; build/bin/test_qbit --run_test=auxpow_tests
- ulimit -n 1024; build/bin/test_qbit --run_test=auxpow_tests_validation
- ulimit -n 1024; build/test/functional/test_runner.py feature_auxpow.py feature_auxpow_commitment_activation.py
- docker lint image: ./ci/lint/06_script.sh with COMMIT_RANGE=HEAD~1..HEAD

Closes #17

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785010484&installation_id=141183937&pr_number=23&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F23&signature=1116eafeb53659eee320a8a8593c037bfdee64aac6bdd56e24192b83a41c6ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches merged-mining block submission and deserialization; incorrect legacy handling could accept bad payloads, but behavior is gated by existing AuxPoW validation and covered by new unit/functional tests.
> 
> **Overview**
> **`submitauxblock`** now accepts **canonical** qbit AuxPoW hex and **legacy** Dogecoin/Namecoin-style payloads that insert a 32-byte **`hashBlock`** after the parent coinbase. Decoding tries canonical first, then legacy; legacy **`hashBlock`** must be zero or match the parent header hash, after which the payload is normalized to **`CAuxPow`** for the same validation, storage, and relay path as before.
> 
> The mining pool quickstart documents both field orders. Unit and functional tests cover canonical and legacy acceptance, mismatched **`hashBlock`** rejection, and on-chain storage of canonical bytes only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b321bda3351f914bd580a069f94d6d78c7c7af56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->