### PR TITLE
Verify libbitcoinpqc tagged subtree imports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,8 +31,8 @@ Choose exactly one:
 
 ## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)
 
-- [ ] Upstream fix is merged into the maintained libbitcoinpqc branch used by qbit.
-- [ ] Curated branch `qbit-subtree` was refreshed with prune.
-- [ ] Subtree update was done with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
-- [ ] `test/lint/git-subtree-check.sh -r src/libbitcoinpqc` passes locally.
-- [ ] Followed `doc/subtrees/libbitcoinpqc.md`.
+- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
+- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
+- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
+- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
+- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

--- a/ci/libbitcoinpqc/collect-tsan-evidence.sh
+++ b/ci/libbitcoinpqc/collect-tsan-evidence.sh
@@ -18,7 +18,7 @@ Options:
   --build-dir DIR               CMake build directory (default: OUT/build)
   --upstream-repo OWNER/REPO    libbitcoinpqc upstream repo metadata
   --upstream-ref REF            libbitcoinpqc upstream ref metadata
-  --curated-subtree-ref REF     qbit subtree import commit metadata
+  --subtree-source-ref REF      libbitcoinpqc source tag metadata (default: --upstream-ref)
   --expected-subtree-tree SHA   fail if HEAD:src/libbitcoinpqc tree differs
   --threads N                  worker thread count (default: 8)
   --iterations N               per-thread iterations when duration is 0 (default: 2)
@@ -32,7 +32,7 @@ output_dir=""
 build_dir=""
 upstream_repo=""
 upstream_ref=""
-curated_subtree_ref=""
+subtree_source_ref=""
 expected_subtree_tree=""
 threads="8"
 iterations="2"
@@ -46,7 +46,7 @@ while [[ $# -gt 0 ]]; do
         --build-dir) build_dir="$2"; shift 2 ;;
         --upstream-repo) upstream_repo="$2"; shift 2 ;;
         --upstream-ref) upstream_ref="$2"; shift 2 ;;
-        --curated-subtree-ref) curated_subtree_ref="$2"; shift 2 ;;
+        --subtree-source-ref) subtree_source_ref="$2"; shift 2 ;;
         --expected-subtree-tree) expected_subtree_tree="$2"; shift 2 ;;
         --threads) threads="$2"; shift 2 ;;
         --iterations) iterations="$2"; shift 2 ;;
@@ -57,9 +57,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "$output_dir" || -z "$upstream_repo" || -z "$upstream_ref" || -z "$curated_subtree_ref" ]]; then
+if [[ -z "$output_dir" || -z "$upstream_repo" || -z "$upstream_ref" ]]; then
     usage >&2
     exit 2
+fi
+if [[ -z "$subtree_source_ref" ]]; then
+    subtree_source_ref="$upstream_ref"
 fi
 
 for numeric in threads iterations duration_seconds; do
@@ -104,7 +107,6 @@ build_status="not_run"
 tsan_smoke_status="not_run"
 harness_status="not_run"
 upstream_ref_status="not_run"
-curated_subtree_ref_status="not_run"
 actual_subtree_tree=""
 
 record_failure() {
@@ -125,15 +127,6 @@ do_validate_upstream_ref() {
     fi
 }
 
-do_validate_curated_subtree_ref() {
-    if validate_curated_subtree_ref "$source_dir" "$curated_subtree_ref" "$log_dir"; then
-        curated_subtree_ref_status="passed"
-    else
-        curated_subtree_ref_status="failed"
-        record_failure "failed to resolve curated subtree ref $curated_subtree_ref in qbit repository"
-    fi
-}
-
 qbit_commit="$(git -C "$source_dir" rev-parse HEAD 2>/dev/null || true)"
 run_url=""
 if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
@@ -146,7 +139,7 @@ fi
     echo "source_dir=$source_dir"
     echo "upstream_repo=$upstream_repo"
     echo "upstream_ref=$upstream_ref"
-    echo "curated_subtree_ref=$curated_subtree_ref"
+    echo "subtree_source_ref=$subtree_source_ref"
     echo "expected_subtree_tree=$expected_subtree_tree"
     echo "github_run_url=$run_url"
     echo "github_ref=${GITHUB_REF:-}"
@@ -182,7 +175,6 @@ fi
 } > "$meta_dir/host.txt" 2>&1
 
 do_validate_upstream_ref
-do_validate_curated_subtree_ref
 
 if actual_subtree_tree="$(git -C "$source_dir" rev-parse HEAD:src/libbitcoinpqc 2>"$log_dir/subtree-tree.log")"; then
     printf '%s\n' "$actual_subtree_tree" > "$meta_dir/subtree-tree.txt"
@@ -302,7 +294,7 @@ export QBIT_COMMIT="$qbit_commit"
 export SOURCE_DIR="$source_dir"
 export UPSTREAM_REPO="$upstream_repo"
 export UPSTREAM_REF="$upstream_ref"
-export CURATED_SUBTREE_REF="$curated_subtree_ref"
+export SUBTREE_SOURCE_REF="$subtree_source_ref"
 export EXPECTED_SUBTREE_TREE="$expected_subtree_tree"
 export ACTUAL_SUBTREE_TREE="$actual_subtree_tree"
 export GITHUB_RUN_URL="$run_url"
@@ -311,7 +303,6 @@ export ITERATIONS="$iterations"
 export DURATION_SECONDS="$duration_seconds"
 export SANITIZER="$sanitizer"
 export UPSTREAM_REF_STATUS="$upstream_ref_status"
-export CURATED_SUBTREE_REF_STATUS="$curated_subtree_ref_status"
 export SUBTREE_CHECK_STATUS="$subtree_check_status"
 export TSAN_SMOKE_STATUS="$tsan_smoke_status"
 export CONFIGURE_STATUS="$configure_status"
