### PR TITLE
ci: Fix BuildKit DNS for internal registry CI builds

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -20,6 +20,14 @@ inputs:
     description: 'Whether to add --load so the built image is available to docker create/run'
     required: false
     default: 'true'
+  buildkit-dns-nameservers:
+    description: 'Comma-separated BuildKit DNS nameservers to write to buildkitd.toml'
+    required: false
+    default: ''
+  buildkit-dns-search-domains:
+    description: 'Comma-separated BuildKit DNS search domains to write to buildkitd.toml'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -35,23 +43,13 @@ runs:
             ;;
         esac
 
-    - name: Configure BuildKit registry access
+    - name: Configure BuildKit registry and DNS access
       shell: bash
+      env:
+        BUILDKIT_DNS_NAMESERVERS: ${{ inputs.buildkit-dns-nameservers }}
+        BUILDKIT_DNS_SEARCH_DOMAINS: ${{ inputs.buildkit-dns-search-domains }}
       run: |
-        BUILDKIT_CONFIG="${RUNNER_TEMP}/buildkitd.toml"
-        : > "${BUILDKIT_CONFIG}"
-
-        if [[ "${CI_ENFORCE_INTERNAL_REGISTRY}" == "1" ]] && [[ -n "${CI_IMAGE_REGISTRY_PREFIX}" ]]; then
-          REGISTRY_HOST="${CI_IMAGE_REGISTRY_PREFIX%%/*}"
-          {
-            echo "[registry.\"${REGISTRY_HOST}\"]"
-            echo "  http = true"
-            echo "  insecure = true"
-          } >> "${BUILDKIT_CONFIG}"
-          echo "Configured BuildKit to allow plain HTTP for registry host '${REGISTRY_HOST}'."
-        fi
-
-        echo "BUILDKIT_CONFIG=${BUILDKIT_CONFIG}" >> "${GITHUB_ENV}"
+        bash "${GITHUB_ACTION_PATH}/buildkit-config.sh"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/actions/configure-docker/buildkit-config.sh
+++ b/.github/actions/configure-docker/buildkit-config.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026-present The qbit core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+set -euo pipefail
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "${value}"
+}
+
+toml_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "${value}"
+}
+
+toml_array_from_csv() {
+  local csv="$1"
+  local raw_value
+  local remaining="${csv},"
+  local value
+  local separator=""
+
+  printf '['
+  while [[ -n "${remaining}" ]]; do
+    raw_value="${remaining%%,*}"
+    remaining="${remaining#*,}"
+    value="$(trim "${raw_value}")"
+    if [[ -n "${value}" ]]; then
+      printf '%s"%s"' "${separator}" "$(toml_escape "${value}")"
+      separator=", "
+    fi
+  done
+  printf ']'
+}
+
+if [[ -z "${RUNNER_TEMP:-}" ]]; then
+  echo "::error::RUNNER_TEMP is required to write buildkitd.toml."
+  exit 1
+fi
+
+if [[ -z "${GITHUB_ENV:-}" ]]; then
+  echo "::error::GITHUB_ENV is required to export BUILDKIT_CONFIG."
+  exit 1
+fi
+
+BUILDKIT_CONFIG="${RUNNER_TEMP}/buildkitd.toml"
+: > "${BUILDKIT_CONFIG}"
+
+if [[ "${CI_ENFORCE_INTERNAL_REGISTRY:-}" == "1" ]] && [[ -n "${CI_IMAGE_REGISTRY_PREFIX:-}" ]]; then
+  REGISTRY_HOST="${CI_IMAGE_REGISTRY_PREFIX%%/*}"
+  {
+    echo "[registry]"
+    echo "  [registry.\"${REGISTRY_HOST}\"]"
+    echo "    http = true"
+    echo "    insecure = true"
+  } >> "${BUILDKIT_CONFIG}"
+  echo "Configured BuildKit to allow plain HTTP for registry host '${REGISTRY_HOST}'."
+fi
+
+dns_nameservers="$(toml_array_from_csv "${BUILDKIT_DNS_NAMESERVERS:-${CI_BUILDKIT_DNS_NAMESERVERS:-}}")"
+dns_search_domains="$(toml_array_from_csv "${BUILDKIT_DNS_SEARCH_DOMAINS:-${CI_BUILDKIT_DNS_SEARCH_DOMAINS:-}}")"
+
+if [[ "${dns_nameservers}" != "[]" || "${dns_search_domains}" != "[]" ]]; then
+  needs_blank_line="0"
+  if [[ -s "${BUILDKIT_CONFIG}" ]]; then
+    needs_blank_line="1"
+  fi
+  {
+    if [[ "${needs_blank_line}" == "1" ]]; then
+      echo
+    fi
+    echo "[dns]"
+    if [[ "${dns_nameservers}" != "[]" ]]; then
+      echo "  nameservers = ${dns_nameservers}"
+    fi
+    if [[ "${dns_search_domains}" != "[]" ]]; then
+      echo "  searchDomains = ${dns_search_domains}"
+    fi
+  } >> "${BUILDKIT_CONFIG}"
+  echo "Configured BuildKit DNS settings."
+fi
+
+echo "BUILDKIT_CONFIG=${BUILDKIT_CONFIG}" >> "${GITHUB_ENV}"

