### PR TITLE
Fix PQC data-hash counter accounting

### DIFF
--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -9,6 +9,7 @@
 #include <script/signingprovider.h>
 
 #include <logging.h>
+#include <util/strencodings.h>
 #include <util/signing_timing.h>
 #include <util/time.h>
 
@@ -59,6 +60,12 @@ bool HidingSigningProvider::CanSignPQC(const CPQCPubKey& pubkey) const
 {
     if (m_hide_secret) return false;
     return m_provider->CanSignPQC(pubkey);
+}
+
+bool HidingSigningProvider::IsPQCSignatureCounterExhausted(const CPQCPubKey& pubkey) const
+{
+    if (m_hide_secret) return false;
+    return m_provider->IsPQCSignatureCounterExhausted(pubkey);
 }
 
 bool HidingSigningProvider::SignPQC(const CPQCPubKey& pubkey, const uint256& hash, std::vector<unsigned char>& sig) const
@@ -121,6 +128,18 @@ bool FlatSigningProvider::CanSignPQC(const CPQCPubKey& pubkey) const
     const uint32_t previous_counter = counter_it != pqc_sig_counters.end() ? counter_it->second : 0;
     return previous_counter < PQC_MAX_SIGNATURES;
 }
+
+bool FlatSigningProvider::IsPQCSignatureCounterExhausted(const CPQCPubKey& pubkey) const
+{
+    CPQCKey key;
+    if (!LookupHelper(pqc_keys, pubkey, key)) return false;
+    if (!key.IsValid()) return false;
+
+    const auto counter_it = pqc_sig_counters.find(pubkey);
+    const uint32_t previous_counter = counter_it != pqc_sig_counters.end() ? counter_it->second : 0;
+    return previous_counter >= PQC_MAX_SIGNATURES;
+}
+
 bool FlatSigningProvider::SignPQC(const CPQCPubKey& pubkey, const uint256& hash, std::vector<unsigned char>& sig) const
 {
     const bool timing_enabled{util::signing_timing::Enabled() && util::signing_timing::CurrentId() != 0};
@@ -165,6 +184,15 @@ bool FlatSigningProvider::SignPQC(const CPQCPubKey& pubkey, const uint256& hash,
     uint32_t reserved_previous_counter = previous_counter;
     uint32_t reserved_counter = previous_counter + 1;
     uint32_t counter = previous_counter;
+    bool committed_reservation{false};
+    const auto observe_counter_advance = [&](uint32_t observed_previous_counter, uint32_t observed_reserved_counter) {
+        pqc_sig_counters[pubkey] = observed_reserved_counter;
+        if (pqc_counter_observer) {
+            const auto observer_start{SteadyClock::now()};
+            pqc_counter_observer(pubkey, observed_previous_counter, observed_reserved_counter);
+            observer_time += SteadyClock::now() - observer_start;
+        }
+    };
     if (previous_counter >= PQC_MAX_SIGNATURES) {
         log_pqc_sign_timing(/*success=*/false, "limit_exceeded");
         return false;
@@ -185,6 +213,11 @@ bool FlatSigningProvider::SignPQC(const CPQCPubKey& pubkey, const uint256& hash,
             return false;
         }
         counter = reserved_previous_counter;
+        committed_reservation = true;
+        // Wallet-backed reservations have already been durably committed by
+        // the reserver. Treat that counter range as consumed even if the raw
+        // signer fails below; reusing it would be less safe than overcounting.
+        observe_counter_advance(reserved_previous_counter, reserved_counter);
     } else if (pqc_counter_writer) {
         // Reserve exactly one counter value in authoritative storage first.
         const auto reserve_start{SteadyClock::now()};
@@ -197,13 +230,19 @@ bool FlatSigningProvider::SignPQC(const CPQCPubKey& pubkey, const uint256& hash,
     }
 
     const auto raw_sign_start{SteadyClock::now()};
-    const bool signed_ok = key.Sign(hash, sig, counter);
+    const bool signed_ok = pqc_raw_signer ? pqc_raw_signer(key, hash, sig, counter) : key.Sign(hash, sig, counter);
     raw_sign_time = SteadyClock::now() - raw_sign_start;
     if (!signed_ok || counter != reserved_counter) {
         if (signed_ok) {
             LogPrintf("%s: PQC signer returned unexpected counter %u (expected %u)\n", __func__, counter, reserved_counter);
         }
-        if (pqc_counter_writer && !pqc_counter_reserver) {
+        if (committed_reservation) {
+            LogPrintf("%s: PQC signing failed after committed counter reservation for pubkey %s [%u, %u)\n",
+                __func__,
+                HexStr(std::span<const unsigned char>{pubkey.begin(), pubkey.end()}),
+                reserved_previous_counter,
+                reserved_counter);
+        } else if (pqc_counter_writer && !pqc_counter_reserver) {
             // Best-effort rollback of reservation if signing failed.
             const auto rollback_start{SteadyClock::now()};
             if (!pqc_counter_writer(pubkey, reserved_counter, previous_counter)) {
@@ -221,11 +260,8 @@ bool FlatSigningProvider::SignPQC(const CPQCPubKey& pubkey, const uint256& hash,
         return false;
     }
 
-    pqc_sig_counters[pubkey] = reserved_counter;
-    if (pqc_counter_observer) {
-        const auto observer_start{SteadyClock::now()};
-        pqc_counter_observer(pubkey, reserved_previous_counter, reserved_counter);
-        observer_time = SteadyClock::now() - observer_start;
+    if (!committed_reservation) {
+        observe_counter_advance(reserved_previous_counter, reserved_counter);
     }
     log_pqc_sign_timing(/*success=*/true, "ok");
     return true;
@@ -290,6 +326,9 @@ FlatSigningProvider& FlatSigningProvider::Merge(FlatSigningProvider&& b)
     }
     if (!pqc_counter_observer && b.pqc_counter_observer) {
         pqc_counter_observer = std::move(b.pqc_counter_observer);
+    }
+    if (!pqc_raw_signer && b.pqc_raw_signer) {
+        pqc_raw_signer = std::move(b.pqc_raw_signer);
     }
     p2mr_pubkeys.merge(b.p2mr_pubkeys);
     for (auto& [output, spenddata] : b.p2mr_spenddata) {
@@ -493,6 +532,14 @@ bool MultiSigningProvider::CanSignPQC(const CPQCPubKey& pubkey) const
 {
     for (const auto& provider : m_providers) {
         if (provider->CanSignPQC(pubkey)) return true;
+    }
+    return false;
+}
+
+bool MultiSigningProvider::IsPQCSignatureCounterExhausted(const CPQCPubKey& pubkey) const
+{
+    for (const auto& provider : m_providers) {
+        if (provider->IsPQCSignatureCounterExhausted(pubkey)) return true;
     }
     return false;
 }

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -32,6 +32,7 @@ struct ShortestVectorFirstComparator
 
 using PQCSignatureCounterObserver = std::function<void(const CPQCPubKey&, uint32_t, uint32_t)>;
 using PQCSignatureCounterReserver = std::function<bool(const CPQCPubKey&, uint32_t, uint32_t&, uint32_t&)>;
+using PQCRawSigner = std::function<bool(const CPQCKey&, const uint256&, std::vector<unsigned char>&, uint32_t&)>;
 
 struct PQCSignatureCounterRange {
     CPQCPubKey pubkey;
@@ -217,6 +218,7 @@ public:
     virtual bool GetKey(const CKeyID &address, CKey& key) const { return false; }
     virtual bool GetPQCKey(const CPQCPubKey& pubkey, CPQCKey& key) const { return false; }
     virtual bool CanSignPQC(const CPQCPubKey& pubkey) const { return false; }
+    virtual bool IsPQCSignatureCounterExhausted(const CPQCPubKey& pubkey) const { return false; }
     virtual bool SignPQC(const CPQCPubKey& pubkey, const uint256& hash, std::vector<unsigned char>& sig) const;
     virtual bool HaveKey(const CKeyID &address) const { return false; }
     virtual bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const { return false; }
@@ -267,6 +269,7 @@ public:
     bool GetKey(const CKeyID& keyid, CKey& key) const override;
     bool GetPQCKey(const CPQCPubKey& pubkey, CPQCKey& key) const override;
     bool CanSignPQC(const CPQCPubKey& pubkey) const override;
+    bool IsPQCSignatureCounterExhausted(const CPQCPubKey& pubkey) const override;
     bool SignPQC(const CPQCPubKey& pubkey, const uint256& hash, std::vector<unsigned char>& sig) const override;
     bool GetKeyOrigin(const CKeyID& keyid, KeyOriginInfo& info) const override;
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
@@ -288,6 +291,7 @@ struct FlatSigningProvider final : public SigningProvider
     PQCSignatureCounterReserver pqc_counter_reserver;
     PQCSignatureCounterBatchReserver pqc_counter_batch_reserver;
     PQCSignatureCounterObserver pqc_counter_observer;
+    PQCRawSigner pqc_raw_signer;
     std::map<uint32_t, CPQCPubKey> p2mr_pubkeys; /** Map key expression index -> derived P2MR pubkey */
     std::map<WitnessV2P2MR, P2MRSpendData> p2mr_spenddata; /** Map from output key to raw P2MR spend data */
     std::map<XOnlyPubKey, TaprootBuilder> tr_trees; /** Map from output key to Taproot tree (which can then make the TaprootSpendData */
@@ -301,6 +305,7 @@ struct FlatSigningProvider final : public SigningProvider
     bool GetKey(const CKeyID& keyid, CKey& key) const override;
     bool GetPQCKey(const CPQCPubKey& pubkey, CPQCKey& key) const override;
     bool CanSignPQC(const CPQCPubKey& pubkey) const override;
+    bool IsPQCSignatureCounterExhausted(const CPQCPubKey& pubkey) const override;
     bool SignPQC(const CPQCPubKey& pubkey, const uint256& hash, std::vector<unsigned char>& sig) const override;
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;
@@ -400,6 +405,7 @@ public:
     bool GetKey(const CKeyID& keyid, CKey& key) const override;
     bool GetPQCKey(const CPQCPubKey& pubkey, CPQCKey& key) const override;
     bool CanSignPQC(const CPQCPubKey& pubkey) const override;
+    bool IsPQCSignatureCounterExhausted(const CPQCPubKey& pubkey) const override;
     bool SignPQC(const CPQCPubKey& pubkey, const uint256& hash, std::vector<unsigned char>& sig) const override;
     bool GetTaprootSpendData(const XOnlyPubKey& output_key, TaprootSpendData& spenddata) const override;
     bool GetTaprootBuilder(const XOnlyPubKey& output_key, TaprootBuilder& builder) const override;

--- a/src/test/pqc_tests.cpp
+++ b/src/test/pqc_tests.cpp
@@ -498,6 +498,45 @@ BOOST_AUTO_TEST_CASE(pqc_signing_provider_reserves_authoritative_counter)
     BOOST_CHECK(observed_ranges[1] == std::make_pair(1U, 2U));
 }
 
+BOOST_AUTO_TEST_CASE(pqc_signing_provider_reports_committed_reservation_on_sign_failure)
+{
+    CPQCKey key;
+    key.MakeNewKey();
+    const CPQCPubKey pubkey = key.GetPubKey();
+
+    uint32_t authoritative_counter{0};
+
+    FlatSigningProvider provider;
+    provider.pqc_keys.emplace(pubkey, key);
+    provider.pqc_sig_counters.emplace(pubkey, 0);
+    provider.pqc_counter_reserver = [&](const CPQCPubKey& seen_pubkey, uint32_t count, uint32_t& previous_counter, uint32_t& reserved_counter) {
+        BOOST_CHECK(seen_pubkey == pubkey);
+        BOOST_CHECK_EQUAL(count, 1U);
+        previous_counter = authoritative_counter;
+        reserved_counter = authoritative_counter + count;
+        authoritative_counter = reserved_counter;
+        return true;
+    };
+
+    std::vector<std::pair<uint32_t, uint32_t>> observed_ranges;
+    provider.pqc_counter_observer = [&](const CPQCPubKey& seen_pubkey, uint32_t previous_counter, uint32_t reserved_counter) {
+        BOOST_CHECK(seen_pubkey == pubkey);
+        observed_ranges.emplace_back(previous_counter, reserved_counter);
+    };
+    provider.pqc_raw_signer = [&](const CPQCKey&, const uint256&, std::vector<unsigned char>& sig, uint32_t&) {
+        sig.assign(PQC_SIG_SIZE, 0x42);
+        return false;
+    };
+
+    std::vector<unsigned char> sig;
+    BOOST_CHECK(!provider.SignPQC(pubkey, TestHash("pqc_signing_provider_reports_committed_reservation_on_sign_failure"), sig));
+    BOOST_CHECK(sig.empty());
+    BOOST_CHECK_EQUAL(authoritative_counter, 1U);
+    BOOST_CHECK_EQUAL(provider.pqc_sig_counters[pubkey], 1U);
+    BOOST_REQUIRE_EQUAL(observed_ranges.size(), 1U);
+    BOOST_CHECK(observed_ranges[0] == std::make_pair(0U, 1U));
+}
+
 #ifdef ENABLE_WALLET
 BOOST_AUTO_TEST_CASE(pqc_usage_level_boundaries)
 {

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -9,6 +9,7 @@
 #include <rpc/util.h>
 #include <script/interpreter.h>
 #include <util/strencodings.h>
+#include <util/translation.h>
 #include <wallet/pqc_usage.h>
 #include <wallet/rpc/util.h>
 #include <wallet/wallet.h>
@@ -67,6 +68,18 @@ void EnsurePQCKeyValidationReadyForSigning(const CWallet& wallet)
     }
     if (info.failed_records > 0) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Error: plaintext PQC wallet key validation failed. Wallet signing is disabled until the wallet is restored or repaired.");
+    }
+}
+
+void LogConsumedPQCDataHashCounters(const CWallet& wallet, const PQCUsageRecorder& recorder, const bilingual_str& error)
+{
+    for (const PQCUsageAdvance& advance : recorder.GetAdvances()) {
+        wallet.WalletLogPrintf(
+            "PQC data-hash signing consumed counter for pubkey %s [%u, %u) before failing: %s\n",
+            HexStr(std::span<const unsigned char>{advance.pubkey.begin(), advance.pubkey.end()}),
+            advance.previous_count,
+            advance.new_count,
+            error.original);
     }
 }
 
@@ -219,11 +232,13 @@ RPCHelpMan signdatapqchash()
             PQCUsageRecorder pqc_usage_recorder;
             util::Result<DataPQCSignatureProof> proof{pwallet->SignDataPQCHash(
                 *output, message_hash, requested_pubkey, requested_leaf_script, requested_control_block, pqc_usage_recorder.GetObserver())};
-            if (!proof) {
-                throw JSONRPCError(RPC_WALLET_ERROR, util::ErrorString(proof).original);
-            }
             const PQCUsageReport pqc_usage{BuildSigningPQCUsageReport(pqc_usage_recorder)};
             LogPQCUsageWarnings(*pwallet, pqc_usage);
+            if (!proof) {
+                const bilingual_str error{util::ErrorString(proof)};
+                LogConsumedPQCDataHashCounters(*pwallet, pqc_usage_recorder, error);
+                throw JSONRPCError(RPC_WALLET_ERROR, error.original);
+            }
 
             UniValue result{UniValue::VOBJ};
             result.pushKV("address", address);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2504,6 +2504,7 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
 
     bool found_matching_leaf{false};
     bool found_signable_key{false};
+    bool found_exhausted_key{false};
     bool signing_failed{false};
     const std::vector<unsigned char> requested_leaf_bytes = requested_leaf_script ?
         std::vector<unsigned char>{requested_leaf_script->begin(), requested_leaf_script->end()} :
@@ -2525,7 +2526,10 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
         if (!control_block) continue;
 
         found_matching_leaf = true;
-        if (!provider.CanSignPQC(*pubkey)) continue;
+        if (!provider.CanSignPQC(*pubkey)) {
+            if (provider.IsPQCSignatureCounterExhausted(*pubkey)) found_exhausted_key = true;
+            continue;
+        }
         found_signable_key = true;
 
         std::vector<unsigned char> signature;
@@ -2546,6 +2550,9 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
         return proof;
     }
 
+    if (found_matching_leaf && found_exhausted_key && !found_signable_key) {
+        return util::Error{_("PQC signature budget is exhausted for the selected P2MR pubkey leaf")};
+    }
     if (found_matching_leaf && !found_signable_key) {
         return util::Error{_("Private key is not available for the selected P2MR pubkey leaf")};
     }

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2507,6 +2507,7 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
     bool found_exhausted_key{false};
     bool found_unavailable_key{false};
     bool signing_failed{false};
+    bool signing_failed_after_exhaustion{false};
     const std::vector<unsigned char> requested_leaf_bytes = requested_leaf_script ?
         std::vector<unsigned char>{requested_leaf_script->begin(), requested_leaf_script->end()} :
         std::vector<unsigned char>{};
@@ -2540,6 +2541,9 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
         std::vector<unsigned char> signature;
         if (!provider.SignPQC(*pubkey, datasig_hash, signature)) {
             signing_failed = true;
+            if (provider.IsPQCSignatureCounterExhausted(*pubkey)) {
+                signing_failed_after_exhaustion = true;
+            }
             continue;
         }
 
@@ -2562,6 +2566,9 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
         return util::Error{_("Private key is not available for the selected P2MR pubkey leaf")};
     }
     if (signing_failed) {
+        if (signing_failed_after_exhaustion && !found_unavailable_key) {
+            return util::Error{_("PQC signature budget is exhausted for the selected P2MR pubkey leaf")};
+        }
         return util::Error{_("PQC data-hash signing failed")};
     }
     return util::Error{_("No supported single-key P2MR pubkey leaf was found for this address")};

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -2505,6 +2505,7 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
     bool found_matching_leaf{false};
     bool found_signable_key{false};
     bool found_exhausted_key{false};
+    bool found_unavailable_key{false};
     bool signing_failed{false};
     const std::vector<unsigned char> requested_leaf_bytes = requested_leaf_script ?
         std::vector<unsigned char>{requested_leaf_script->begin(), requested_leaf_script->end()} :
@@ -2527,7 +2528,11 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
 
         found_matching_leaf = true;
         if (!provider.CanSignPQC(*pubkey)) {
-            if (provider.IsPQCSignatureCounterExhausted(*pubkey)) found_exhausted_key = true;
+            if (provider.IsPQCSignatureCounterExhausted(*pubkey)) {
+                found_exhausted_key = true;
+            } else {
+                found_unavailable_key = true;
+            }
             continue;
         }
         found_signable_key = true;
@@ -2550,10 +2555,10 @@ util::Result<DataPQCSignatureProof> SignP2MRDataHash(
         return proof;
     }
 
-    if (found_matching_leaf && found_exhausted_key && !found_signable_key) {
-        return util::Error{_("PQC signature budget is exhausted for the selected P2MR pubkey leaf")};
-    }
     if (found_matching_leaf && !found_signable_key) {
+        if (found_exhausted_key && !found_unavailable_key) {
+            return util::Error{_("PQC signature budget is exhausted for the selected P2MR pubkey leaf")};
+        }
         return util::Error{_("Private key is not available for the selected P2MR pubkey leaf")};
     }
     if (signing_failed) {

--- a/src/wallet/test/wallet_p2mr_descriptor_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_descriptor_tests.cpp
@@ -383,6 +383,109 @@ BOOST_AUTO_TEST_CASE(P2MRDataHashSigningDistinguishesExhaustedPQCKey)
     BOOST_CHECK(recorder.Empty());
 }
 
+BOOST_AUTO_TEST_CASE(P2MRDataHashSigningPrefersMissingKeyOverMixedExhaustion)
+{
+    CPQCKey exhausted_key;
+    CPQCKey missing_key;
+    exhausted_key.MakeNewKey();
+    missing_key.MakeNewKey();
+
+    const CPQCPubKey exhausted_pubkey{exhausted_key.GetPubKey()};
+    const CPQCPubKey missing_pubkey{missing_key.GetPubKey()};
+    const CScript exhausted_leaf{p2mr::BuildPKScript(exhausted_pubkey)};
+    const CScript missing_leaf{p2mr::BuildPKScript(missing_pubkey)};
+
+    TaprootBuilder builder;
+    builder.AddP2MR(/*depth=*/1, ToBytes(exhausted_leaf), P2MR_LEAF_VERSION_V1)
+        .AddP2MR(/*depth=*/1, ToBytes(missing_leaf), P2MR_LEAF_VERSION_V1)
+        .FinalizeP2MR();
+    const WitnessV2P2MR output{builder.GetP2MROutput()};
+
+    FlatSigningProvider provider;
+    AddPQCSigningKeyForTest(provider, exhausted_key);
+    provider.pqc_sig_counters[exhausted_pubkey] = PQC_MAX_SIGNATURES;
+    provider.mr_trees.emplace(output, builder);
+
+    PQCUsageRecorder recorder;
+    provider.pqc_counter_observer = recorder.GetObserver();
+
+    const util::Result<DataPQCSignatureProof> proof{SignP2MRDataHash(
+        provider, output, uint256::ONE, std::nullopt, std::nullopt, std::nullopt)};
+
+    BOOST_CHECK(!proof);
+    BOOST_CHECK_EQUAL(util::ErrorString(proof).original, "Private key is not available for the selected P2MR pubkey leaf");
+    BOOST_CHECK(recorder.Empty());
+}
+
+BOOST_AUTO_TEST_CASE(P2MRWalletDataHashSigningReportsNearLimitExhaustion)
+{
+    auto wallet = CreateDescriptorWallet(*m_node.chain, P2MR_ONLY_OUTPUT_TYPES, SINGLE_ADDRESS_KEYPOOL_SIZE);
+
+    DescriptorScriptPubKeyMan* p2mr_spk_man{nullptr};
+    CScript p2mr_script;
+    {
+        LOCK(wallet->cs_wallet);
+        p2mr_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false));
+    }
+    BOOST_REQUIRE(p2mr_spk_man);
+
+    {
+        LOCK(p2mr_spk_man->cs_desc_man);
+        const WalletDescriptor wallet_descriptor = p2mr_spk_man->GetWalletDescriptor();
+        std::vector<CScript> scripts;
+        FlatSigningProvider out_keys;
+        BOOST_REQUIRE(wallet_descriptor.descriptor->ExpandFromCache(/*pos=*/0, wallet_descriptor.cache, scripts, out_keys));
+        BOOST_REQUIRE_EQUAL(scripts.size(), 1U);
+        p2mr_script = scripts.at(0);
+    }
+
+    std::vector<std::vector<unsigned char>> solutions;
+    BOOST_REQUIRE_EQUAL(Solver(p2mr_script, solutions), TxoutType::WITNESS_V2_P2MR);
+    const WitnessV2P2MR output{std::span<const unsigned char>{solutions.at(0)}};
+    const CachedP2MRPubKeys pubkeys{GetCachedP2MRPubKeys(*p2mr_spk_man, /*pos=*/0)};
+
+    auto provider{p2mr_spk_man->GetSigningProvider(pubkeys.pqc_pubkey)};
+    BOOST_REQUIRE(provider);
+    uint32_t previous_counter{0};
+    uint32_t reserved_counter{0};
+    BOOST_REQUIRE(provider->pqc_counter_reserver(pubkeys.pqc_pubkey, PQC_MAX_SIGNATURES - 1, previous_counter, reserved_counter));
+    BOOST_CHECK_EQUAL(previous_counter, 0U);
+    BOOST_CHECK_EQUAL(reserved_counter, PQC_MAX_SIGNATURES - 1);
+    BOOST_CHECK_EQUAL(GetProviderPQCCounter(*p2mr_spk_man, pubkeys.descriptor_pubkey, pubkeys.pqc_pubkey), PQC_MAX_SIGNATURES - 1);
+
+    PQCUsageRecorder recorder;
+    const util::Result<DataPQCSignatureProof> proof{wallet->SignDataPQCHash(
+        output, uint256::ONE, std::nullopt, std::nullopt, std::nullopt, recorder.GetObserver())};
+    BOOST_REQUIRE_MESSAGE(proof, util::ErrorString(proof).original);
+    BOOST_CHECK(proof->pubkey == pubkeys.pqc_pubkey);
+    BOOST_CHECK_EQUAL(proof->signature.size(), PQC_SIG_SIZE);
+
+    const PQCUsageReport report{BuildSigningPQCUsageReport(recorder)};
+    BOOST_REQUIRE(report.overall_state.has_value());
+    BOOST_CHECK(*report.overall_state == PQCSignatureLimitState::EXHAUSTED);
+    BOOST_REQUIRE_EQUAL(report.key_states.size(), 1U);
+    const PQCUsageSnapshot& snapshot{report.key_states.front()};
+    BOOST_CHECK(snapshot.pubkey == pubkeys.pqc_pubkey);
+    BOOST_CHECK_EQUAL(snapshot.signature_count, PQC_MAX_SIGNATURES);
+    BOOST_CHECK_EQUAL(snapshot.signature_limit, PQC_MAX_SIGNATURES);
+    BOOST_CHECK_EQUAL(snapshot.signatures_remaining, 0U);
+    BOOST_CHECK(snapshot.limit_state == PQCSignatureLimitState::EXHAUSTED);
+
+    const std::vector<bilingual_str> warnings{FormatPQCUsageWarnings(report.warnings)};
+    BOOST_REQUIRE_EQUAL(warnings.size(), 1U);
+    BOOST_CHECK(warnings.front().original.find("reached the signature limit") != std::string::npos);
+    BOOST_CHECK(warnings.front().original.find("0 remaining") != std::string::npos);
+    BOOST_CHECK_EQUAL(GetProviderPQCCounter(*p2mr_spk_man, pubkeys.descriptor_pubkey, pubkeys.pqc_pubkey), PQC_MAX_SIGNATURES);
+
+    PQCUsageRecorder exhausted_recorder;
+    const util::Result<DataPQCSignatureProof> exhausted_proof{wallet->SignDataPQCHash(
+        output, uint256::ONE, std::nullopt, std::nullopt, std::nullopt, exhausted_recorder.GetObserver())};
+    BOOST_CHECK(!exhausted_proof);
+    BOOST_CHECK_EQUAL(util::ErrorString(exhausted_proof).original, "PQC signature budget is exhausted for the selected P2MR pubkey leaf");
+    BOOST_CHECK(exhausted_recorder.Empty());
+    BOOST_CHECK_EQUAL(GetProviderPQCCounter(*p2mr_spk_man, pubkeys.descriptor_pubkey, pubkeys.pqc_pubkey), PQC_MAX_SIGNATURES);
+}
+
 BOOST_FIXTURE_TEST_CASE(NonRangedP2MRDescriptorDoesNotDeriveUnrelatedPQCKeys, TestingSetup)
 {
     CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());

--- a/src/wallet/test/wallet_p2mr_descriptor_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_descriptor_tests.cpp
@@ -356,6 +356,59 @@ BOOST_AUTO_TEST_CASE(P2MRDataHashSigningReportsCommittedFailedLeafReservation)
     BOOST_CHECK(reported_pubkeys.contains(second_pubkey));
 }
 
+BOOST_AUTO_TEST_CASE(P2MRDataHashSigningReportsFinalSlotFailureAsExhausted)
+{
+    CPQCKey key;
+    key.MakeNewKey();
+    const CPQCPubKey pubkey{key.GetPubKey()};
+    const CScript leaf{p2mr::BuildPKScript(pubkey)};
+
+    TaprootBuilder builder;
+    builder.AddP2MR(/*depth=*/0, ToBytes(leaf), P2MR_LEAF_VERSION_V1).FinalizeP2MR();
+    const WitnessV2P2MR output{builder.GetP2MROutput()};
+
+    FlatSigningProvider provider;
+    AddPQCSigningKeyForTest(provider, key);
+    provider.pqc_sig_counters[pubkey] = PQC_MAX_SIGNATURES - 1;
+    provider.mr_trees.emplace(output, builder);
+
+    uint32_t authoritative_counter{PQC_MAX_SIGNATURES - 1};
+    provider.pqc_counter_reserver = [&](const CPQCPubKey& reserved_pubkey, uint32_t count, uint32_t& previous_counter, uint32_t& reserved_counter) {
+        BOOST_CHECK(reserved_pubkey == pubkey);
+        BOOST_CHECK_EQUAL(count, 1U);
+        previous_counter = authoritative_counter;
+        reserved_counter = previous_counter + count;
+        authoritative_counter = reserved_counter;
+        return true;
+    };
+
+    PQCUsageRecorder recorder;
+    provider.pqc_counter_observer = recorder.GetObserver();
+    provider.pqc_raw_signer = [&](const CPQCKey& raw_key, const uint256&, std::vector<unsigned char>& sig, uint32_t&) {
+        BOOST_CHECK(raw_key.GetPubKey() == pubkey);
+        sig.clear();
+        return false;
+    };
+
+    const util::Result<DataPQCSignatureProof> proof{SignP2MRDataHash(
+        provider, output, uint256::ONE, std::nullopt, std::nullopt, std::nullopt)};
+
+    BOOST_CHECK(!proof);
+    BOOST_CHECK_EQUAL(util::ErrorString(proof).original, "PQC signature budget is exhausted for the selected P2MR pubkey leaf");
+    BOOST_CHECK_EQUAL(authoritative_counter, PQC_MAX_SIGNATURES);
+    BOOST_CHECK_EQUAL(provider.pqc_sig_counters.at(pubkey), PQC_MAX_SIGNATURES);
+
+    const PQCUsageReport report{BuildSigningPQCUsageReport(recorder)};
+    BOOST_REQUIRE(report.overall_state.has_value());
+    BOOST_CHECK(*report.overall_state == PQCSignatureLimitState::EXHAUSTED);
+    BOOST_REQUIRE_EQUAL(report.key_states.size(), 1U);
+    const PQCUsageSnapshot& snapshot{report.key_states.front()};
+    BOOST_CHECK(snapshot.pubkey == pubkey);
+    BOOST_CHECK_EQUAL(snapshot.signature_count, PQC_MAX_SIGNATURES);
+    BOOST_CHECK_EQUAL(snapshot.signatures_remaining, 0U);
+    BOOST_CHECK(snapshot.limit_state == PQCSignatureLimitState::EXHAUSTED);
+}
+
 BOOST_AUTO_TEST_CASE(P2MRDataHashSigningDistinguishesExhaustedPQCKey)
 {
     CPQCKey key;

--- a/src/wallet/test/wallet_p2mr_descriptor_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_descriptor_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <test/data/p2mr_datapqchash_vectors.json.h>
+#include <wallet/pqc_usage.h>
 #include <wallet/test/wallet_p2mr_test_util.h>
 
 #include <span>
@@ -281,6 +282,105 @@ BOOST_AUTO_TEST_CASE(P2MRDataHashSigningMatchesPinnedProofFixture)
     BOOST_CHECK(proof->control_block == control_block);
     BOOST_CHECK_EQUAL(proof->leaf_version, P2MR_LEAF_VERSION_V1);
     BOOST_CHECK_EQUAL(HexStr(proof->signature), vector["signature"].get_str());
+}
+
+BOOST_AUTO_TEST_CASE(P2MRDataHashSigningReportsCommittedFailedLeafReservation)
+{
+    CPQCKey first_key;
+    CPQCKey second_key;
+    first_key.MakeNewKey();
+    second_key.MakeNewKey();
+
+    CPQCPubKey first_pubkey{first_key.GetPubKey()};
+    CPQCPubKey second_pubkey{second_key.GetPubKey()};
+    CScript first_leaf{p2mr::BuildPKScript(first_pubkey)};
+    CScript second_leaf{p2mr::BuildPKScript(second_pubkey)};
+
+    if (ToBytes(second_leaf) < ToBytes(first_leaf)) {
+        std::swap(first_key, second_key);
+        std::swap(first_pubkey, second_pubkey);
+        std::swap(first_leaf, second_leaf);
+    }
+
+    TaprootBuilder builder;
+    builder.AddP2MR(/*depth=*/1, ToBytes(first_leaf), P2MR_LEAF_VERSION_V1)
+        .AddP2MR(/*depth=*/1, ToBytes(second_leaf), P2MR_LEAF_VERSION_V1)
+        .FinalizeP2MR();
+    const WitnessV2P2MR output{builder.GetP2MROutput()};
+
+    FlatSigningProvider provider;
+    AddPQCSigningKeyForTest(provider, first_key);
+    AddPQCSigningKeyForTest(provider, second_key);
+    provider.mr_trees.emplace(output, builder);
+
+    std::map<CPQCPubKey, uint32_t> authoritative_counters{{first_pubkey, 0}, {second_pubkey, 0}};
+    provider.pqc_counter_reserver = [&](const CPQCPubKey& pubkey, uint32_t count, uint32_t& previous_counter, uint32_t& reserved_counter) {
+        BOOST_CHECK_EQUAL(count, 1U);
+        auto counter_it{authoritative_counters.find(pubkey)};
+        BOOST_REQUIRE(counter_it != authoritative_counters.end());
+        previous_counter = counter_it->second;
+        reserved_counter = previous_counter + count;
+        counter_it->second = reserved_counter;
+        return true;
+    };
+
+    PQCUsageRecorder recorder;
+    provider.pqc_counter_observer = recorder.GetObserver();
+    provider.pqc_raw_signer = [&](const CPQCKey& key, const uint256& hash, std::vector<unsigned char>& sig, uint32_t& counter) {
+        if (key.GetPubKey() == first_pubkey) {
+            sig.clear();
+            return false;
+        }
+        return key.Sign(hash, sig, counter);
+    };
+
+    const uint256 message_hash{uint256::ONE};
+    const util::Result<DataPQCSignatureProof> proof{SignP2MRDataHash(
+        provider, output, message_hash, std::nullopt, std::nullopt, std::nullopt)};
+
+    BOOST_REQUIRE(proof);
+    BOOST_CHECK(proof->pubkey == second_pubkey);
+    BOOST_CHECK_EQUAL(authoritative_counters.at(first_pubkey), 1U);
+    BOOST_CHECK_EQUAL(authoritative_counters.at(second_pubkey), 1U);
+    BOOST_CHECK_EQUAL(provider.pqc_sig_counters.at(first_pubkey), 1U);
+    BOOST_CHECK_EQUAL(provider.pqc_sig_counters.at(second_pubkey), 1U);
+
+    const PQCUsageReport report{BuildSigningPQCUsageReport(recorder)};
+    BOOST_REQUIRE_EQUAL(report.key_states.size(), 2U);
+    std::set<CPQCPubKey> reported_pubkeys;
+    for (const PQCUsageSnapshot& snapshot : report.key_states) {
+        BOOST_CHECK_EQUAL(snapshot.signature_count, 1U);
+        reported_pubkeys.insert(snapshot.pubkey);
+    }
+    BOOST_CHECK(reported_pubkeys.contains(first_pubkey));
+    BOOST_CHECK(reported_pubkeys.contains(second_pubkey));
+}
+
+BOOST_AUTO_TEST_CASE(P2MRDataHashSigningDistinguishesExhaustedPQCKey)
+{
+    CPQCKey key;
+    key.MakeNewKey();
+    const CPQCPubKey pubkey{key.GetPubKey()};
+    const CScript leaf{p2mr::BuildPKScript(pubkey)};
+
+    TaprootBuilder builder;
+    builder.AddP2MR(/*depth=*/0, ToBytes(leaf), P2MR_LEAF_VERSION_V1).FinalizeP2MR();
+    const WitnessV2P2MR output{builder.GetP2MROutput()};
+
+    FlatSigningProvider provider;
+    AddPQCSigningKeyForTest(provider, key);
+    provider.pqc_sig_counters[pubkey] = PQC_MAX_SIGNATURES;
+    provider.mr_trees.emplace(output, builder);
+
+    PQCUsageRecorder recorder;
+    provider.pqc_counter_observer = recorder.GetObserver();
+
+    const util::Result<DataPQCSignatureProof> proof{SignP2MRDataHash(
+        provider, output, uint256::ONE, std::nullopt, std::nullopt, std::nullopt)};
+
+    BOOST_CHECK(!proof);
+    BOOST_CHECK_EQUAL(util::ErrorString(proof).original, "PQC signature budget is exhausted for the selected P2MR pubkey leaf");
+    BOOST_CHECK(recorder.Empty());
 }
 
 BOOST_FIXTURE_TEST_CASE(NonRangedP2MRDescriptorDoesNotDeriveUnrelatedPQCKeys, TestingSetup)

--- a/test/functional/wallet_pqc_usage.py
+++ b/test/functional/wallet_pqc_usage.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
 
 PQC_SIGNATURE_LIMIT = 1 << 30
@@ -199,6 +199,93 @@ class WalletPQCUsageTest(BitcoinTestFramework):
         assert_equal(signed_psbt["complete"], False)
         self.assert_pqc_fields(signed_psbt)
 
+    def test_signdatapqchash(self):
+        signer = self.create_wallet("pqc_hash_signer", load_on_startup=True)
+        address = signer.getnewaddress(address_type="p2mr")
+        self.wait_pqc_key_validation_ready(signer)
+        self.assert_pqc_signature_count(signer, address, 0)
+
+        proof = signer.signdatapqchash(address, "55" * 32)
+        assert_equal(proof["address"], address)
+        self.assert_pqc_fields(proof, min_signature_count=1)
+        assert_equal(proof["pqc_signature_count"], 1)
+        assert_equal(proof["pqc_key_states"][0]["pubkey"], proof["pubkey"])
+        self.assert_pqc_signature_count(signer, address, 1)
+
+        hidden_usage = signer.signdatapqchash(address, "56" * 32, {"include_pqc_usage": False})
+        self.assert_no_pqc_fields(hidden_usage)
+        self.assert_pqc_signature_count(signer, address, 2)
+
+        assert_raises_rpc_error(
+            -4,
+            "No supported single-key P2MR pubkey leaf was found for this address",
+            signer.signdatapqchash,
+            address,
+            "57" * 32,
+            {"pubkey": "00" * 32},
+        )
+        self.assert_pqc_signature_count(signer, address, 2)
+
+        watch = self.create_wallet("pqc_hash_watch", disable_private_keys=True)
+        watch.importpubkeydb(signer.exportpubkeydb()["pubkeys"], False, 0)
+        assert_raises_rpc_error(
+            -4,
+            "Private key is not available for the selected P2MR pubkey leaf",
+            watch.signdatapqchash,
+            address,
+            "58" * 32,
+            {
+                "pubkey": proof["pubkey"],
+                "leaf_script": proof["leaf_script"],
+                "control_block": proof["control_block"],
+            },
+        )
+        self.assert_pqc_signature_count(signer, address, 2)
+
+        passphrase = "pass"
+        self.nodes[0].createwallet(wallet_name="pqc_hash_locked", passphrase=passphrase)
+        locked = self.nodes[0].get_wallet_rpc("pqc_hash_locked")
+        locked.walletpassphrase(passphrase, 60)
+        locked_address = locked.getnewaddress(address_type="p2mr")
+        self.wait_pqc_key_validation_ready(locked)
+        locked.walletlock()
+        assert_raises_rpc_error(
+            -13,
+            "Please enter the wallet passphrase",
+            locked.signdatapqchash,
+            locked_address,
+            "59" * 32,
+        )
+        locked.walletpassphrase(passphrase, 60)
+        locked_proof = locked.signdatapqchash(locked_address, "5a" * 32)
+        self.assert_pqc_fields(locked_proof, min_signature_count=1)
+        self.assert_pqc_signature_count(locked, locked_address, 1)
+
+    def test_signdatapqchash_plaintext_validation_block(self):
+        source_name = "pqc_hash_validation_source"
+        source = self.create_wallet(source_name)
+        source.keypoolrefill(200)
+        address = source.getnewaddress(address_type="p2mr")
+        backup_file = self.nodes[0].datadir_path / "pqc_hash_validation_source.bak"
+        source.backupwallet(backup_file)
+        self.nodes[0].unloadwallet(source_name)
+
+        restored_name = "pqc_hash_validation_restored"
+        self.nodes[0].restorewallet(restored_name, backup_file)
+        restored = self.nodes[0].get_wallet_rpc(restored_name)
+        self.wait_until(
+            lambda: restored.getwalletinfo()["pqc_key_validation"]["signing_blocked"],
+            timeout=10,
+        )
+        assert_raises_rpc_error(
+            -4,
+            "plaintext PQC wallet key validation",
+            restored.signdatapqchash,
+            address,
+            "5b" * 32,
+        )
+        restored.unloadwallet()
+
     def test_counter_lifecycle(self, funder, receiver):
         wallet_name = "pqc_counter_lifecycle"
         signer = self.create_wallet(wallet_name, load_on_startup=True)
@@ -298,6 +385,8 @@ class WalletPQCUsageTest(BitcoinTestFramework):
         self.test_sendtoaddress_and_sendmany(funder, receiver)
         self.test_send_and_sendall(funder, receiver)
         self.test_rawtx_and_psbt(funder, receiver)
+        self.test_signdatapqchash()
+        self.test_signdatapqchash_plaintext_validation_block()
         self.test_counter_lifecycle(funder, receiver)
         funder = self.nodes[0].get_wallet_rpc("pqc_funder")
         receiver = self.nodes[0].get_wallet_rpc("pqc_receiver")


### PR DESCRIPTION
## Summary
- Treat wallet-backed PQC counter reservations as consumed once persisted for data-hash signing paths.
- Report/log consumed data-hash counter ranges even when signing later fails.
- Distinguish exhausted PQC signature budgets from missing private keys for selected P2MR leaves.
- Add provider, wallet unit, and functional RPC coverage for success and failure cases.

Fixes #45

## Validation
- `ninja -C build test_qbit qbitd qbit-cli`
- `git diff --check`
- `ulimit -n 1024; build/bin/test_qbit --run_test=pqc_tests`
- `ulimit -n 1024; build/bin/test_qbit '--run_test=wallet_tests/P2MRDataHash*'`\n- `ulimit -n 1024; test/functional/wallet_pqc_usage.py --configfile=build/test/config.ini`\n- `DOCKER_BUILDKIT=1 docker build -t bitcoin-linter --file "./ci/lint_imagefile" .`\n- `docker run --rm -v "$(pwd)":/bitcoin -v /Users/miller/conductor/repos/qbit-v1:/Users/miller/conductor/repos/qbit-v1 bitcoin-linter`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785337169&installation_id=141183937&pr_number=46&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F46&signature=531c7a0c2451bb8085f6bbe1ae1d907835dd992b3e3341c841a3870d1204fcdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes bounded PQC counter semantics on failure paths (intentional overcount vs reuse) and wallet/RPC signing behavior; mistakes could waste signature budget or misreport key state.
> 
> **Overview**
> Fixes **PQC signature counter accounting** when wallet-backed reservations are already persisted: `FlatSigningProvider::SignPQC` now treats a successful `pqc_counter_reserver` as **consumed immediately** (updates cache and observer before raw signing), skips rollback on later sign failure, and adds an injectable **`pqc_raw_signer`** for tests. **`IsPQCSignatureCounterExhausted`** is wired through `SigningProvider`, `HidingSigningProvider`, `MultiSigningProvider`, and `FlatSigningProvider`.
> 
> **P2MR data-hash signing** (`SignP2MRDataHash`) returns a dedicated **“signature budget exhausted”** error instead of lumping exhausted keys with missing private keys; **`signdatapqchash`** builds the PQC usage report first and **logs consumed counter ranges** when signing fails after a reservation.
> 
> Adds unit tests (provider, P2MR wallet paths) and functional coverage for **`signdatapqchash`** and PQC usage counters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1761c827a3df5c8bfc415e2db479ff714cfe6de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->