### PR TITLE
Reject non-P2MR raw funding outputs

### DIFF
--- a/src/wallet/rpc/spend.cpp
+++ b/src/wallet/rpc/spend.cpp
@@ -2,7 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <chainparams.h>
 #include <common/messages.h>
+#include <consensus/restricted_outputs.h>
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <key_io.h>
@@ -49,6 +51,14 @@ static void RejectReservedWitnessOutputs(const std::vector<CTxOut>& outputs)
 {
     for (const CTxOut& output : outputs) {
         RejectReservedWitnessOutput(output.scriptPubKey);
+    }
+}
+
+static void RejectRestrictedOutputModeDisallowedOutput(const CScript& script_pub_key, const Consensus::Params& consensus, int height)
+{
+    RejectReservedWitnessOutput(script_pub_key);
+    if (consensus.fRestrictedOutputMode && !Consensus::IsRestrictedOutputModeConsensusOutput(script_pub_key, consensus, height)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Output scriptPubKey is not allowed in restricted-output mode");
     }
 }
 
@@ -557,7 +567,7 @@ static std::vector<RPCArg> FundTxDoc(bool solving_data = true)
     return args;
 }
 
-CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransaction& tx, const std::vector<CRecipient>& recipients, const UniValue& options, CCoinControl& coinControl, bool override_min_fee)
+CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransaction& tx, const std::vector<CRecipient>& recipients, const UniValue& options, CCoinControl& coinControl, bool override_min_fee, const std::vector<CTxOut>* original_outputs = nullptr)
 {
     // We want to make sure tx.vout is not used now that we are passing outputs as a vector of recipients.
     // This sets us up to remove tx completely in a future PR in favor of passing the inputs directly.
@@ -776,6 +786,15 @@ CreatedTransactionResult FundTransaction(CWallet& wallet, const CMutableTransact
     if (recipients.empty())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "TX must have at least one output");
 
+    if (original_outputs) {
+        const Consensus::Params& consensus{Params().GetConsensus()};
+        const std::optional<int> chain_height{wallet.chain().getHeight()};
+        const int next_block_height{chain_height.value_or(-1) + 1};
+        for (const CTxOut& output : *original_outputs) {
+            RejectRestrictedOutputModeDisallowedOutput(output.scriptPubKey, consensus, next_block_height);
+        }
+    }
+
     auto txr = FundTransaction(wallet, tx, recipients, change_position, lockUnspents, coinControl);
     if (!txr) {
         throw JSONRPCError(RPC_WALLET_ERROR, ErrorString(txr).original);
@@ -905,6 +924,7 @@ RPCHelpMan fundrawtransaction()
     if (!DecodeHexTx(tx, request.params[0].get_str(), try_no_witness, try_witness)) {
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     }
+    const std::vector<CTxOut> original_outputs{tx.vout};
     UniValue options = request.params[1];
     std::vector<std::pair<CTxDestination, CAmount>> destinations;
     for (const auto& tx_out : tx.vout) {
@@ -923,7 +943,7 @@ RPCHelpMan fundrawtransaction()
     // Clear tx.vout since it is not meant to be used now that we are passing outputs directly.
     // This sets us up for a future PR to completely remove tx from the function signature in favor of passing inputs directly
     tx.vout.clear();
-    auto txr = FundTransaction(*pwallet, tx, recipients, options, coin_control, /*override_min_fee=*/true);
+    auto txr = FundTransaction(*pwallet, tx, recipients, options, coin_control, /*override_min_fee=*/true, &original_outputs);
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("hex", EncodeHexTx(*txr.tx));

--- a/test/functional/wallet_p2mr.py
+++ b/test/functional/wallet_p2mr.py
@@ -19,6 +19,7 @@ from test_framework.blocktools import (
 from test_framework.descriptors import descsum_create
 from test_framework.messages import (
     COIN,
+    CTransaction,
     CTxOut,
 )
 from test_framework.script_util import (
@@ -26,6 +27,9 @@ from test_framework.script_util import (
     DUMMY_MIN_OP_RETURN_SCRIPT,
     PAY_TO_ANCHOR,
     key_to_p2pkh_script,
+    key_to_p2sh_p2wpkh_script,
+    key_to_p2wpkh_script,
+    output_key_to_p2tr_script,
     program_to_witness_script,
 )
 from test_framework.segwit_addr import (
@@ -53,6 +57,12 @@ NON_P2MR_OUTPUT_TYPES = ("legacy", "p2sh-segwit", "bech32", "bech32m")
 
 def reserved_witness_script(version, fill=0x42):
     return program_to_witness_script(version, bytes([fill] * 32))
+
+
+def raw_tx_with_outputs(outputs):
+    tx = CTransaction()
+    tx.vout = [CTxOut(amount, script_pub_key) for script_pub_key, amount in outputs]
+    return tx.serialize().hex()
 
 
 class WalletP2MRTest(BitcoinTestFramework):
@@ -460,6 +470,33 @@ class WalletP2MRTest(BitcoinTestFramework):
             0,
             {"solving_data": {"scripts": [key_to_p2pkh_script(legacy_pubkey_for_rpc).hex()]}},
         )
+
+        self.log.info("Check -p2mronly fundrawtransaction rejects prebuilt non-P2MR recipient outputs")
+        _, raw_recipient_pubkey = generate_keypair(wif=True)
+        for output_name, script_pub_key in (
+            ("legacy P2PKH", key_to_p2pkh_script(raw_recipient_pubkey)),
+            ("P2SH-SegWit", key_to_p2sh_p2wpkh_script(raw_recipient_pubkey)),
+            ("bech32 v0", key_to_p2wpkh_script(raw_recipient_pubkey)),
+            ("bech32m v1", output_key_to_p2tr_script(bytes(range(32, 64)))),
+        ):
+            self.log.debug("Reject %s raw recipient output", output_name)
+            assert_raises_rpc_error(
+                -8,
+                "Output scriptPubKey is not allowed in restricted-output mode",
+                p2mr_wallet.fundrawtransaction,
+                raw_tx_with_outputs([(script_pub_key, COIN)]),
+            )
+
+        self.log.info("Check -p2mronly fundrawtransaction accepts prebuilt allowed recipient outputs")
+        p2mr_script = bytes.fromhex(receive_info["scriptPubKey"])
+        for output_name, outputs in (
+            ("P2MR", [(p2mr_script, COIN)]),
+            ("P2MR with OP_RETURN", [(p2mr_script, COIN), (DUMMY_MIN_OP_RETURN_SCRIPT, 0)]),
+            ("PayToAnchor", [(PAY_TO_ANCHOR, COIN)]),
+        ):
+            self.log.debug("Accept %s raw recipient output", output_name)
+            funded_raw = p2mr_wallet.fundrawtransaction(raw_tx_with_outputs(outputs))
+            assert "hex" in funded_raw
 
         self.log.info("Check restricted-output mempool rejection for legacy outputs")
         _, non_p2mr_pubkey = generate_keypair(wif=True)


### PR DESCRIPTION
Fixes #33 

## Summary
- reject prebuilt raw `fundrawtransaction` outputs that are not allowed in restricted-output mode before wallet funding
- preserve the reserved-witness wallet policy rejection while using restricted-output consensus rules for original raw recipient scripts
- add P2MR wallet functional coverage for rejected legacy/P2SH/v0/v1 raw recipients and accepted P2MR/OP_RETURN/PayToAnchor raw outputs

## Root Cause
On P2MR-only chains, `fundrawtransaction` converted decoded raw transaction outputs into `CRecipient`s and cleared `tx.vout` without validating the original recipient scripts against restricted-output mode. Wallet funding then rebuilt those non-P2MR recipient scripts and only failed later at mempool validation.

## Tests
- `python3 -m py_compile test/functional/wallet_p2mr.py`
- `git diff --check`
- `cmake --build build_issue33 --target qbitd qbit-cli -j 10`
- `ulimit -n 256; build_issue33/test/functional/test_runner.py wallet_p2mr.py`
- `DOCKER_BUILDKIT=1 docker run --rm -v "$(pwd)":/bitcoin -v /Users/miller/conductor/repos/qbit-v1/.git:/Users/miller/conductor/repos/qbit-v1/.git bitcoin-linter`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785254479&installation_id=141183937&pr_number=37&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F37&signature=149c0a0c81b158ea9ce4c156d327775d11b09097ad77f893f048498c331326af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet transaction-building policy on P2MR-only chains; scope is limited to `fundrawtransaction`’s new pre-funding check, not broader auth or consensus code.
> 
> **Overview**
> **`fundrawtransaction`** on restricted-output chains now validates the **decoded raw transaction’s `vout` scripts** before wallet funding, instead of only failing later at mempool acceptance.
> 
> Wallet RPC funding adds **`RejectRestrictedOutputModeDisallowedOutput`**, which keeps the existing reserved-witness rejection and, when **`fRestrictedOutputMode`** is active, rejects outputs that fail **`Consensus::IsRestrictedOutputModeConsensusOutput`** at the next block height. The RPC **`FundTransaction`** helper takes an optional **`original_outputs`** pointer; **`fundrawtransaction`** snapshots **`tx.vout`**, clears it for the existing recipient path, and passes that snapshot so prebuilt recipient scripts are checked even though funding no longer reads **`tx.vout`**.
> 
> Functional coverage in **`wallet_p2mr.py`** asserts RPC errors for legacy, P2SH-SegWit, v0, and v1 raw recipients, and successful funding for P2MR, OP_RETURN, and PayToAnchor prebuilt outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f394576c494866a834e750cd82dd794cee3e0a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->