--- a/.github/workflows/ci-nightly-heavy.yml
+++ b/.github/workflows/ci-nightly-heavy.yml
@@ -53,7 +53,7 @@ env:
   REPO_USE_CIRRUS_RUNNERS: ''
   CI_IMAGE_REGISTRY_PREFIX: qbit-ci-autoscaler:5000/qbit-cache
   CI_ENFORCE_INTERNAL_REGISTRY: 1
-  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100' || '' }}
+  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100,1.1.1.1,8.8.8.8' || '' }}
   CI_BUILDKIT_DNS_SEARCH_DOMAINS: ${{ github.repository == 'Qbit-Org/qbit' && 'tailfa7aa.ts.net,localdomain' || '' }}
 
 jobs:

--- a/.github/workflows/ci-nightly-heavy.yml
+++ b/.github/workflows/ci-nightly-heavy.yml
@@ -53,6 +53,8 @@ env:
   REPO_USE_CIRRUS_RUNNERS: ''
   CI_IMAGE_REGISTRY_PREFIX: qbit-ci-autoscaler:5000/qbit-cache
   CI_ENFORCE_INTERNAL_REGISTRY: 1
+  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100' || '' }}
+  CI_BUILDKIT_DNS_SEARCH_DOMAINS: ${{ github.repository == 'Qbit-Org/qbit' && 'tailfa7aa.ts.net,localdomain' || '' }}
 
 jobs:
   nightly-matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ env:
   REPO_USE_CIRRUS_RUNNERS: '' # Disabled: using self-hosted runners
   CI_IMAGE_REGISTRY_PREFIX: qbit-ci-autoscaler:5000/qbit-cache
   CI_ENFORCE_INTERNAL_REGISTRY: 1
-  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100' || '' }}
+  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100,1.1.1.1,8.8.8.8' || '' }}
   CI_BUILDKIT_DNS_SEARCH_DOMAINS: ${{ github.repository == 'Qbit-Org/qbit' && 'tailfa7aa.ts.net,localdomain' || '' }}
 
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ env:
   REPO_USE_CIRRUS_RUNNERS: '' # Disabled: using self-hosted runners
   CI_IMAGE_REGISTRY_PREFIX: qbit-ci-autoscaler:5000/qbit-cache
   CI_ENFORCE_INTERNAL_REGISTRY: 1
+  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100' || '' }}
+  CI_BUILDKIT_DNS_SEARCH_DOMAINS: ${{ github.repository == 'Qbit-Org/qbit' && 'tailfa7aa.ts.net,localdomain' || '' }}
 
 defaults:
   run:

--- a/.github/workflows/lint-image-prewarm.yml
+++ b/.github/workflows/lint-image-prewarm.yml
@@ -28,7 +28,7 @@ env:
   CONTAINER_NAME: "bitcoin-linter-main"
   CI_IMAGE_REGISTRY_PREFIX: qbit-ci-autoscaler:5000/qbit-cache
   CI_ENFORCE_INTERNAL_REGISTRY: 1
-  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100' || '' }}
+  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100,1.1.1.1,8.8.8.8' || '' }}
   CI_BUILDKIT_DNS_SEARCH_DOMAINS: ${{ github.repository == 'Qbit-Org/qbit' && 'tailfa7aa.ts.net,localdomain' || '' }}
 
 jobs:

--- a/.github/workflows/lint-image-prewarm.yml
+++ b/.github/workflows/lint-image-prewarm.yml
@@ -28,6 +28,8 @@ env:
   CONTAINER_NAME: "bitcoin-linter-main"
   CI_IMAGE_REGISTRY_PREFIX: qbit-ci-autoscaler:5000/qbit-cache
   CI_ENFORCE_INTERNAL_REGISTRY: 1
