### PR TITLE
Fix nightly CI and RPC perf failures

### DIFF
--- a/.github/workflows/ci-nightly-heavy.yml
+++ b/.github/workflows/ci-nightly-heavy.yml
@@ -70,15 +70,23 @@ jobs:
       MAKEJOBS: ${{ matrix.makejobs || '-j6' }}
       TEST_RUNNER_JOBS: '6'
       CTEST_JOBS: '6'
+      CTEST_INCLUDE_RANGE: ${{ matrix.ctest_include_range || '' }}
       CI_DOCKER_RUN_CPUS: ${{ matrix.container-cpus || '8' }}
       CI_DOCKER_RUN_MEMORY: ${{ matrix.container-memory || '48g' }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: '32 bit ARM, unit tests, no functional tests'
+          - name: '32 bit ARM, unit tests shard 1/2, no functional tests'
             timeout-minutes: 180
             file-env: './ci/test/00_setup_env_arm.sh'
+            ctest_include_range: '1,139'
+            container-cpus: '8'
+            container-memory: '48g'
+          - name: '32 bit ARM, unit tests shard 2/2, no functional tests'
+            timeout-minutes: 180
+            file-env: './ci/test/00_setup_env_arm.sh'
+            ctest_include_range: '140,99999'
             container-cpus: '8'
             container-memory: '48g'
           - name: 'previous releases, depends DEBUG'

--- a/ci/scanners/install-scanner-tools.sh
+++ b/ci/scanners/install-scanner-tools.sh
@@ -14,6 +14,7 @@ TOOL_ROOT="${QBIT_SCANNER_TOOL_ROOT:-${RUNNER_TOOL_CACHE:-$HOME/.cache/qbit}/sca
 BIN_DIR="${QBIT_SCANNER_BIN_DIR:-$TOOL_ROOT/bin}"
 CARGO_ROOT="${QBIT_SCANNER_CARGO_ROOT:-$TOOL_ROOT/cargo}"
 PYTHON_VENV="${QBIT_SCANNER_PYTHON_VENV:-$TOOL_ROOT/python}"
+CARGO_AUDIT_VERSION="${QBIT_SCANNER_CARGO_AUDIT_VERSION:-0.21.1}"
 
 mkdir -p "$BIN_DIR" "$CARGO_ROOT/bin"
 export PATH="$BIN_DIR:$CARGO_ROOT/bin:$PATH"
@@ -251,13 +252,19 @@ install_python_tool() {
 }
 
 install_cargo_audit() {
+    local current_version=""
     if cargo audit --version >/dev/null 2>&1; then
-        log "cargo-audit already available"
-        return
+        current_version="$(cargo audit --version | awk '{print $2}')"
+        if [[ "$current_version" == "$CARGO_AUDIT_VERSION" ]]; then
+            log "cargo-audit $CARGO_AUDIT_VERSION already available"
+            return
+        fi
+        log "Replacing cargo-audit $current_version with $CARGO_AUDIT_VERSION"
+    else
+        log "Installing cargo-audit $CARGO_AUDIT_VERSION"
     fi
 
-    log "Installing cargo-audit"
-    cargo install cargo-audit --locked --root "$CARGO_ROOT"
+    cargo install cargo-audit --version "$CARGO_AUDIT_VERSION" --locked --root "$CARGO_ROOT" --force
 }
 
 show_versions() {

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -39,6 +39,7 @@ export MAKEJOBS=${MAKEJOBS:--j8}
 # Parallelism for runtime test execution, decoupled from build parallelism
 export TEST_RUNNER_JOBS=${TEST_RUNNER_JOBS:-6}
 export CTEST_JOBS=${CTEST_JOBS:-$TEST_RUNNER_JOBS}
+export CTEST_INCLUDE_RANGE=${CTEST_INCLUDE_RANGE:-}
 export CMAKE_GENERATOR=${CMAKE_GENERATOR:-Ninja}
 # Whether to prefer BusyBox over GNU utilities
 export USE_BUSY_BOX=${USE_BUSY_BOX:-false}

--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -210,13 +210,19 @@ if [ "$RUN_CHECK_DEPS" = "true" ]; then
 fi
 
 if [ "$RUN_UNIT_TESTS" = "true" ]; then
+  CTEST_ARGS=()
+  if [ -n "${CTEST_INCLUDE_RANGE}" ]; then
+    CTEST_ARGS+=(-I "${CTEST_INCLUDE_RANGE}")
+  fi
+
   DIR_UNIT_TEST_DATA="${DIR_UNIT_TEST_DATA}" \
   LD_LIBRARY_PATH="${DEPENDS_DIR}/${HOST}/lib" \
   CTEST_OUTPUT_ON_FAILURE=ON \
   ctest --test-dir "${BASE_BUILD_DIR}" \
     --stop-on-failure \
     -j "${CTEST_JOBS}" \
-    --timeout $(( TEST_RUNNER_TIMEOUT_FACTOR * 60 ))
+    --timeout $(( TEST_RUNNER_TIMEOUT_FACTOR * 60 )) \
+    "${CTEST_ARGS[@]}"
 fi
 
 # Build qbit-photon relay daemon for integration tests.

--- a/test/functional/feature_rpc_perf.py
+++ b/test/functional/feature_rpc_perf.py
@@ -232,8 +232,13 @@ class RPCPerfTest(BitcoinTestFramework):
         for context in self.fixture_contexts:
             for node_index in context.node_indexes:
                 self.extra_args[node_index] = list(context.plan.extra_args)
+                node_init = {}
                 if context.plan.bin_dir is not None:
-                    self.extra_init[node_index] = {"binaries": self.get_binaries(context.plan.bin_dir)}
+                    node_init["binaries"] = self.get_binaries(context.plan.bin_dir)
+                if context.plan.target == REFERENCE_TARGET:
+                    node_init["supports_p2mronly"] = False
+                if node_init:
+                    self.extra_init[node_index] = node_init
 
     def setup_network(self):
         self.setup_nodes()

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -104,7 +104,7 @@ class TestNode():
     To make things easier for the test writer, any unrecognised messages will
     be dispatched to the RPC connection."""
 
-    def __init__(self, i, datadir_path, *, chain, rpchost, timewait, timeout_factor, binaries, coverage_dir, cwd, extra_conf=None, extra_args=None, use_cli=False, start_perf=False, use_valgrind=False, version=None, v2transport=False, uses_wallet=False, ipcbind=False):
+    def __init__(self, i, datadir_path, *, chain, rpchost, timewait, timeout_factor, binaries, coverage_dir, cwd, extra_conf=None, extra_args=None, use_cli=False, start_perf=False, use_valgrind=False, version=None, v2transport=False, uses_wallet=False, ipcbind=False, supports_p2mronly=None):
         """
         Kwargs:
             start_perf (bool): If True, begin profiling the node with `perf` as soon as
@@ -134,6 +134,7 @@ class TestNode():
         self.extra_args = extra_args
         self.running_args = list(extra_args or [])
         self.version = version
+        self.supports_p2mronly = self.version is None if supports_p2mronly is None else supports_p2mronly
         # Configuration for logging is set as command-line args rather than in the qbit.conf file.
         # This means that starting a bitcoind using the temp dir to debug a failed test won't
         # spam debug.log.
@@ -334,7 +335,7 @@ class TestNode():
         return False
 
     def _supports_p2mronly(self):
-        return self.version is None
+        return self.supports_p2mronly
 
     def _with_regtest_p2mronly_default(self, extra_args):
         extra_args = list(extra_args or [])


### PR DESCRIPTION
## Summary

- Pin scanner `cargo-audit` installation to a Rust 1.75-compatible version, with an override for future updates.
- Add an explicit `supports_p2mronly` TestNode capability and disable it for RPC perf Bitcoin Core reference nodes.
- Split the Nightly ARM unit-test job into two CTest shards through a shared `CTEST_INCLUDE_RANGE` hook.

## Root Cause

The Nightly scanner job installed the newest `cargo-audit`, which now requires a newer Rust compiler than the runner package provides. The RPC perf comparison failed because Bitcoin Core reference nodes inherited qbit-only `-p2mronly=0` startup arguments. The ARM unit-test Nightly job reached the long CTest tail and timed out before completing all tests.

## Validation

- `bash -n ci/scanners/install-scanner-tools.sh ci/test/00_setup_env.sh ci/test/03_test_script.sh`
- `python3 -m py_compile test/functional/test_framework/test_node.py test/functional/feature_rpc_perf.py`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest .github/workflows/ci-nightly-heavy.yml`
- `git diff --check`
- Targeted Python sanity check for `TestNode` `supports_p2mronly` behavior

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785093380&installation_id=141183937&pr_number=32&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F32&signature=f012fc737161d5dcb19848cc51738df11075fe907f39e39f093cdc38bae4d7c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI scripts, scanner install pinning, and functional-test node startup flags; no production node or consensus logic is modified.
> 
> **Overview**
> Fixes three CI/test failures: scanner installs, cross-target RPC perf startup, and ARM nightly unit-test timeouts.
> 
> **Nightly ARM unit tests** are split into two matrix jobs that pass **`CTEST_INCLUDE_RANGE`** (`1,139` and `140,99999`) into the workflow env. **`00_setup_env.sh`** exports the variable and **`03_test_script.sh`** forwards it to **`ctest -I`** when set, so each shard runs a subset of tests in parallel.
> 
> **Scanner tooling** pins **`cargo-audit`** to **0.21.1** (override **`QBIT_SCANNER_CARGO_AUDIT_VERSION`**) and reinstalls with **`--force`** when the runner has a mismatched version, avoiding builds that need a newer Rust than the host provides.
> 
> **RPC perf vs Bitcoin Core reference** adds an explicit **`supports_p2mronly`** flag on **`TestNode`** (default unchanged: qbit when `version is None`). **`feature_rpc_perf.py`** sets **`supports_p2mronly=False`** for reference fixture nodes so regtest startup no longer injects qbit-only **`-p2mronly=0`** into upstream **`bitcoind`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67b7e83248e424c41cbf170f9dc309ce85b5a62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->