### PR TITLE
wallet: avoid MarkUnused P2MR full top-up

### DIFF
--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1509,9 +1509,18 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
 
 std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(const CScript& script, const MarkUnusedAddressesOptions& options)
 {
-    LOCK(cs_desc_man);
     std::vector<WalletDestination> result;
-    if (IsMine(script)) {
+    bool p2mr_refill{false};
+    bool non_p2mr_top_up{false};
+    unsigned int p2mr_refill_target{0};
+    unsigned int p2mr_remaining{0};
+    unsigned int p2mr_low_watermark{0};
+    std::string p2mr_descriptor_id;
+
+    {
+        LOCK(cs_desc_man);
+        if (!m_map_script_pub_keys.contains(script)) return result;
+
         int32_t index = m_map_script_pub_keys[script];
         bool advanced_next_index{false};
         if (index >= m_wallet_descriptor.next_index) {
@@ -1551,19 +1560,32 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
             if (!NeedsP2MRKeyPoolRefillNoLock()) {
                 return result;
             }
-            if (m_storage.IsLocked()) {
-                WalletLogPrintf("%s: P2MR keypool low-watermark refill deferred for locked wallet (descriptor id %s, remaining=%u, low_watermark=%u)\n",
-                    __func__, GetID().ToString(), GetKeyPoolSizeNoLock(), GetP2MRReceiveKeyPoolLowWatermarkNoLock());
-                return result;
-            }
 
-            const unsigned int target{options.preserve_full_keypool_lookahead ? 0 : GetP2MRReceiveKeyPoolRefillStepTargetNoLock()};
-            util::Result<void> res{TopUpWithInternalHintResult(options.internal_hint, target)};
-            if (!res) {
-                WalletLogPrintf("%s: P2MR keypool low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
-                    __func__, GetID().ToString(), target == 0 ? static_cast<unsigned int>(m_keypool_size) : target, GetKeyPoolSizeNoLock(), util::ErrorString(res).original);
-            }
-        } else if (!TopUp()) {
+            p2mr_refill = true;
+            p2mr_refill_target = options.preserve_full_keypool_lookahead ? 0 : GetP2MRReceiveKeyPoolRefillStepTargetNoLock();
+            p2mr_remaining = GetKeyPoolSizeNoLock();
+            p2mr_low_watermark = GetP2MRReceiveKeyPoolLowWatermarkNoLock();
+            p2mr_descriptor_id = GetID().ToString();
+        } else {
+            non_p2mr_top_up = true;
+        }
+    }
+
+    if (p2mr_refill) {
+        if (m_storage.IsLocked()) {
+            WalletLogPrintf("%s: P2MR keypool low-watermark refill deferred for locked wallet (descriptor id %s, remaining=%u, low_watermark=%u)\n",
+                __func__, p2mr_descriptor_id, p2mr_remaining, p2mr_low_watermark);
+            return result;
+        }
+
+        util::Result<void> res{TopUpWithInternalHintResult(options.internal_hint, p2mr_refill_target)};
+        if (!res) {
+            WalletLogPrintf("%s: P2MR keypool low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
+                __func__, p2mr_descriptor_id, p2mr_refill_target == 0 ? static_cast<unsigned int>(m_keypool_size) : p2mr_refill_target, GetKeyPoolSize(), util::ErrorString(res).original);
+        }
+    } else if (non_p2mr_top_up) {
+        util::Result<void> res{TopUpWithInternalHintResult(options.internal_hint)};
+        if (!res) {
             WalletLogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);
         }
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -976,6 +976,9 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
             return util::Error{_("Error: Cannot extract destination from the generated scriptpubkey")}; // shouldn't happen
         }
         m_wallet_descriptor.next_index++;
+        if (IsRangedP2MRDescriptorNoLock() && !m_deferred_create_keypool_top_up) {
+            m_wallet_descriptor.deferred_create_keypool_top_up = false;
+        }
         WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
         return dest;
     }