+  CI_BUILDKIT_DNS_NAMESERVERS: ${{ github.repository == 'Qbit-Org/qbit' && '100.100.100.100' || '' }}
+  CI_BUILDKIT_DNS_SEARCH_DOMAINS: ${{ github.repository == 'Qbit-Org/qbit' && 'tailfa7aa.ts.net,localdomain' || '' }}
 
 jobs:
   prewarm:

--- a/ci/checks/test_configure_docker_buildkit_config.py
+++ b/ci/checks/test_configure_docker_buildkit_config.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The qbit core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+"""Tests for the configure-docker BuildKit config helper."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / ".github/actions/configure-docker/buildkit-config.sh"
+
+
+class ConfigureDockerBuildKitConfigTest(unittest.TestCase):
+    def run_script(self, extra_env: dict[str, str]) -> tuple[str, str]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runner_temp = Path(tmpdir) / "runner-temp"
+            runner_temp.mkdir()
+            github_env = Path(tmpdir) / "github-env"
+
+            env = os.environ.copy()
+            for name in (
+                "BUILDKIT_DNS_NAMESERVERS",
+                "BUILDKIT_DNS_SEARCH_DOMAINS",
+                "CI_BUILDKIT_DNS_NAMESERVERS",
+                "CI_BUILDKIT_DNS_SEARCH_DOMAINS",
+                "CI_ENFORCE_INTERNAL_REGISTRY",
+                "CI_IMAGE_REGISTRY_PREFIX",
+            ):
+                env.pop(name, None)
+            env.update(extra_env)
+            env["RUNNER_TEMP"] = str(runner_temp)
+            env["GITHUB_ENV"] = str(github_env)
+
+            subprocess.run(
+                ["bash", str(SCRIPT)],
+                check=True,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+
+            return (
+                (runner_temp / "buildkitd.toml").read_text(encoding="utf8"),
+                github_env.read_text(encoding="utf8"),
+            )
+
+    def test_writes_internal_registry_and_dns_config(self) -> None:
+        config, github_env = self.run_script(
+            {
+                "CI_ENFORCE_INTERNAL_REGISTRY": "1",
+                "CI_IMAGE_REGISTRY_PREFIX": "qbit-ci-autoscaler:5000/qbit-cache",
+                "CI_BUILDKIT_DNS_NAMESERVERS": "100.100.100.100",
+                "CI_BUILDKIT_DNS_SEARCH_DOMAINS": "tailfa7aa.ts.net,localdomain",
+            }
+        )
+
+        self.assertEqual(
+            config,
+            '\n'.join(
+                [
+                    "[registry]",
+                    '  [registry."qbit-ci-autoscaler:5000"]',
+                    "    http = true",
+                    "    insecure = true",
+                    "",
+                    "[dns]",
+                    '  nameservers = ["100.100.100.100"]',
+                    '  searchDomains = ["tailfa7aa.ts.net", "localdomain"]',
+                    "",
+                ]
+            ),
+        )
+        self.assertIn("BUILDKIT_CONFIG=", github_env)
+
+    def test_preserves_registry_config_without_dns(self) -> None:
+        config, _github_env = self.run_script(
+            {
+                "CI_ENFORCE_INTERNAL_REGISTRY": "1",
+                "CI_IMAGE_REGISTRY_PREFIX": "qbit-ci-autoscaler:5000/qbit-cache",
+            }
+        )
+
+        self.assertEqual(
+            config,
+            '\n'.join(
+                [
+                    "[registry]",
+                    '  [registry."qbit-ci-autoscaler:5000"]',
+                    "    http = true",
+                    "    insecure = true",
+                    "",
+                ]
+            ),
+        )
+
+    def test_action_input_dns_values_override_ci_env_values(self) -> None:
+        config, _github_env = self.run_script(
+            {
+                "BUILDKIT_DNS_NAMESERVERS": "100.100.100.100",
+                "BUILDKIT_DNS_SEARCH_DOMAINS": "tailfa7aa.ts.net, localdomain",
+                "CI_BUILDKIT_DNS_NAMESERVERS": "192.0.2.1",
+                "CI_BUILDKIT_DNS_SEARCH_DOMAINS": "example.invalid",
+            }
+        )
+
+        self.assertEqual(
+            config,
+            '\n'.join(
+                [
+                    "[dns]",
+                    '  nameservers = ["100.100.100.100"]',
+                    '  searchDomains = ["tailfa7aa.ts.net", "localdomain"]',
+                    "",
+                ]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/checks/test_configure_docker_buildkit_config.py
+++ b/ci/checks/test_configure_docker_buildkit_config.py
@@ -56,7 +56,7 @@ class ConfigureDockerBuildKitConfigTest(unittest.TestCase):
             {
                 "CI_ENFORCE_INTERNAL_REGISTRY": "1",
                 "CI_IMAGE_REGISTRY_PREFIX": "qbit-ci-autoscaler:5000/qbit-cache",
-                "CI_BUILDKIT_DNS_NAMESERVERS": "100.100.100.100",
+                "CI_BUILDKIT_DNS_NAMESERVERS": "100.100.100.100,1.1.1.1,8.8.8.8",
                 "CI_BUILDKIT_DNS_SEARCH_DOMAINS": "tailfa7aa.ts.net,localdomain",
             }
         )
@@ -71,7 +71,7 @@ class ConfigureDockerBuildKitConfigTest(unittest.TestCase):
                     "    insecure = true",
                     "",
                     "[dns]",
-                    '  nameservers = ["100.100.100.100"]',
+                    '  nameservers = ["100.100.100.100", "1.1.1.1", "8.8.8.8"]',
                     '  searchDomains = ["tailfa7aa.ts.net", "localdomain"]',
                     "",
                 ]


### PR DESCRIPTION
## Summary

- Move configure-docker BuildKit config generation into a tested helper.
- Preserve the internal registry config for `qbit-ci-autoscaler:5000` with `http = true` and `insecure = true`.
- Add opt-in BuildKit DNS config and set Qbit CI to use Tailscale MagicDNS (`100.100.100.100`) first, followed by public DNS fallback (`1.1.1.1`, `8.8.8.8`) for Ubuntu mirrors and other public hosts.
- Keep `tailfa7aa.ts.net` and `localdomain` search domains for short internal names.

## Why

Buildx docker-container builders were inheriting a resolver path that failed inside BuildKit for the internal registry host. The host could resolve and reach the registry, but BuildKit containers could not resolve `qbit-ci-autoscaler`, so image pulls/builds failed before using the existing insecure registry allowance.

A MagicDNS-only BuildKit resolver fixes the internal registry lookup but can leave `apt` unable to resolve public Ubuntu mirrors. This config keeps MagicDNS first for tailnet names and gives build steps public DNS fallback for external package hosts.

This fixes the BuildKit-side DNS config only. It does not change Tailscale ACLs.

## Validation

- `python3 -m unittest ci.checks.test_configure_docker_buildkit_config`
- `python3 -m unittest discover -s ci/checks`
- `bash -n .github/actions/configure-docker/buildkit-config.sh`
- `docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable .github/actions/configure-docker/buildkit-config.sh`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color=false -shellcheck '' -ignore 'constant expression "false"' -ignore 'label "blacksmith-8vcpu-windows-2025" is unknown' -ignore 'property ".*" is not defined' .github/workflows/ci.yml .github/workflows/ci-nightly-heavy.yml .github/workflows/lint-image-prewarm.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI Docker/BuildKit configuration and tests; no application runtime or security policy changes beyond fixing DNS inside BuildKit builders.
> 
> **Overview**
> Moves **configure-docker** BuildKit `buildkitd.toml` generation out of inline bash into **`buildkit-config.sh`**, with unit tests in **`test_configure_docker_buildkit_config.py`**.
> 
> The helper still writes insecure HTTP registry settings for the internal CI registry when `CI_ENFORCE_INTERNAL_REGISTRY` is set, and now optionally adds a **`[dns]`** section (nameservers and search domains) from action inputs or `CI_BUILDKIT_*` env vars, with inputs taking precedence.
> 
> **`ci.yml`**, **`ci-nightly-heavy.yml`**, and **`lint-image-prewarm.yml`** set Tailscale MagicDNS (`100.100.100.100`) plus public resolvers and `tailfa7aa.ts.net` / `localdomain` search domains only for **`Qbit-Org/qbit`**, so BuildKit containers can resolve **`qbit-ci-autoscaler`** where the host could but BuildKit could not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95503868cdbffec955bfa48b0d5fe9f51b7dff37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->