@@ -343,7 +334,7 @@ summary = {
     "qbit_commit": os.environ["QBIT_COMMIT"],
     "upstream_repo": os.environ["UPSTREAM_REPO"],
     "upstream_ref": os.environ["UPSTREAM_REF"],
-    "curated_subtree_ref": os.environ["CURATED_SUBTREE_REF"],
+    "subtree_source_ref": os.environ["SUBTREE_SOURCE_REF"],
     "expected_subtree_tree": os.environ["EXPECTED_SUBTREE_TREE"],
     "actual_subtree_tree": os.environ["ACTUAL_SUBTREE_TREE"],
     "github_run_url": os.environ["GITHUB_RUN_URL"],
@@ -362,7 +353,6 @@ summary = {
     },
     "checks": {
         "upstream_ref": os.environ["UPSTREAM_REF_STATUS"],
-        "curated_subtree_ref": os.environ["CURATED_SUBTREE_REF_STATUS"],
         "subtree_tree": os.environ["SUBTREE_CHECK_STATUS"],
         "tsan_smoke": os.environ["TSAN_SMOKE_STATUS"],
         "cmake_configure": os.environ["CONFIGURE_STATUS"],
@@ -383,7 +373,7 @@ lines = [
     f"- Status: `{summary['status']}`",
     f"- qbit commit: `{summary['qbit_commit']}`",
     f"- upstream: `{summary['upstream_repo']}` @ `{summary['upstream_ref']}`",
-    f"- curated subtree ref: `{summary['curated_subtree_ref']}`",
+    f"- subtree source ref: `{summary['subtree_source_ref']}`",
     f"- expected subtree tree: `{summary['expected_subtree_tree']}`",
     f"- actual subtree tree: `{summary['actual_subtree_tree']}`",
     f"- GitHub run: {summary['github_run_url'] or '(not running in GitHub Actions)'}",
@@ -393,7 +383,6 @@ lines = [
     f"- iterations: `{summary['harness']['iterations']}`",
     f"- duration seconds: `{summary['harness']['duration_seconds']}`",
     f"- upstream ref check: `{summary['checks']['upstream_ref']}`",
-    f"- curated subtree ref check: `{summary['checks']['curated_subtree_ref']}`",
     f"- TSAN smoke: `{summary['checks']['tsan_smoke']}`",
     f"- CMake configure: `{summary['checks']['cmake_configure']}`",
     f"- CMake build: `{summary['checks']['cmake_build']}`",

--- a/ci/libbitcoinpqc/evidence-helpers.sh
+++ b/ci/libbitcoinpqc/evidence-helpers.sh
@@ -45,19 +45,3 @@ validate_upstream_ref() {
         return 1
     fi
 }
-
-validate_curated_subtree_ref() {
-    local source_dir="$1"
-    local curated_subtree_ref="$2"
-    local log_dir="$3"
-
-    : > "$log_dir/curated-subtree-ref.log"
-    if git -C "$source_dir" cat-file -e "${curated_subtree_ref}^{commit}" 2>>"$log_dir/curated-subtree-ref.log"; then
-        return 0
-    elif git -C "$source_dir" fetch --depth=1 origin "$curated_subtree_ref" >>"$log_dir/curated-subtree-ref.log" 2>&1 &&
-         git -C "$source_dir" cat-file -e "${curated_subtree_ref}^{commit}" 2>>"$log_dir/curated-subtree-ref.log"; then
-        return 0
-    else
-        return 1
-    fi
-}

--- a/ci/scanners/README.md
+++ b/ci/scanners/README.md
@@ -25,8 +25,9 @@ python3 ci/scanners/run-scanners.py \
 
 The vendored `src/libbitcoinpqc` provenance scanner reads
 `LIBBITCOINPQC_READ_TOKEN` for authenticated access to the configured
-`libbitcoinpqc-qbit` upstream repository. `UPSTREAM_GITHUB_TOKEN` is accepted as
-a compatibility fallback for existing libbitcoinpqc evidence workflows.
+`qbit-libbitcoinpqc` upstream repository and verifies the pinned release tag.
+`UPSTREAM_GITHUB_TOKEN` is accepted as a compatibility fallback for existing
+libbitcoinpqc evidence workflows.
 
 For frozen review evidence, write summaries directly into the review record workspace:
 

--- a/ci/scanners/run-scanners.py
+++ b/ci/scanners/run-scanners.py
@@ -324,8 +324,15 @@ def libbitcoinpqc_github_auth_env(repo_url: str) -> dict[str, str] | None:
     return env
 
 
-def libbitcoinpqc_verify_env() -> dict[str, str] | None:
-    return libbitcoinpqc_github_auth_env(LIBBITCOINPQC_UPSTREAM_REPO)
+def libbitcoinpqc_verify_env() -> dict[str, str]:
+    env = (
+        libbitcoinpqc_github_auth_env(LIBBITCOINPQC_UPSTREAM_REPO)
+        or os.environ.copy()
+    )
+    env["LIBBITCOINPQC_PATH"] = LIBBITCOINPQC_PATH
+    env["LIBBITCOINPQC_REMOTE_URL"] = LIBBITCOINPQC_UPSTREAM_REPO
+    env["LIBBITCOINPQC_REMOTE_REF"] = LIBBITCOINPQC_UPSTREAM_TAG
+    return env
 
 
 def safe_review_id(value: Any) -> str:

--- a/ci/scanners/run-scanners.py
+++ b/ci/scanners/run-scanners.py
@@ -124,10 +124,11 @@ LEGACY_MODE_ALIASES = {
 }
 
 LIBBITCOINPQC_PATH = "src/libbitcoinpqc"
-LIBBITCOINPQC_UPSTREAM_REPO = "https://github.com/Qbit-Org/libbitcoinpqc-qbit.git"
-LIBBITCOINPQC_UPSTREAM_REF = "refs/heads/develop"
-LIBBITCOINPQC_CURATED_REF = "refs/heads/qbit-subtree"
-LIBBITCOINPQC_VERIFY_COMMAND = ["test/lint/git-subtree-check.sh", "-r", LIBBITCOINPQC_PATH]
+LIBBITCOINPQC_UPSTREAM_REPO = "https://github.com/Qbit-Org/qbit-libbitcoinpqc.git"
+LIBBITCOINPQC_UPSTREAM_TAG = "v0.3.0"
+LIBBITCOINPQC_UPSTREAM_REF = f"refs/tags/{LIBBITCOINPQC_UPSTREAM_TAG}"
+LIBBITCOINPQC_UPSTREAM_PEELED_REF = f"{LIBBITCOINPQC_UPSTREAM_REF}^{{}}"
+LIBBITCOINPQC_VERIFY_COMMAND = ["test/lint/libbitcoinpqc-subtree-check.sh"]
 
 
 def utcnow() -> str:
@@ -1113,25 +1114,6 @@ def git_commit_tree(source: Path, commit: str) -> str:
     return stdout.strip() if exit_code == 0 else ""
 
 
-def git_commit_parents(source: Path, commit: str) -> list[str]:
-    exit_code, stdout, _stderr = git_command(source, "show", "-s", "--format=%P", commit)
-    return stdout.split() if exit_code == 0 else []
-
-
-def imported_upstream_source_commit(source: Path, curated_commit: str) -> tuple[str, str]:
-    if not curated_commit or git_object_type(source, curated_commit) != "commit":
-        return "", "unavailable"
-    parents = git_commit_parents(source, curated_commit)
-    if len(parents) >= 2:
-        return parents[1], "merge_second_parent"
-    if not parents:
-        return "", "missing_parent"
-    merge_parents = git_commit_parents(source, parents[0])
-    if len(merge_parents) >= 2:
-        return merge_parents[1], "first_parent_merge_second_parent"
-    return "", "not_derivable"
-
-
 def git_ls_remote_ref(source: Path, repo_url: str, ref: str) -> tuple[str, int]:
     exit_code, stdout, _stderr = run_text_command(
         ["git", "ls-remote", repo_url, ref],
@@ -1165,15 +1147,12 @@ def fetch_libbitcoinpqc_provenance_objects(source: Path, split: str) -> tuple[li
         git_fetch(
             source,
             LIBBITCOINPQC_UPSTREAM_REPO,
-            [
-                LIBBITCOINPQC_UPSTREAM_REF,
-                LIBBITCOINPQC_CURATED_REF,
-            ],
+            [LIBBITCOINPQC_UPSTREAM_TAG],
         )
     ]
     gaps = []
     if results[0]["exit_code"] != 0:
-        gaps.append("libbitcoinpqc remote provenance refs fetch failed.")
+        gaps.append(f"libbitcoinpqc upstream tag fetch failed: {LIBBITCOINPQC_UPSTREAM_TAG}")
     if split and git_object_type(source, split) != "commit":
         split_result = git_fetch(source, LIBBITCOINPQC_UPSTREAM_REPO, [split])
         results.append(split_result)
@@ -1187,43 +1166,28 @@ def git_object_type(source: Path, object_name: str) -> str:
     return stdout.strip() if exit_code == 0 else ""
 
 
-def git_ancestor_relationship(source: Path, ancestor: str, descendant: str) -> str:
-    if not ancestor or not descendant:
-        return "missing"
-    if git_object_type(source, ancestor) != "commit" or git_object_type(source, descendant) != "commit":
-        return "unverified"
-    exit_code, _stdout, _stderr = git_command(source, "merge-base", "--is-ancestor", ancestor, descendant)
-    if exit_code == 0:
-        return "ancestor"
-    if exit_code == 1:
-        return "not_ancestor"
-    return "unverified"
-
-
 def libbitcoinpqc_provenance(source: Path) -> tuple[dict[str, Any], list[str]]:
     provenance: dict[str, Any] = {
         "upstream_repo": LIBBITCOINPQC_UPSTREAM_REPO,
         "upstream_ref": LIBBITCOINPQC_UPSTREAM_REF,
-        "curated_ref": LIBBITCOINPQC_CURATED_REF,
+        "upstream_tag": LIBBITCOINPQC_UPSTREAM_TAG,
+        "upstream_peeled_ref": LIBBITCOINPQC_UPSTREAM_PEELED_REF,
         "verification_command": command_to_string(LIBBITCOINPQC_VERIFY_COMMAND),
         "auth_source": libbitcoinpqc_auth_source() or "checkout/default",
     }
     gaps: list[str] = []
 
     upstream_ref_commit, upstream_ref_exit = git_ls_remote_ref(
-        source, LIBBITCOINPQC_UPSTREAM_REPO, LIBBITCOINPQC_UPSTREAM_REF
+        source, LIBBITCOINPQC_UPSTREAM_REPO, LIBBITCOINPQC_UPSTREAM_PEELED_REF
     )
-    curated_ref_commit, curated_ref_exit = git_ls_remote_ref(
-        source, LIBBITCOINPQC_UPSTREAM_REPO, LIBBITCOINPQC_CURATED_REF
-    )
+    if not upstream_ref_commit and upstream_ref_exit == 0:
+        upstream_ref_commit, upstream_ref_exit = git_ls_remote_ref(
+            source, LIBBITCOINPQC_UPSTREAM_REPO, LIBBITCOINPQC_UPSTREAM_REF
+        )
     provenance["upstream_ref_commit"] = upstream_ref_commit
     provenance["upstream_ref_lookup_exit_code"] = upstream_ref_exit
-    provenance["curated_ref_commit"] = curated_ref_commit
-    provenance["curated_ref_lookup_exit_code"] = curated_ref_exit
     if not upstream_ref_commit:
-        gaps.append(f"libbitcoinpqc upstream ref unavailable: {LIBBITCOINPQC_UPSTREAM_REF}")
-    if not curated_ref_commit:
-        gaps.append(f"libbitcoinpqc curated ref unavailable: {LIBBITCOINPQC_CURATED_REF}")
+        gaps.append(f"libbitcoinpqc upstream tag unavailable: {LIBBITCOINPQC_UPSTREAM_REF}")
 
     metadata = latest_git_subtree_metadata(source, LIBBITCOINPQC_PATH)
     provenance.update(metadata)
@@ -1235,37 +1199,25 @@ def libbitcoinpqc_provenance(source: Path) -> tuple[dict[str, Any], list[str]]:
     provenance["fetch_results"] = fetch_results
     gaps.extend(fetch_gaps)
 
-    imported_source_commit, imported_source_method = imported_upstream_source_commit(source, split)
-    provenance["imported_upstream_source_commit"] = imported_source_commit
-    provenance["imported_upstream_source_method"] = imported_source_method
-    if split and not imported_source_commit:
-        gaps.append("libbitcoinpqc imported upstream source commit is not derivable from the curated split.")
-    if imported_source_commit and upstream_ref_commit:
-        if imported_source_commit == upstream_ref_commit:
-            upstream_source_relationship = "matches_upstream_ref"
-        else:
-            upstream_source_relationship = git_ancestor_relationship(
-                source,
-                imported_source_commit,
-                upstream_ref_commit,
-            )
+    if split and upstream_ref_commit:
+        upstream_source_relationship = "matches_upstream_tag" if split == upstream_ref_commit else "differs"
         provenance["upstream_source_relationship"] = upstream_source_relationship
-        if upstream_source_relationship not in {"matches_upstream_ref", "ancestor"}:
+        if upstream_source_relationship != "matches_upstream_tag":
             gaps.append(
-                "libbitcoinpqc imported upstream source does not match "
-                f"{LIBBITCOINPQC_UPSTREAM_REF}: imported={imported_source_commit} upstream={upstream_ref_commit}"
+                "libbitcoinpqc subtree split does not match "
+                f"{LIBBITCOINPQC_UPSTREAM_REF}: split={split} upstream={upstream_ref_commit}"
             )
 
     current_tree = git_tree_for_path(source, LIBBITCOINPQC_PATH)
-    import_tree = git_commit_tree(source, import_commit) if import_commit else ""
+    upstream_tree = git_commit_tree(source, upstream_ref_commit) if upstream_ref_commit else ""
     provenance["qbit_subtree_tree"] = current_tree
-    provenance["qbit_import_tree"] = import_tree
+    provenance["upstream_tag_tree"] = upstream_tree
     if not current_tree:
         gaps.append("libbitcoinpqc subtree tree hash unavailable from HEAD.")
-    if import_commit and not import_tree:
-        gaps.append(f"libbitcoinpqc qbit import commit tree unavailable: {import_commit}")
-    if current_tree and import_tree and current_tree != import_tree:
-        gaps.append("libbitcoinpqc subtree tree does not match the recorded qbit import commit tree.")
+    if upstream_ref_commit and not upstream_tree:
+        gaps.append(f"libbitcoinpqc upstream tag commit tree unavailable: {upstream_ref_commit}")
+    if current_tree and upstream_tree and current_tree != upstream_tree:
+        gaps.append("libbitcoinpqc subtree tree does not match the upstream tag tree.")
 
     verify_script = source / LIBBITCOINPQC_VERIFY_COMMAND[0]
     if verify_script.is_file():
@@ -1278,18 +1230,6 @@ def libbitcoinpqc_provenance(source: Path) -> tuple[dict[str, Any], list[str]]:
         gaps.append(
             f"libbitcoinpqc full subtree verification failed: {command_to_string(LIBBITCOINPQC_VERIFY_COMMAND)}"
         )
-
-    if split and curated_ref_commit:
-        if split == curated_ref_commit:
-            relationship = "matches_curated_ref"
-        else:
-            relationship = git_ancestor_relationship(source, split, curated_ref_commit)
-        provenance["curated_ref_relationship"] = relationship
-        if relationship not in {"matches_curated_ref", "ancestor"}:
-            gaps.append(
-                "libbitcoinpqc imported split is not proven reachable from "
-                f"{LIBBITCOINPQC_CURATED_REF}: imported={split} curated={curated_ref_commit}"
-            )
 
     return provenance, gaps
 

--- a/ci/scanners/run-scanners.py
+++ b/ci/scanners/run-scanners.py
@@ -324,6 +324,10 @@ def libbitcoinpqc_github_auth_env(repo_url: str) -> dict[str, str] | None:
     return env
 
 
+def libbitcoinpqc_verify_env() -> dict[str, str] | None:
+    return libbitcoinpqc_github_auth_env(LIBBITCOINPQC_UPSTREAM_REPO)
+
+
 def safe_review_id(value: Any) -> str:
     text = str(value or "").strip()
     if not text:
@@ -1245,7 +1249,11 @@ def libbitcoinpqc_provenance(source: Path) -> tuple[dict[str, Any], list[str]]:
 
     verify_script = source / LIBBITCOINPQC_VERIFY_COMMAND[0]
     if verify_script.is_file():
-        verify_exit, _stdout, _stderr = run_text_command(LIBBITCOINPQC_VERIFY_COMMAND, source)
+        verify_exit, _stdout, _stderr = run_text_command(
+            LIBBITCOINPQC_VERIFY_COMMAND,
+            source,
+            env=libbitcoinpqc_verify_env(),
+        )
     else:
         verify_exit = 127
     provenance["verification_exit_code"] = verify_exit

--- a/ci/scanners/run-scanners.py
+++ b/ci/scanners/run-scanners.py
@@ -1114,6 +1114,22 @@ def git_commit_tree(source: Path, commit: str) -> str:
     return stdout.strip() if exit_code == 0 else ""
 
 
+def ls_remote_ref_matches(query_ref: str, candidate_ref: str) -> bool:
+    if candidate_ref == query_ref:
+        return True
+    if query_ref.endswith("^{}") and candidate_ref == query_ref.removesuffix("^{}"):
+        return True
+    return False
+
+
+def ls_remote_ref_oid(stdout: str, ref: str) -> str:
+    for line in stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and ls_remote_ref_matches(ref, parts[1]):
+            return parts[0]
+    return ""
+
+
 def git_ls_remote_ref(source: Path, repo_url: str, ref: str) -> tuple[str, int]:
     exit_code, stdout, _stderr = run_text_command(
         ["git", "ls-remote", repo_url, ref],
@@ -1122,11 +1138,7 @@ def git_ls_remote_ref(source: Path, repo_url: str, ref: str) -> tuple[str, int]:
     )
     if exit_code != 0:
         return "", exit_code
-    for line in stdout.splitlines():
-        parts = line.split()
-        if len(parts) >= 2 and parts[1] == ref:
-            return parts[0], exit_code
-    return "", exit_code
+    return ls_remote_ref_oid(stdout, ref), exit_code
 
 
 def git_fetch(source: Path, repo_url: str, refs: list[str]) -> dict[str, Any]:

--- a/ci/scanners/run-scanners.py
+++ b/ci/scanners/run-scanners.py
@@ -1114,6 +1114,13 @@ def git_commit_tree(source: Path, commit: str) -> str:
     return stdout.strip() if exit_code == 0 else ""
 
 
+def git_peel_commit(source: Path, object_name: str) -> str:
+    if not object_name:
+        return ""
+    exit_code, stdout, _stderr = git_command(source, "rev-parse", f"{object_name}^{{commit}}")
+    return stdout.strip() if exit_code == 0 else ""
+
+
 def ls_remote_ref_matches(query_ref: str, candidate_ref: str) -> bool:
     if candidate_ref == query_ref:
         return True
@@ -1189,16 +1196,16 @@ def libbitcoinpqc_provenance(source: Path) -> tuple[dict[str, Any], list[str]]:
     }
     gaps: list[str] = []
 
-    upstream_ref_commit, upstream_ref_exit = git_ls_remote_ref(
+    upstream_ref_object, upstream_ref_exit = git_ls_remote_ref(
         source, LIBBITCOINPQC_UPSTREAM_REPO, LIBBITCOINPQC_UPSTREAM_PEELED_REF
     )
-    if not upstream_ref_commit and upstream_ref_exit == 0:
-        upstream_ref_commit, upstream_ref_exit = git_ls_remote_ref(
+    if not upstream_ref_object and upstream_ref_exit == 0:
+        upstream_ref_object, upstream_ref_exit = git_ls_remote_ref(
             source, LIBBITCOINPQC_UPSTREAM_REPO, LIBBITCOINPQC_UPSTREAM_REF
         )
-    provenance["upstream_ref_commit"] = upstream_ref_commit
+    provenance["upstream_ref_object"] = upstream_ref_object
     provenance["upstream_ref_lookup_exit_code"] = upstream_ref_exit
-    if not upstream_ref_commit:
+    if not upstream_ref_object:
         gaps.append(f"libbitcoinpqc upstream tag unavailable: {LIBBITCOINPQC_UPSTREAM_REF}")
 
     metadata = latest_git_subtree_metadata(source, LIBBITCOINPQC_PATH)
@@ -1210,6 +1217,11 @@ def libbitcoinpqc_provenance(source: Path) -> tuple[dict[str, Any], list[str]]:
     fetch_results, fetch_gaps = fetch_libbitcoinpqc_provenance_objects(source, split)
     provenance["fetch_results"] = fetch_results
     gaps.extend(fetch_gaps)
+
+    upstream_ref_commit = git_peel_commit(source, upstream_ref_object)
+    provenance["upstream_ref_commit"] = upstream_ref_commit
+    if upstream_ref_object and not upstream_ref_commit:
+        gaps.append(f"libbitcoinpqc upstream tag object is not peelable to a commit: {upstream_ref_object}")
 
     if split and upstream_ref_commit:
         upstream_source_relationship = "matches_upstream_tag" if split == upstream_ref_commit else "differs"

--- a/ci/scanners/run-scanners.py
+++ b/ci/scanners/run-scanners.py
@@ -1244,11 +1244,21 @@ def libbitcoinpqc_provenance(source: Path) -> tuple[dict[str, Any], list[str]]:
             )
 
     current_tree = git_tree_for_path(source, LIBBITCOINPQC_PATH)
+    import_tree = (
+        git_tree_for_path(source, LIBBITCOINPQC_PATH, import_commit)
+        if import_commit
+        else ""
+    )
     upstream_tree = git_commit_tree(source, upstream_ref_commit) if upstream_ref_commit else ""
     provenance["qbit_subtree_tree"] = current_tree
+    provenance["qbit_import_tree"] = import_tree
     provenance["upstream_tag_tree"] = upstream_tree
     if not current_tree:
         gaps.append("libbitcoinpqc subtree tree hash unavailable from HEAD.")
+    if import_commit and not import_tree:
+        gaps.append(f"libbitcoinpqc qbit import commit tree unavailable: {import_commit}")
+    if current_tree and import_tree and current_tree != import_tree:
+        gaps.append("libbitcoinpqc subtree tree does not match the recorded qbit import commit tree.")
     if upstream_ref_commit and not upstream_tree:
         gaps.append(f"libbitcoinpqc upstream tag commit tree unavailable: {upstream_ref_commit}")
     if current_tree and upstream_tree and current_tree != upstream_tree:

--- a/ci/scanners/test_run_scanners.py
+++ b/ci/scanners/test_run_scanners.py
@@ -105,6 +105,36 @@ class RunScannersTest(unittest.TestCase):
         self.assertTrue(
             any(value.startswith("AUTHORIZATION: basic ") for value in auth_headers)
         )
+        self.assertEqual(run_scanners.LIBBITCOINPQC_PATH, env["LIBBITCOINPQC_PATH"])
+        self.assertEqual(
+            run_scanners.LIBBITCOINPQC_UPSTREAM_REPO,
+            env["LIBBITCOINPQC_REMOTE_URL"],
+        )
+        self.assertEqual(
+            run_scanners.LIBBITCOINPQC_UPSTREAM_TAG,
+            env["LIBBITCOINPQC_REMOTE_REF"],
+        )
+
+    def test_libbitcoinpqc_verify_env_pins_shell_inputs_without_auth(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "LIBBITCOINPQC_READ_TOKEN": "",
+                "UPSTREAM_GITHUB_TOKEN": "",
+            },
+            clear=False,
+        ):
+            env = run_scanners.libbitcoinpqc_verify_env()
+
+        self.assertEqual(run_scanners.LIBBITCOINPQC_PATH, env["LIBBITCOINPQC_PATH"])
+        self.assertEqual(
+            run_scanners.LIBBITCOINPQC_UPSTREAM_REPO,
+            env["LIBBITCOINPQC_REMOTE_URL"],
+        )
+        self.assertEqual(
+            run_scanners.LIBBITCOINPQC_UPSTREAM_TAG,
+            env["LIBBITCOINPQC_REMOTE_REF"],
+        )
 
     def test_libbitcoinpqc_provenance_passes_auth_to_verifier(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -166,6 +196,10 @@ class RunScannersTest(unittest.TestCase):
         ]
         self.assertTrue(
             any(value.startswith("AUTHORIZATION: basic ") for value in auth_headers)
+        )
+        self.assertEqual(
+            run_scanners.LIBBITCOINPQC_UPSTREAM_TAG,
+            verifier_env["LIBBITCOINPQC_REMOTE_REF"],
         )
 
 

--- a/ci/scanners/test_run_scanners.py
+++ b/ci/scanners/test_run_scanners.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026-present The qbit core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+"""Tests for scanner evidence helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_SCANNERS_PATH = REPO_ROOT / "ci/scanners/run-scanners.py"
+
+
+def load_run_scanners():
+    spec = importlib.util.spec_from_file_location("run_scanners", RUN_SCANNERS_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+run_scanners = load_run_scanners()
+
+
+class RunScannersTest(unittest.TestCase):
+    def test_ls_remote_ref_oid_accepts_exact_peeled_tag_ref(self) -> None:
+        stdout = "ac72d1\trefs/tags/v0.3.0^{}\n456aaf\trefs/tags/v0.3.0\n"
+
+        self.assertEqual(
+            run_scanners.ls_remote_ref_oid(stdout, "refs/tags/v0.3.0^{}"),
+            "ac72d1",
+        )
+
+    def test_ls_remote_ref_oid_accepts_base_ref_for_peeled_query(self) -> None:
+        stdout = "ac72d1\trefs/tags/v0.3.0\n"
+
+        self.assertEqual(
+            run_scanners.ls_remote_ref_oid(stdout, "refs/tags/v0.3.0^{}"),
+            "ac72d1",
+        )
+
+    def test_ls_remote_ref_oid_does_not_accept_peeled_ref_for_base_query(self) -> None:
+        stdout = "ac72d1\trefs/tags/v0.3.0^{}\n"
+
+        self.assertEqual(
+            run_scanners.ls_remote_ref_oid(stdout, "refs/tags/v0.3.0"),
+            "",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ci/scanners/test_run_scanners.py
+++ b/ci/scanners/test_run_scanners.py
@@ -7,11 +7,13 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -84,6 +86,87 @@ class RunScannersTest(unittest.TestCase):
 
             self.assertNotEqual(tag_object, commit)
             self.assertEqual(run_scanners.git_peel_commit(repo, tag_object), commit)
+
+    def test_libbitcoinpqc_verify_env_uses_read_token(self) -> None:
+        with patch.dict(
+            os.environ,
+            {"LIBBITCOINPQC_READ_TOKEN": "test-token"},
+            clear=False,
+        ):
+            env = run_scanners.libbitcoinpqc_verify_env()
+
+        self.assertIsNotNone(env)
+        assert env is not None
+        auth_headers = [
+            value
+            for key, value in env.items()
+            if key.startswith("GIT_CONFIG_VALUE_")
+        ]
+        self.assertTrue(
+            any(value.startswith("AUTHORIZATION: basic ") for value in auth_headers)
+        )
+
+    def test_libbitcoinpqc_provenance_passes_auth_to_verifier(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir)
+            verify_script = source / run_scanners.LIBBITCOINPQC_VERIFY_COMMAND[0]
+            verify_script.parent.mkdir(parents=True)
+            verify_script.write_text("#!/bin/sh\nexit 0\n", encoding="utf8")
+            verifier_envs = []
+
+            def fake_run_text_command(command, cwd, env=None):
+                verifier_envs.append(env)
+                return 0, "", ""
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {"LIBBITCOINPQC_READ_TOKEN": "test-token"},
+                    clear=False,
+                ),
+                patch.object(
+                    run_scanners,
+                    "git_ls_remote_ref",
+                    return_value=("tag-object", 0),
+                ),
+                patch.object(
+                    run_scanners,
+                    "latest_git_subtree_metadata",
+                    return_value={
+                        "git_subtree_split": "commit",
+                        "qbit_import_commit": "import",
+                    },
+                ),
+                patch.object(
+                    run_scanners,
+                    "fetch_libbitcoinpqc_provenance_objects",
+                    return_value=([], []),
+                ),
+                patch.object(run_scanners, "git_peel_commit", return_value="commit"),
+                patch.object(run_scanners, "git_tree_for_path", return_value="tree"),
+                patch.object(run_scanners, "git_commit_tree", return_value="tree"),
+                patch.object(
+                    run_scanners,
+                    "run_text_command",
+                    side_effect=fake_run_text_command,
+                ),
+            ):
+                provenance, gaps = run_scanners.libbitcoinpqc_provenance(source)
+
+        self.assertEqual([], gaps)
+        self.assertEqual(0, provenance["verification_exit_code"])
+        self.assertEqual(1, len(verifier_envs))
+        verifier_env = verifier_envs[0]
+        self.assertIsNotNone(verifier_env)
+        assert verifier_env is not None
+        auth_headers = [
+            value
+            for key, value in verifier_env.items()
+            if key.startswith("GIT_CONFIG_VALUE_")
+        ]
+        self.assertTrue(
+            any(value.startswith("AUTHORIZATION: basic ") for value in auth_headers)
+        )
 
 
 if __name__ == "__main__":

--- a/ci/scanners/test_run_scanners.py
+++ b/ci/scanners/test_run_scanners.py
@@ -7,7 +7,9 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -53,6 +55,35 @@ class RunScannersTest(unittest.TestCase):
             run_scanners.ls_remote_ref_oid(stdout, "refs/tags/v0.3.0"),
             "",
         )
+
+    def test_git_peel_commit_resolves_annotated_tag_object(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "commit.gpgsign", "false"], cwd=repo, check=True)
+            subprocess.run(["git", "config", "tag.gpgSign", "false"], cwd=repo, check=True)
+            (repo / "file.txt").write_text("content\n", encoding="utf8")
+            subprocess.run(["git", "add", "file.txt"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-q", "-m", "initial"], cwd=repo, check=True)
+            subprocess.run(["git", "tag", "-a", "v1", "-m", "release"], cwd=repo, check=True)
+
+            tag_object = subprocess.check_output(
+                ["git", "rev-parse", "v1"],
+                cwd=repo,
+                text=True,
+                encoding="utf8",
+            ).strip()
+            commit = subprocess.check_output(
+                ["git", "rev-parse", "v1^{}"],
+                cwd=repo,
+                text=True,
+                encoding="utf8",
+            ).strip()
+
+            self.assertNotEqual(tag_object, commit)
+            self.assertEqual(run_scanners.git_peel_commit(repo, tag_object), commit)
 
 
 if __name__ == "__main__":

--- a/ci/scanners/test_run_scanners.py
+++ b/ci/scanners/test_run_scanners.py
@@ -202,6 +202,62 @@ class RunScannersTest(unittest.TestCase):
             verifier_env["LIBBITCOINPQC_REMOTE_REF"],
         )
 
+    def test_libbitcoinpqc_provenance_flags_import_tree_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir)
+            verify_script = source / run_scanners.LIBBITCOINPQC_VERIFY_COMMAND[0]
+            verify_script.parent.mkdir(parents=True)
+            verify_script.write_text("#!/bin/sh\nexit 0\n", encoding="utf8")
+
+            def fake_git_tree_for_path(source, relpath, commit="HEAD"):
+                return "current-tree" if commit == "HEAD" else "import-tree"
+
+            with (
+                patch.object(
+                    run_scanners,
+                    "git_ls_remote_ref",
+                    return_value=("tag-object", 0),
+                ),
+                patch.object(
+                    run_scanners,
+                    "latest_git_subtree_metadata",
+                    return_value={
+                        "git_subtree_split": "commit",
+                        "qbit_import_commit": "import",
+                    },
+                ),
+                patch.object(
+                    run_scanners,
+                    "fetch_libbitcoinpqc_provenance_objects",
+                    return_value=([], []),
+                ),
+                patch.object(run_scanners, "git_peel_commit", return_value="commit"),
+                patch.object(
+                    run_scanners,
+                    "git_tree_for_path",
+                    side_effect=fake_git_tree_for_path,
+                ),
+                patch.object(
+                    run_scanners,
+                    "git_commit_tree",
+                    return_value="current-tree",
+                ),
+                patch.object(
+                    run_scanners,
+                    "run_text_command",
+                    return_value=(0, "", ""),
+                ),
+            ):
+                provenance, gaps = run_scanners.libbitcoinpqc_provenance(source)
+
+        self.assertEqual("current-tree", provenance["qbit_subtree_tree"])
+        self.assertEqual("import-tree", provenance["qbit_import_tree"])
+        self.assertEqual("current-tree", provenance["upstream_tag_tree"])
+        self.assertIn(
+            "libbitcoinpqc subtree tree does not match the recorded qbit import commit tree.",
+            gaps,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -177,14 +177,14 @@ Example usage:
 update-libbitcoinpqc-subtree.sh
 ===============================
 
-Updates the `src/libbitcoinpqc` subtree from the curated upstream branch
-(`qbit-subtree` by default), then runs `test/lint/git-subtree-check.sh` to
-verify the subtree remains pure.
-Default source resolves from the local `origin` owner to
-`git@github.com:<owner>/libbitcoinpqc-qbit.git`.
+Updates the `src/libbitcoinpqc` subtree from the pinned upstream release tag,
+then runs `test/lint/libbitcoinpqc-subtree-check.sh` to verify that the vendored
+tree and recorded `git-subtree-split` match the peeled tag commit.
 
-For the full two-repo workflow (`develop` -> prune -> `qbit-subtree` -> qbit
-import), see [`doc/subtrees/libbitcoinpqc.md`](../../doc/subtrees/libbitcoinpqc.md).
+The default source is
+`https://github.com/Qbit-Org/qbit-libbitcoinpqc.git` tag `v0.3.0`. For the
+full release-tag import workflow, see
+[`doc/subtrees/libbitcoinpqc.md`](../../doc/subtrees/libbitcoinpqc.md).
 
 Run from the repository root:
 
@@ -195,7 +195,7 @@ contrib/devtools/update-libbitcoinpqc-subtree.sh
 Optional overrides:
 
 ```bash
-LIBBITCOINPQC_REMOTE_URL=git@github.com:your-org/libbitcoinpqc-qbit.git \
-LIBBITCOINPQC_REMOTE_REF=qbit-subtree \
+LIBBITCOINPQC_REMOTE_URL=git@github.com:Qbit-Org/qbit-libbitcoinpqc.git \
+LIBBITCOINPQC_REMOTE_REF=v0.3.0 \
 contrib/devtools/update-libbitcoinpqc-subtree.sh
 ```

--- a/contrib/devtools/update-libbitcoinpqc-subtree.sh
+++ b/contrib/devtools/update-libbitcoinpqc-subtree.sh
@@ -80,8 +80,8 @@ EXPECTED_UPSTREAM_COMMIT="$(resolve_remote_commit "${REMOTE_URL}" "${REMOTE_REF}
 if [[ -n "${EXPECTED_UPSTREAM_COMMIT}" ]]; then
   echo "Expected upstream commit: ${EXPECTED_UPSTREAM_COMMIT}"
 else
-  echo "Expected upstream commit: unavailable (git ls-remote failed)"
-  echo "Proceeding with local subtree checks only."
+  echo "error: expected upstream commit unavailable (git ls-remote failed)" >&2
+  exit 1
 fi
 
 if git rev-parse --verify "HEAD:${PREFIX}" >/dev/null 2>&1; then
@@ -92,10 +92,8 @@ else
   git subtree add --prefix="${PREFIX}" "${REMOTE_URL}" "${REMOTE_REF}" --squash
 fi
 
-if [[ -n "${EXPECTED_UPSTREAM_COMMIT}" ]]; then
-  test/lint/git-subtree-check.sh -r "${PREFIX}"
-else
-  test/lint/git-subtree-check.sh "${PREFIX}"
-fi
+LIBBITCOINPQC_REMOTE_URL="${REMOTE_URL}" \
+LIBBITCOINPQC_REMOTE_REF="${REMOTE_REF}" \
+  test/lint/libbitcoinpqc-subtree-check.sh
 
 echo "Subtree update and integrity check completed for ${PREFIX}."

--- a/doc/development/developer-notes.md
+++ b/doc/development/developer-notes.md
@@ -1122,12 +1122,12 @@ The tool instructions also include a list of the subtrees managed by Bitcoin Cor
 The ultimate upstream of the few externally managed subtrees are:
 
 - src/libbitcoinpqc
-  - Upstream at https://github.com/<owner>/libbitcoinpqc-qbit ; maintained via
-    the curated `qbit-subtree` branch for subtree imports.
+  - Upstream at https://github.com/Qbit-Org/qbit-libbitcoinpqc ; imported
+    directly from immutable release tags.
   - Follow [libbitcoinpqc subtree runbook](../subtrees/libbitcoinpqc.md).
   - Use `contrib/devtools/update-libbitcoinpqc-subtree.sh` to update this
     subtree, so updates come through `git subtree add/pull --squash` and remain
-    verifiable by `test/lint/git-subtree-check.sh`.
+    verifiable by `test/lint/libbitcoinpqc-subtree-check.sh`.
 
 - src/leveldb
   - Upstream at https://github.com/google/leveldb ; maintained by Google. Open

--- a/doc/subtrees/libbitcoinpqc.md
+++ b/doc/subtrees/libbitcoinpqc.md
@@ -50,12 +50,12 @@ After importing, verify that the qbit subtree exactly matches the upstream
 commit referenced by the subtree metadata:
 
 ```bash
-git fetch https://github.com/Qbit-Org/qbit-libbitcoinpqc.git v0.3.0
-test/lint/git-subtree-check.sh -r src/libbitcoinpqc
+test/lint/libbitcoinpqc-subtree-check.sh
 ```
 
-The check should report `GOOD` and show the subtree split commit as
-`ac72d1ffa0ef486f08d37334a43f5db1adb731db` for the current pin.
+The check fetches the pinned tag if needed, should report `GOOD`, and should
+show the subtree split commit as `ac72d1ffa0ef486f08d37334a43f5db1adb731db`
+for the current pin.
 
 ## PR Checklist For Subtree Updates
 
@@ -64,26 +64,27 @@ When a PR touches `src/libbitcoinpqc`, confirm:
 - [ ] The source commit is reachable from an immutable release tag in
   `Qbit-Org/qbit-libbitcoinpqc`.
 - [ ] qbit imported that tag via `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
-- [ ] `test/lint/git-subtree-check.sh -r src/libbitcoinpqc` passes locally.
+- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
 - [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh`
   is intentional and matches this runbook.
 
 ## Common Failures
 
 1. Signature:
-   `FAIL: subtree directory was touched without subtree merge`
+   `FAIL: src/libbitcoinpqc tree differs from upstream tag <tag>`
    Cause:
    Files under `src/libbitcoinpqc` were edited manually after the subtree import.
    Fix:
    Re-import via `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
 
 2. Signature:
-   `subtree commit <hash> unavailable: cannot compare. Did you add and fetch the remote?`
+   `FAIL: subtree split <hash> does not match upstream tag commit <hash>`
    Cause:
-   `git-subtree-check.sh -r` cannot find the upstream commit locally.
+   The recorded `git-subtree-split` metadata does not match the configured
+   release tag.
    Fix:
-   Run the update script, or fetch the pinned tag from
-   `Qbit-Org/qbit-libbitcoinpqc`, before the `-r` check.
+   Re-import the intended release tag via
+   `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
 
 3. Signature:
    `fatal: unable to access 'https://github.com/...': The requested URL returned error: 403`

--- a/test/fuzz/shared_target_mappings.json
+++ b/test/fuzz/shared_target_mappings.json
@@ -24,9 +24,9 @@
       "mapping_status": "external_upstream",
       "smoke_check": false,
       "upstream": {
-        "repo": "libbitcoinpqc-qbit",
-        "ref": "8ec06cc452c30ab12de00b704144e6139c1e9b3a",
-        "curated_subtree_ref": "8da5e95c83c3f12c9d178fd8e7576b871dd0f2b2",
+        "repo": "Qbit-Org/qbit-libbitcoinpqc",
+        "tag": "v0.3.0",
+        "peeled_commit": "ac72d1ffa0ef486f08d37334a43f5db1adb731db",
         "fuzz_manifest": "fuzz/Cargo.toml",
         "runner": "fuzz/run_all_fuzzers.sh",
         "commands": [
@@ -35,7 +35,7 @@
           "./fuzz/check_fuzz_inventory.sh"
         ]
       },
-      "notes": "The qbit curated subtree prunes cargo-fuzz tooling; run these concrete harnesses from the upstream libbitcoinpqc-qbit checkout at the recorded upstream ref."
+      "notes": "The qbit subtree is imported directly from the recorded upstream tag; run these concrete harnesses from src/libbitcoinpqc or from the matching upstream checkout."
     },
     {
       "target_id": "lane-a-pqc-wrapper",

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -101,18 +101,30 @@ maintained:
 
 Keep this list in sync with `fn get_subtrees()` in the lint runner.
 
-The qbit-specific `src/libbitcoinpqc` vendored source is excluded from generic
-file linters, but public release snapshot branches may not carry
-`git-subtree` metadata until the public `Qbit-Org/libbitcoinpqc-qbit`
-repository is available. For the libbitcoinpqc subtree workflow and provenance
-checks, see
-[`doc/subtrees/libbitcoinpqc.md`](../../doc/subtrees/libbitcoinpqc.md).
-
-To do so, add the upstream repository as remote:
+For the generic subtree checks, add the upstream repository as remote:
 
 ```
 git remote add --fetch secp256k1 https://github.com/bitcoin-core/secp256k1.git
 ```
+
+libbitcoinpqc-subtree-check.sh
+==============================
+Run this script from the root of the repository to verify the qbit-specific
+libbitcoinpqc subtree against the pinned upstream release tag:
+
+```
+test/lint/libbitcoinpqc-subtree-check.sh
+```
+
+The defaults match `doc/subtrees/libbitcoinpqc.md`; `LIBBITCOINPQC_REMOTE_URL`
+and `LIBBITCOINPQC_REMOTE_REF` can be overridden when testing a future tagged
+release before changing the defaults.
+
+This check fetches the pinned `Qbit-Org/qbit-libbitcoinpqc` release tag and
+verifies that both `HEAD:src/libbitcoinpqc` and the recorded
+`git-subtree-split` match the peeled tag commit. For the full libbitcoinpqc
+subtree workflow, see
+[`doc/subtrees/libbitcoinpqc.md`](../../doc/subtrees/libbitcoinpqc.md).
 
 lint-libbitcoinpqc-vectors.py
 =============================
@@ -123,13 +135,12 @@ vector wiring in `src/libbitcoinpqc/sphincsplus`:
 test/lint/lint-libbitcoinpqc-vectors.py
 ```
 
-If the curated subtree still contains the upstream NIST KAT generator sources,
-the lint regenerates a reference vector and checks it against `SHA256SUMS`.
-If those sources were pruned from the curated qbit subtree, the lint falls back
-to static bounded30 guard checks and treats the prune as expected. A partially
-present KAT payload, or a missing implementation directory, is treated as an
-error so accidental subtree corruption does not silently bypass vector
-coverage.
+If the upstream tag contains the NIST KAT generator sources, the lint
+regenerates a reference vector and checks it against `SHA256SUMS`. If those
+sources are absent from the upstream tag, the lint falls back to static
+bounded30 guard checks. A partially present KAT payload, or a missing
+implementation directory, is treated as an error so accidental subtree
+corruption does not silently bypass vector coverage.
 
 lint-qbit-node-defaults.py
 ==========================

--- a/test/lint/libbitcoinpqc-subtree-check.sh
+++ b/test/lint/libbitcoinpqc-subtree-check.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026-present The qbit core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit.
+
+export LC_ALL=C
+set -euo pipefail
+
+PREFIX="${LIBBITCOINPQC_PATH:-src/libbitcoinpqc}"
+REMOTE_URL="${LIBBITCOINPQC_REMOTE_URL:-https://github.com/Qbit-Org/qbit-libbitcoinpqc.git}"
+REMOTE_REF="${LIBBITCOINPQC_REMOTE_REF:-v0.3.0}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0")
+
+Verify that $PREFIX matches the tagged upstream libbitcoinpqc tree.
+
+Environment overrides:
+  LIBBITCOINPQC_PATH        default: src/libbitcoinpqc
+  LIBBITCOINPQC_REMOTE_URL  default: https://github.com/Qbit-Org/qbit-libbitcoinpqc.git
+  LIBBITCOINPQC_REMOTE_REF  default: v0.3.0
+EOF
+}
+
+resolve_remote_commit() {
+  local remote_url="$1"
+  local remote_ref="$2"
+  local ls_remote_output
+
+  if ls_remote_output="$(git ls-remote --exit-code "${remote_url}" "${remote_ref}^{}" 2>/dev/null)"; then
+    printf '%s\n' "${ls_remote_output}" | awk 'NR==1 {print $1}'
+    return
+  fi
+
+  if ls_remote_output="$(git ls-remote --exit-code "${remote_url}" "${remote_ref}" 2>/dev/null)"; then
+    printf '%s\n' "${ls_remote_output}" | awk 'NR==1 {print $1}'
+  fi
+}
+
+if [[ "${1-}" == "--help" || "${1-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 0 ]]; then
+  usage >&2
+  exit 2
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "FAIL: must run inside a git worktree" >&2
+  exit 1
+fi
+
+current_tree="$(git rev-parse "HEAD:${PREFIX}" 2>/dev/null || true)"
+if [[ -z "${current_tree}" ]]; then
+  echo "FAIL: subtree directory ${PREFIX} not found in HEAD" >&2
+  exit 1
+fi
+
+upstream_commit="$(resolve_remote_commit "${REMOTE_URL}" "${REMOTE_REF}")"
+if [[ -z "${upstream_commit}" ]]; then
+  echo "FAIL: unable to resolve ${REMOTE_URL} ${REMOTE_REF}" >&2
+  exit 1
+fi
+
+if ! git cat-file -e "${upstream_commit}^{commit}" 2>/dev/null; then
+  git fetch --depth=1 "${REMOTE_URL}" "${REMOTE_REF}" >/dev/null
+fi
+
+if ! git cat-file -e "${upstream_commit}^{commit}" 2>/dev/null; then
+  echo "FAIL: upstream commit ${upstream_commit} unavailable after fetch" >&2
+  exit 1
+fi
+
+upstream_tree="$(git show -s --format=%T "${upstream_commit}")"
+metadata_split="$(
+  git log \
+    --grep="^git-subtree-dir: ${PREFIX}/*$" \
+    --pretty=format:%B \
+    HEAD |
+  awk '/^git-subtree-split: / {print $2; exit}'
+)"
+
+echo "${PREFIX} in HEAD currently refers to tree ${current_tree}"
+echo "${REMOTE_URL} ${REMOTE_REF} resolves to commit ${upstream_commit} tree ${upstream_tree}"
+
+if [[ -z "${metadata_split}" ]]; then
+  echo "FAIL: subtree metadata missing: no git-subtree-split entry found for ${PREFIX}" >&2
+  exit 1
+fi
+
+echo "${PREFIX} latest git-subtree-split is ${metadata_split}"
+if [[ "${metadata_split}" != "${upstream_commit}" ]]; then
+  echo "FAIL: subtree split ${metadata_split} does not match upstream tag commit ${upstream_commit}" >&2
+  exit 1
+fi
+
+if [[ "${current_tree}" != "${upstream_tree}" ]]; then
+  git diff --stat "${upstream_tree}" "${current_tree}" >&2 || true
+  echo "FAIL: ${PREFIX} tree differs from upstream tag ${REMOTE_REF}" >&2
+  exit 1
+fi
+
+echo "GOOD"

--- a/test/lint/libbitcoinpqc-subtree-check.sh
+++ b/test/lint/libbitcoinpqc-subtree-check.sh
@@ -75,6 +75,7 @@ if ! git cat-file -e "${upstream_commit}^{commit}" 2>/dev/null; then
   exit 1
 fi
 
+upstream_commit="$(git rev-parse "${upstream_commit}^{commit}")"
 upstream_tree="$(git show -s --format=%T "${upstream_commit}")"
 metadata_split="$(
   git log \

--- a/test/lint/libbitcoinpqc-subtree-check.sh
+++ b/test/lint/libbitcoinpqc-subtree-check.sh
@@ -77,25 +77,51 @@ fi
 
 upstream_commit="$(git rev-parse "${upstream_commit}^{commit}")"
 upstream_tree="$(git show -s --format=%T "${upstream_commit}")"
-metadata_split="$(
+metadata_commit="$(
   git log \
     --grep="^git-subtree-dir: ${PREFIX}/*$" \
-    --pretty=format:%B \
-    HEAD |
-  awk '/^git-subtree-split: / {print $2; exit}'
+    --format=%H \
+    -n 1 \
+    HEAD
 )"
+metadata_split=""
+metadata_tree=""
+if [[ -n "${metadata_commit}" ]]; then
+  metadata_split="$(
+    git show -s --format=%B "${metadata_commit}" |
+    awk '/^git-subtree-split: / {print $2; exit}'
+  )"
+  metadata_tree="$(git rev-parse "${metadata_commit}:${PREFIX}" 2>/dev/null || true)"
+fi
 
 echo "${PREFIX} in HEAD currently refers to tree ${current_tree}"
 echo "${REMOTE_URL} ${REMOTE_REF} resolves to commit ${upstream_commit} tree ${upstream_tree}"
+
+if [[ -z "${metadata_commit}" ]]; then
+  echo "FAIL: subtree metadata missing: no git-subtree-dir entry found for ${PREFIX}" >&2
+  exit 1
+fi
 
 if [[ -z "${metadata_split}" ]]; then
   echo "FAIL: subtree metadata missing: no git-subtree-split entry found for ${PREFIX}" >&2
   exit 1
 fi
 
+if [[ -z "${metadata_tree}" ]]; then
+  echo "FAIL: subtree import commit ${metadata_commit} lacks ${PREFIX}" >&2
+  exit 1
+fi
+
+echo "${PREFIX} latest git-subtree import commit is ${metadata_commit} tree ${metadata_tree}"
 echo "${PREFIX} latest git-subtree-split is ${metadata_split}"
 if [[ "${metadata_split}" != "${upstream_commit}" ]]; then
   echo "FAIL: subtree split ${metadata_split} does not match upstream tag commit ${upstream_commit}" >&2
+  exit 1
+fi
+
+if [[ "${current_tree}" != "${metadata_tree}" ]]; then
+  git diff --stat "${metadata_tree}" "${current_tree}" >&2 || true
+  echo "FAIL: ${PREFIX} tree differs from latest subtree import commit ${metadata_commit}" >&2
   exit 1
 fi
 

--- a/test/lint/lint-libbitcoinpqc-vectors.py
+++ b/test/lint/lint-libbitcoinpqc-vectors.py
@@ -6,9 +6,9 @@
 #
 # Verify bounded30 SPHINCS+ wiring in src/libbitcoinpqc/sphincsplus.
 #
-# The curated qbit subtree prunes the upstream NIST KAT generator payload. When
+# The current upstream tag does not carry the NIST KAT generator payload. When
 # those sources are absent, fall back to static bounded30 guard checks instead
-# of treating the prune as a lint failure.
+# of treating that absence as a lint failure.
 
 import subprocess
 import sys
@@ -35,11 +35,11 @@ def kat_generator_state(sphincs_dir: Path, implementation: str) -> str | None:
     if len(existing) == len(KAT_GENERATOR_FILES):
         return "present"
     if not existing:
-        return "pruned"
+        return "absent"
 
     missing = [name for name in KAT_GENERATOR_FILES if name not in existing]
     print(
-        f"{impl_dir} has a partially pruned KAT generator payload.",
+        f"{impl_dir} has a partially present KAT generator payload.",
         flush=True,
     )
     print(f"  present: {', '.join(existing)}", flush=True)
@@ -82,10 +82,10 @@ def main() -> None:
         state = kat_generator_state(sphincs_dir, implementation)
         if state == "present":
             ok &= run_vector_check(sphincs_dir, instance, implementation)
-        elif state == "pruned":
+        elif state == "absent":
             print(
-                "Skipping SPHINCS+ vector regeneration because the curated "
-                f"subtree prunes KAT generator sources from {implementation}.",
+                "Skipping SPHINCS+ vector regeneration because the upstream "
+                f"tag does not include KAT generator sources for {implementation}.",
                 flush=True,
             )
         else:

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -242,6 +242,10 @@ fn lint_subtree() -> LintResult {
             .expect("command_error")
             .success();
     }
+    good &= Command::new("test/lint/libbitcoinpqc-subtree-check.sh")
+        .status()
+        .expect("command_error")
+        .success();
     if good {
         Ok(())
     } else {


### PR DESCRIPTION
## Summary

- replace the stale curated/pruned libbitcoinpqc subtree checklist wording with the direct tagged import flow
- add `test/lint/libbitcoinpqc-subtree-check.sh` to compare `HEAD:src/libbitcoinpqc`, the peeled upstream tag tree, and the recorded `git-subtree-split`
- wire the new verifier into the subtree lint runner, update helper, scanner provenance, TSAN evidence metadata, fuzz mapping, and subtree docs

## Testing

- `docker run --rm -v /Users/miller/conductor:/Users/miller/conductor -w /Users/miller/conductor/workspaces/qbit-v1/budapest-v1 bitcoin-linter bash -lc 'git config --global --add safe.directory /Users/miller/conductor/workspaces/qbit-v1/budapest-v1 && ./ci/lint/06_script.sh'`
- `git diff --check`

## Notes

The signed commit verifies locally with GPG key `289EA3EC2F1939A24984840ED26CFC05586D371E`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785334817&installation_id=141183937&pr_number=41&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F41&signature=096a1351b148e79319d4256fc82f0200df500d203411fe67c7e1b852ae6958b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes crypto vendoring provenance and CI/scanner gates for `src/libbitcoinpqc`; mistakes could allow a mismatched or untagged tree while the rest of the repo still builds.
> 
> **Overview**
> Moves **libbitcoinpqc** provenance from the old **curated `qbit-subtree` / `libbitcoinpqc-qbit`** model to **direct imports from `Qbit-Org/qbit-libbitcoinpqc` release tags** (default **`v0.3.0`**).
> 
> Adds **`test/lint/libbitcoinpqc-subtree-check.sh`**, which fetches the pinned tag, peels it to a commit, and checks that **`HEAD:src/libbitcoinpqc`**, the latest **`git-subtree-split`**, and the upstream tag tree all match. That script replaces **`git-subtree-check.sh -r`** in the update helper, lint runner, PR checklist, and docs.
> 
> **`contrib/devtools/update-libbitcoinpqc-subtree.sh`** now **fails** if `git ls-remote` cannot resolve the tag and always runs the new check with **`LIBBITCOINPQC_REMOTE_*`** env overrides. **TSAN evidence** drops the curated-subtree ref validation and records **`subtree_source_ref`** instead.
> 
> **`ci/scanners/run-scanners.py`** provenance is retargeted to the tagged upstream: peeled-tag lookup, strict split-vs-tag equality, tree comparisons against import and tag commits, and authenticated invocation of the new verifier. **`ci/scanners/test_run_scanners.py`** adds unit tests for tag peeling and provenance gaps.
> 
> Docs, fuzz mapping, and vector lint wording are updated to match the tag-based flow (no “pruned curated subtree” assumptions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 431409fd7794295034cff764ef57bbe2858b23a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->