### PR TITLE
Document AuxPoW commitment order fields

### DIFF
--- a/doc/integration/mining-pool-quickstart.md
+++ b/doc/integration/mining-pool-quickstart.md
@@ -140,6 +140,8 @@ qbit-cli <chain option> createauxblock "$QBIT_PAYOUT_ADDRESS"
 | `coinbasevalue` | qbit coinbase value in satoshis, including fees |
 | `bits` | compact qbit target for this candidate |
 | `height` | candidate qbit block height |
+| `commitmentorder` | AuxPoW commitment root byte order to use when building the parent coinbase commitment for this candidate |
+| `commitmentactivationheight` | height where AuxPoW commitment byte-order behavior changes; at and after this height, valid submissions must follow the returned `commitmentorder` |
 | `target` | expanded qbit target |
 
 Submit a solved AuxPoW payload:
@@ -223,6 +225,12 @@ The commitment is:
 ```text
 0xfa 0xbe 0x6d 0x6d || aux_merkle_root || merkle_tree_size_le32 || nonce_le32
 ```
+
+Pool software must use the `commitmentorder` returned by `createauxblock`
+when serializing `aux_merkle_root` into the parent coinbase commitment. Do not
+infer this byte order from Namecoin/Dogecoin conventions or from local
+serializer assumptions; the RPC result is the source of truth for the
+candidate.
 
 Validation requirements include:
 


### PR DESCRIPTION
## Summary

- Document the `commitmentorder` and `commitmentactivationheight` fields in the mining pool quickstart `createauxblock` return table.
- Clarify that pool software must use the RPC-returned commitment order when constructing the parent coinbase AuxPoW commitment.
- Explicitly warn operators not to infer byte order from Namecoin/Dogecoin conventions or local serializer assumptions.

## Validation

- `git diff --check origin/0.1.x...HEAD`
- `docker run --rm -v "$PWD":/bitcoin -v /Users/miller/conductor/repos/qbit-v1/.git:/Users/miller/conductor/repos/qbit-v1/.git:ro qbit-linter test/lint/lint-qbit-public-docs.py`
- `docker run --rm -v "$PWD":/bitcoin -v /Users/miller/conductor/repos/qbit-v1/.git:/Users/miller/conductor/repos/qbit-v1/.git:ro qbit-linter mlc --offline --gitignore --gituntracked --root-dir . doc/integration/mining-pool-quickstart.md`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785099520&installation_id=141183937&pr_number=35&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F35&signature=718765e9332002b685a20212630d5c9a4f91666d0503d3b92a2069759fda233b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the mining integration guide; no runtime, consensus, or RPC behavior is modified in this PR.
> 
> **Overview**
> Updates **mining-pool-quickstart** so AuxPoW integrators treat `createauxblock` as authoritative for parent coinbase commitment serialization.
> 
> The **`createauxblock` return table** now documents **`commitmentorder`** and **`commitmentactivationheight`**, including that submissions at/after the activation height must follow the returned order. The **AuxPoW commitment requirements** section adds an explicit rule: pools must serialize `aux_merkle_root` using RPC **`commitmentorder`**, not Namecoin/Dogecoin habits or local serializer guesses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f28ae3a0062c1266700c3af5fb2cac85dba37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->