@@ -1504,17 +1507,19 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
     return {};
 }
 
-std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(const CScript& script)
+std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(const CScript& script, const MarkUnusedAddressesOptions& options)
 {
     LOCK(cs_desc_man);
     std::vector<WalletDestination> result;
     if (IsMine(script)) {
         int32_t index = m_map_script_pub_keys[script];
+        bool advanced_next_index{false};
         if (index >= m_wallet_descriptor.next_index) {
             WalletLogPrintf("%s: Detected a used keypool item at index %d, mark all keypool items up to this item as used\n", __func__, index);
             auto out_keys = std::make_unique<FlatSigningProvider>();
             std::vector<CScript> scripts_temp;
             while (index >= m_wallet_descriptor.next_index) {
+                scripts_temp.clear();
                 if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, *out_keys)) {
                     throw std::runtime_error(std::string(__func__) + ": Unable to expand descriptor from cache");
                 }
@@ -1522,15 +1527,41 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
                 ExtractDestination(scripts_temp[0], dest);
                 result.push_back({dest, std::nullopt});
                 m_wallet_descriptor.next_index++;
+                advanced_next_index = true;
             }
         }
         if (m_deferred_create_keypool_top_up) {
-            if (!result.empty()) {
+            if (advanced_next_index) {
+                m_wallet_descriptor.deferred_create_keypool_top_up = true;
                 WalletBatch batch(m_storage.GetDatabase());
                 if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
                     throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
                 }
                 NotifyCanGetAddressesChanged();
+            }
+        } else if (IsRangedP2MRDescriptorNoLock()) {
+            if (advanced_next_index) {
+                m_wallet_descriptor.deferred_create_keypool_top_up = false;
+                WalletBatch batch(m_storage.GetDatabase());
+                if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+                    throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+                }
+                NotifyCanGetAddressesChanged();
+            }
+            if (!NeedsP2MRKeyPoolRefillNoLock()) {
+                return result;
+            }
+            if (m_storage.IsLocked()) {
+                WalletLogPrintf("%s: P2MR keypool low-watermark refill deferred for locked wallet (descriptor id %s, remaining=%u, low_watermark=%u)\n",
+                    __func__, GetID().ToString(), GetKeyPoolSizeNoLock(), GetP2MRReceiveKeyPoolLowWatermarkNoLock());
+                return result;
+            }
+
+            const unsigned int target{options.preserve_full_keypool_lookahead ? 0 : GetP2MRReceiveKeyPoolRefillStepTargetNoLock()};
+            util::Result<void> res{TopUpWithInternalHintResult(options.internal_hint, target)};
+            if (!res) {
+                WalletLogPrintf("%s: P2MR keypool low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
+                    __func__, GetID().ToString(), target == 0 ? static_cast<unsigned int>(m_keypool_size) : target, GetKeyPoolSizeNoLock(), util::ErrorString(res).original);
             }
         } else if (!TopUp()) {
             WalletLogPrintf("%s: Topping up keypool failed (locked wallet)\n", __func__);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1513,6 +1513,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
     bool p2mr_refill{false};
     bool non_p2mr_top_up{false};
     unsigned int p2mr_refill_target{0};
+    unsigned int p2mr_full_refill_target{0};
     unsigned int p2mr_remaining{0};
     unsigned int p2mr_low_watermark{0};
     std::string p2mr_descriptor_id;
@@ -1557,12 +1558,17 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
                 }
                 NotifyCanGetAddressesChanged();
             }
-            if (!NeedsP2MRKeyPoolRefillNoLock()) {
+            const bool needs_p2mr_refill{
+                options.preserve_full_keypool_lookahead ?
+                    GetKeyPoolSizeNoLock() < static_cast<unsigned int>(m_keypool_size) :
+                    NeedsP2MRKeyPoolRefillNoLock()};
+            if (!needs_p2mr_refill) {
                 return result;
             }
 
             p2mr_refill = true;
             p2mr_refill_target = options.preserve_full_keypool_lookahead ? 0 : GetP2MRReceiveKeyPoolRefillStepTargetNoLock();
+            p2mr_full_refill_target = static_cast<unsigned int>(m_keypool_size);
             p2mr_remaining = GetKeyPoolSizeNoLock();
             p2mr_low_watermark = GetP2MRReceiveKeyPoolLowWatermarkNoLock();
             p2mr_descriptor_id = GetID().ToString();
@@ -1581,7 +1587,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
         util::Result<void> res{TopUpWithInternalHintResult(options.internal_hint, p2mr_refill_target)};
         if (!res) {
             WalletLogPrintf("%s: P2MR keypool low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
-                __func__, p2mr_descriptor_id, p2mr_refill_target == 0 ? static_cast<unsigned int>(m_keypool_size) : p2mr_refill_target, GetKeyPoolSize(), util::ErrorString(res).original);
+                __func__, p2mr_descriptor_id, p2mr_refill_target == 0 ? p2mr_full_refill_target : p2mr_refill_target, GetKeyPoolSize(), util::ErrorString(res).original);
         }
     } else if (non_p2mr_top_up) {
         util::Result<void> res{TopUpWithInternalHintResult(options.internal_hint)};

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -110,6 +110,12 @@ struct WalletDestination
     std::optional<bool> internal;
 };
 
+struct MarkUnusedAddressesOptions
+{
+    std::optional<bool> internal_hint;
+    bool preserve_full_keypool_lookahead{false};
+};
+
 struct CryptedPQCKeyRecord
 {
     std::vector<unsigned char> crypted_secret;
@@ -161,7 +167,7 @@ public:
      *
      * @return All of the addresses affected
      */
-    virtual std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) { return {}; }
+    virtual std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script, const MarkUnusedAddressesOptions& options = {}) { return {}; }
 
     /* Returns true if HD is enabled */
     virtual bool IsHDEnabled() const { return false; }
@@ -439,7 +445,7 @@ public:
     bool TopUpWithInternalHint(std::optional<bool> internal_hint, unsigned int size = 0);
     util::Result<void> TopUpWithInternalHintResult(std::optional<bool> internal_hint, unsigned int size = 0);
 
-    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script) override;
+    std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script, const MarkUnusedAddressesOptions& options = {}) override;
 
     bool IsHDEnabled() const override;
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -1742,6 +1742,290 @@ BOOST_FIXTURE_TEST_CASE(LockedP2MRLowWatermarkRefillStepReportsFailure, RegtestP
     WaitForDeleteWallet(std::move(wallet));
 }
 
+BOOST_FIXTURE_TEST_CASE(MarkUnusedAddressesP2MRDoesNotFullTopUpAboveLowWatermark, RegtestP2MROnlyWalletTestingSetup)
+{
+    constexpr int64_t keypool_size{32};
+    constexpr int32_t used_index{3};
+    m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+
+    DatabaseOptions create_options;
+    create_options.require_create = true;
+    create_options.create_flags = WALLET_FLAG_DESCRIPTORS;
+
+    DatabaseStatus status;
+    bilingual_str error;
+    std::vector<bilingual_str> warnings;
+    auto wallet = CreateWallet(context, "mark_unused_above_watermark_test", std::nullopt, create_options, status, error, warnings);
+    BOOST_REQUIRE(wallet);
+    BOOST_REQUIRE_EQUAL(status, DatabaseStatus::SUCCESS);
+
+    DescriptorScriptPubKeyMan* external_spk_man{nullptr};
+    {
+        LOCK(wallet->cs_wallet);
+        external_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false));
+    }
+    BOOST_REQUIRE(external_spk_man);
+    BOOST_REQUIRE(wallet->RunPendingInitialKeyPoolTopUp());
+    BOOST_REQUIRE(external_spk_man->IsRangedP2MRDescriptor());
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size);
+    BOOST_CHECK_EQUAL(external_spk_man->GetP2MRReceiveKeyPoolLowWatermark(), DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL);
+
+    int32_t initial_range_end;
+    {
+        LOCK(external_spk_man->cs_desc_man);
+        initial_range_end = external_spk_man->GetWalletDescriptor().range_end;
+    }
+    const CScript used_script = GetCachedScriptPubKey(*external_spk_man, used_index);
+
+    const auto marked = external_spk_man->MarkUnusedAddresses(used_script, {
+        .internal_hint = false,
+    });
+    BOOST_CHECK_EQUAL(marked.size(), static_cast<size_t>(used_index + 1));
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), static_cast<unsigned int>(keypool_size - used_index - 1));
+    {
+        LOCK(external_spk_man->cs_desc_man);
+        const WalletDescriptor wallet_descriptor = external_spk_man->GetWalletDescriptor();
+        BOOST_CHECK_EQUAL(wallet_descriptor.next_index, used_index + 1);
+        BOOST_CHECK_EQUAL(wallet_descriptor.range_end, initial_range_end);
+        BOOST_CHECK(!wallet_descriptor.deferred_create_keypool_top_up.value_or(true));
+    }
+
+    BOOST_CHECK(RemoveWallet(context, wallet, std::nullopt));
+    WaitForDeleteWallet(std::move(wallet));
+
+    DatabaseOptions load_options;
+    load_options.require_existing = true;
+    auto loaded_wallet = LoadWallet(context, "mark_unused_above_watermark_test", std::nullopt, load_options, status, error, warnings);
+    BOOST_REQUIRE(loaded_wallet);
+    BOOST_REQUIRE_EQUAL(status, DatabaseStatus::SUCCESS);
+    {
+        LOCK(loaded_wallet->cs_wallet);
+        external_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(loaded_wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false));
+    }
+    BOOST_REQUIRE(external_spk_man);
+    BOOST_CHECK(!loaded_wallet->HasPendingInitialKeyPoolTopUp());
+    {
+        LOCK(external_spk_man->cs_desc_man);
+        const WalletDescriptor wallet_descriptor = external_spk_man->GetWalletDescriptor();
+        BOOST_CHECK_EQUAL(wallet_descriptor.next_index, used_index + 1);
+        BOOST_CHECK(!wallet_descriptor.deferred_create_keypool_top_up.value_or(true));
+    }
+
+    BOOST_CHECK(RemoveWallet(context, loaded_wallet, std::nullopt));
+    WaitForDeleteWallet(std::move(loaded_wallet));
+}
+
+BOOST_FIXTURE_TEST_CASE(MarkUnusedAddressesP2MRDoesNotTopUpGeneratedScriptAboveLowWatermark, RegtestP2MROnlyWalletTestingSetup)
+{
+    constexpr int64_t keypool_size{32};
+    m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+
+    auto wallet = TestLoadWallet(context);
+    DescriptorScriptPubKeyMan* external_spk_man{nullptr};
+    {
+        LOCK(wallet->cs_wallet);
+        external_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false));
+    }
+    BOOST_REQUIRE(external_spk_man);
+    BOOST_CHECK(wallet->RunPendingInitialKeyPoolTopUp());
+
+    const CScript generated_script = GetCachedScriptPubKey(*external_spk_man, 0);
+    BOOST_REQUIRE(wallet->GetNewDestination(OutputType::P2MR, ""));
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size - 1);
+
+    int32_t range_end_after_generation;
+    {
+        LOCK(external_spk_man->cs_desc_man);
+        range_end_after_generation = external_spk_man->GetWalletDescriptor().range_end;
+    }
+
+    const auto marked = external_spk_man->MarkUnusedAddresses(generated_script, {
+        .internal_hint = false,
+    });
+    BOOST_CHECK(marked.empty());
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size - 1);
+    {
+        LOCK(external_spk_man->cs_desc_man);
+        BOOST_CHECK_EQUAL(external_spk_man->GetWalletDescriptor().range_end, range_end_after_generation);
+    }
+
+    TestUnloadWallet(std::move(wallet));
+}
+
+BOOST_FIXTURE_TEST_CASE(MarkUnusedAddressesP2MRBoundsNormalLowWatermarkRefill, RegtestP2MROnlyWalletTestingSetup)
+{
+    constexpr int64_t keypool_size{64};
+    m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+
+    auto wallet = TestLoadWallet(context);
+    DescriptorScriptPubKeyMan* external_spk_man{nullptr};
+    {
+        LOCK(wallet->cs_wallet);
+        external_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false));
+    }
+    BOOST_REQUIRE(external_spk_man);
+    BOOST_CHECK(wallet->RunPendingInitialKeyPoolTopUp());
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size);
+
+    const unsigned int low_watermark{external_spk_man->GetP2MRReceiveKeyPoolLowWatermark()};
+    BOOST_REQUIRE_EQUAL(low_watermark, DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL);
+    const int32_t used_index = keypool_size - low_watermark - 1;
+    const CScript used_script = GetCachedScriptPubKey(*external_spk_man, used_index);
+
+    const auto marked = external_spk_man->MarkUnusedAddresses(used_script, {
+        .internal_hint = false,
+    });
+    BOOST_CHECK_EQUAL(marked.size(), static_cast<size_t>(used_index + 1));
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), low_watermark + DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL);
+    BOOST_CHECK_LT(external_spk_man->GetKeyPoolSize(), static_cast<unsigned int>(keypool_size));
+    {
+        LOCK(external_spk_man->cs_desc_man);
+        const WalletDescriptor wallet_descriptor = external_spk_man->GetWalletDescriptor();
+        BOOST_CHECK_EQUAL(wallet_descriptor.next_index, used_index + 1);
+        BOOST_CHECK_EQUAL(wallet_descriptor.range_end, keypool_size + DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL);
+    }
+
+    TestUnloadWallet(std::move(wallet));
+}
+
+BOOST_FIXTURE_TEST_CASE(MarkUnusedAddressesP2MRPreservesRecoveryLookahead, RegtestP2MROnlyWalletTestingSetup)
+{
+    constexpr int64_t keypool_size{64};
+    m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+
+    auto wallet = TestLoadWallet(context);
+    DescriptorScriptPubKeyMan* external_spk_man{nullptr};
+    {
+        LOCK(wallet->cs_wallet);
+        external_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false));
+    }
+    BOOST_REQUIRE(external_spk_man);
+    BOOST_CHECK(wallet->RunPendingInitialKeyPoolTopUp());
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size);
+
+    const unsigned int low_watermark{external_spk_man->GetP2MRReceiveKeyPoolLowWatermark()};
+    BOOST_REQUIRE_EQUAL(low_watermark, DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL);
+    const int32_t used_index = keypool_size - low_watermark - 1;
+    const CScript used_script = GetCachedScriptPubKey(*external_spk_man, used_index);
+
+    const auto marked = external_spk_man->MarkUnusedAddresses(used_script, {
+        .internal_hint = false,
+        .preserve_full_keypool_lookahead = true,
+    });
+    BOOST_CHECK_EQUAL(marked.size(), static_cast<size_t>(used_index + 1));
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size);
+    {
+        LOCK(external_spk_man->cs_desc_man);
+        const WalletDescriptor wallet_descriptor = external_spk_man->GetWalletDescriptor();
+        BOOST_CHECK_EQUAL(wallet_descriptor.next_index, used_index + 1);
+        BOOST_CHECK_EQUAL(wallet_descriptor.range_end, wallet_descriptor.next_index + keypool_size);
+    }
+
+    TestUnloadWallet(std::move(wallet));
+}
+
+BOOST_FIXTURE_TEST_CASE(MarkUnusedAddressesP2MRLockedWalletDoesNotFailEarly, RegtestP2MROnlyWalletTestingSetup)
+{
+    constexpr int64_t keypool_size{20};
+    constexpr int32_t used_index{4};
+    const SecureString passphrase{"test-passphrase"};
+    m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+
+    DatabaseOptions create_options;
+    create_options.require_create = true;
+    create_options.create_flags = WALLET_FLAG_DESCRIPTORS;
+    create_options.create_passphrase = passphrase;
+
+    DatabaseStatus status;
+    bilingual_str error;
+    std::vector<bilingual_str> warnings;
+    auto wallet = CreateWallet(context, "locked_mark_unused_low_watermark_test", std::nullopt, create_options, status, error, warnings);
+    BOOST_REQUIRE(wallet);
+    BOOST_REQUIRE_EQUAL(status, DatabaseStatus::SUCCESS);
+    BOOST_REQUIRE(wallet->Unlock(passphrase));
+    BOOST_CHECK(!wallet->HasPendingInitialKeyPoolTopUp());
+    BOOST_REQUIRE(wallet->Lock());
+
+    DescriptorScriptPubKeyMan* external_spk_man{nullptr};
+    {
+        LOCK(wallet->cs_wallet);
+        external_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false));
+    }
+    BOOST_REQUIRE(external_spk_man);
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size);
+    const CScript used_script = GetCachedScriptPubKey(*external_spk_man, used_index);
+
+    {
+        DebugLogHelper log_helper("P2MR keypool low-watermark refill deferred for locked wallet", [](const std::string* line) {
+            return line && line->find("remaining=15") != std::string::npos;
+        });
+        const auto marked = external_spk_man->MarkUnusedAddresses(used_script, {
+            .internal_hint = false,
+        });
+        BOOST_CHECK_EQUAL(marked.size(), static_cast<size_t>(used_index + 1));
+    }
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size - used_index - 1);
+    {
+        LOCK(external_spk_man->cs_desc_man);
+        const WalletDescriptor wallet_descriptor = external_spk_man->GetWalletDescriptor();
+        BOOST_CHECK_EQUAL(wallet_descriptor.next_index, used_index + 1);
+        BOOST_CHECK_EQUAL(wallet_descriptor.range_end, keypool_size);
+    }
+
+    BOOST_CHECK(RemoveWallet(context, wallet, std::nullopt));
+    WaitForDeleteWallet(std::move(wallet));
+}
+
+BOOST_AUTO_TEST_CASE(MarkUnusedAddressesNonP2MRStillFullTopUp)
+{
+    constexpr int64_t keypool_size{32};
+    constexpr int32_t used_index{3};
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        wallet.m_keypool_size = keypool_size;
+        wallet.SetupDescriptorScriptPubKeyMans(BECH32_ONLY_OUTPUT_TYPES);
+    }
+
+    auto* spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet.GetScriptPubKeyMan(OutputType::BECH32, /*internal=*/false));
+    BOOST_REQUIRE(spk_man);
+    BOOST_CHECK_EQUAL(spk_man->GetKeyPoolSize(), keypool_size);
+    const CScript used_script = GetCachedScriptPubKey(*spk_man, used_index);
+
+    const auto marked = spk_man->MarkUnusedAddresses(used_script, {
+        .internal_hint = false,
+    });
+    BOOST_CHECK_EQUAL(marked.size(), static_cast<size_t>(used_index + 1));
+    BOOST_CHECK_EQUAL(spk_man->GetKeyPoolSize(), keypool_size);
+    {
+        LOCK(spk_man->cs_desc_man);
+        const WalletDescriptor wallet_descriptor = spk_man->GetWalletDescriptor();
+        BOOST_CHECK_EQUAL(wallet_descriptor.next_index, used_index + 1);
+        BOOST_CHECK_EQUAL(wallet_descriptor.range_end, used_index + 1 + keypool_size);
+    }
+}
+
 BOOST_FIXTURE_TEST_CASE(KeypoolTopUpReportsLockedInternalP2MRDescriptorFailure, RegtestP2MROnlyWalletTestingSetup)
 {
     constexpr int64_t keypool_size{64};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1496,10 +1496,15 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const SyncTxS
             // loop though all outputs
             for (const CTxOut& txout: tx.vout) {
                 for (const auto& spk_man : GetScriptPubKeyMans(txout.scriptPubKey)) {
-                    for (auto &dest : spk_man->MarkUnusedAddresses(txout.scriptPubKey)) {
+                    const std::optional<bool> internal{IsInternalScriptPubKeyMan(spk_man)};
+                    const MarkUnusedAddressesOptions mark_options{
+                        .internal_hint = internal,
+                        .preserve_full_keypool_lookahead = rescanning_old_block,
+                    };
+                    for (auto &dest : spk_man->MarkUnusedAddresses(txout.scriptPubKey, mark_options)) {
                         // If internal flag is not defined try to infer it from the ScriptPubKeyMan
                         if (!dest.internal.has_value()) {
-                            dest.internal = IsInternalScriptPubKeyMan(spk_man);
+                            dest.internal = internal;
                         }
 
                         // skip if can't determine whether it's a receiving address or not


### PR DESCRIPTION
## Summary
- Avoid full synchronous keypool top-up from `MarkUnusedAddresses` for ranged P2MR descriptors when the receive pool is still above the low watermark.
- Run bounded P2MR low-watermark refill from `MarkUnusedAddresses`, while preserving full lookahead for recovery/rescan paths.
- Persist completed deferred-top-up state when address use advances P2MR descriptor `next_index`.
- Add wallet tests covering above-watermark behavior, generated scripts, bounded refill, recovery lookahead, locked wallets, and non-P2MR behavior.

## Base
- Rebased on latest `0.1.x` after PR #13 merged.

## Validation
- `cmake --build build_dev_mode --target test_bitcoin -j8`
- `build_dev_mode/bin/test_qbit '--run_test=wallet_tests/MarkUnusedAddresses*'`\n- `build_dev_mode/bin/test_qbit '--run_test=wallet_tests/P2MRGetNew*'`\n- Docker lint: `DOCKER_BUILDKIT=1 docker build -t qbit-linter-issue14 --file "./ci/lint_imagefile" . && docker run --rm -v "$PWD":/bitcoin -v /Users/miller/conductor/repos/qbit-v1/.git:/Users/miller/conductor/repos/qbit-v1/.git qbit-linter-issue14`\n\n## Related\n- Addresses #14.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet keypool refill timing on transaction detection and rescan for P2MR descriptors; incorrect behavior could affect address availability but is scoped and heavily tested.
> 
> **Overview**
> **Ranged P2MR** descriptors no longer trigger a **full synchronous keypool top-up** from `MarkUnusedAddresses` when the receive pool is still above the low watermark. Instead they use **bounded low-watermark refill** via `TopUpWithInternalHintResult`, skip refill for scripts already consumed by `GetNewDestination`, and **defer refill** when the wallet is locked (with logging).
> 
> A new **`MarkUnusedAddressesOptions`** (`internal_hint`, `preserve_full_keypool_lookahead`) is threaded through the SPKM API. **`CWallet::AddToWalletIfInvolvingMe`** sets `preserve_full_keypool_lookahead` during **old-block rescan** so recovery still restores full lookahead; non-P2MR descriptors keep the previous **full top-up** behavior.
> 
> **Deferred create keypool** state is persisted when address use advances `next_index` (including clearing the flag on P2MR `GetNewDestination` when appropriate). Wallet tests cover above-watermark, generated scripts, bounded refill, recovery lookahead, locked wallets, and non-P2MR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a400cc9072fc0f088ab2cf7ecf3c726ff71a0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->