### PR TITLE
Add independent P2MR commitment vectors

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -156,6 +156,7 @@ target_json_data_sources(test_bitcoin
   data/key_io_valid.json
   data/mainnet_launch_difficulty.json
   data/p2mr_pqc_witness_vectors.json
+  data/p2mr_vectors.json
   data/script_tests.json
   data/sighash.json
   data/testnet4_launch_difficulty.json

--- a/src/test/data/p2mr_vectors.json
+++ b/src/test/data/p2mr_vectors.json
@@ -1,0 +1,146 @@
+{
+    "version": 1,
+    "valid": [
+        {
+            "name": "single_leaf_op_true",
+            "leaf_script": "51",
+            "leaf_version": 192,
+            "leaf_preimage": "c00151",
+            "leaf_hash": "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "siblings": [],
+            "branch_preimages": [],
+            "control_block": "c1",
+            "merkle_root": "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "scriptPubKey": "52205c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "mainnet_address": "qb1zt39mp8jjcqd7pyh7qgz93gmhh2qlqppq8c3j4qy02chzfzp8c7sqkcq5ga",
+            "regtest_address": "qbrt1zt39mp8jjcqd7pyh7qgz93gmhh2qlqppq8c3j4qy02chzfzp8c7sqrw52qh"
+        },
+        {
+            "name": "two_leaf_op_true_with_op_false_sibling",
+            "leaf_script": "51",
+            "leaf_version": 192,
+            "leaf_preimage": "c00151",
+            "leaf_hash": "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "siblings": [
+                "fae97225114b26d9ef3e3bea70f90d08fec30d9833c50b23e4a6cf8c33e6b200"
+            ],
+            "branch_preimages": [
+                "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0fae97225114b26d9ef3e3bea70f90d08fec30d9833c50b23e4a6cf8c33e6b200"
+            ],
+            "control_block": "c1fae97225114b26d9ef3e3bea70f90d08fec30d9833c50b23e4a6cf8c33e6b200",
+            "merkle_root": "a5c90fea49992780b06c4ecb4f5e9a047af3aa6de9161a71636ec69f00049b52",
+            "scriptPubKey": "5220a5c90fea49992780b06c4ecb4f5e9a047af3aa6de9161a71636ec69f00049b52",
+            "mainnet_address": "qb1z5hysl6jfnyncpvrvfm957h56q3a082ndaytp5utrdmrf7qqyndfqqchlr7",
+            "regtest_address": "qbrt1z5hysl6jfnyncpvrvfm957h56q3a082ndaytp5utrdmrf7qqyndfq4wrpt5"
+        },
+        {
+            "name": "two_leaf_spent_hash_sorts_after_sibling",
+            "leaf_script": "5161",
+            "leaf_version": 192,
+            "leaf_preimage": "c0025161",
+            "leaf_hash": "8f089a16a7c9678a8513f5861ad4513beb923c2ce3794d0a476b86fc78af7f22",
+            "siblings": [
+                "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0"
+            ],
+            "branch_preimages": [
+                "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a08f089a16a7c9678a8513f5861ad4513beb923c2ce3794d0a476b86fc78af7f22"
+            ],
+            "control_block": "c15c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "merkle_root": "ac7140a0fc0d901b5b8a3c2549261d7d4bdda60cf5e6daac0489cfaacd01c268",
+            "scriptPubKey": "5220ac7140a0fc0d901b5b8a3c2549261d7d4bdda60cf5e6daac0489cfaacd01c268",
+            "mainnet_address": "qb1z43c5pg8upkgpkku28sj5jfsa049amfsv7hnd4tqy38864ngpcf5qu0l8v3",
+            "regtest_address": "qbrt1z43c5pg8upkgpkku28sj5jfsa049amfsv7hnd4tqy38864ngpcf5qfeteym",
+            "notes": "The spent leaf hash is lexicographically greater than its sibling, so the branch preimage must be sibling || spent."
+        },
+        {
+            "name": "three_leaf_two_level_spend_middle_leaf",
+            "leaf_script": "5161",
+            "leaf_version": 192,
+            "leaf_preimage": "c0025161",
+            "leaf_hash": "8f089a16a7c9678a8513f5861ad4513beb923c2ce3794d0a476b86fc78af7f22",
+            "siblings": [
+                "817b726bbe1b4cb416f82d1e4f3ce1656e762c9d6f19e9f7d1344868f0035fe8",
+                "dda3b0355ee1622abb9fdd5d5abc3d6d4300fbd2e1f4fa4d291d0dee90bd423d"
+            ],
+            "branch_preimages": [
+                "817b726bbe1b4cb416f82d1e4f3ce1656e762c9d6f19e9f7d1344868f0035fe88f089a16a7c9678a8513f5861ad4513beb923c2ce3794d0a476b86fc78af7f22",
+                "dda3b0355ee1622abb9fdd5d5abc3d6d4300fbd2e1f4fa4d291d0dee90bd423deb9299758143faf99fab6012bbd13166ab64ba138e5b861415cc585c0aeb55e6"
+            ],
+            "control_block": "c1817b726bbe1b4cb416f82d1e4f3ce1656e762c9d6f19e9f7d1344868f0035fe8dda3b0355ee1622abb9fdd5d5abc3d6d4300fbd2e1f4fa4d291d0dee90bd423d",
+            "merkle_root": "739202cb6c0a36ebf614703d628bec5a79de0b7bd9ac80d2df5bae9b81657a92",
+            "scriptPubKey": "5220739202cb6c0a36ebf614703d628bec5a79de0b7bd9ac80d2df5bae9b81657a92",
+            "mainnet_address": "qb1zwwfq9jmvpgmwhas5wq7k9zlvtfuauzmmmxkgp5kltwhfhqt902fqu94k5n",
+            "regtest_address": "qbrt1zwwfq9jmvpgmwhas5wq7k9zlvtfuauzmmmxkgp5kltwhfhqt902fqfnpgue",
+            "notes": "Tree shape is A || (B || C); control path is C then A, bottom-up."
+        }
+    ],
+    "invalid": [
+        {
+            "name": "missing_bit0_control_marker",
+            "base": "single_leaf_op_true",
+            "leaf_script": "51",
+            "leaf_version": 192,
+            "control_block": "c0",
+            "merkle_root": "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "expected_error": "SCRIPT_ERR_P2MR_CONTROL_BIT0"
+        },
+        {
+            "name": "malformed_control_block_size",
+            "base": "single_leaf_op_true",
+            "leaf_script": "51",
+            "leaf_version": 192,
+            "control_block": "c100",
+            "merkle_root": "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "expected_error": "SCRIPT_ERR_P2MR_WRONG_CONTROL_SIZE"
+        },
+        {
+            "name": "wrong_leaf_version",
+            "base": "single_leaf_op_true",
+            "leaf_script": "51",
+            "leaf_version": 194,
+            "control_block": "c3",
+            "merkle_root": "5c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "expected_error": "SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH"
+        },
+        {
+            "name": "wrong_compactsize_script_length_encoding",
+            "base": "single_leaf_op_true",
+            "leaf_script": "51",
+            "leaf_version": 192,
+            "wrong_leaf_preimage": "c00251",
+            "wrong_leaf_hash": "076b9b5fa1d9a0d61f35d64bcf39f52a756a11e607b58fd2294bdfc621cc8880",
+            "control_block": "c1",
+            "merkle_root": "076b9b5fa1d9a0d61f35d64bcf39f52a756a11e607b58fd2294bdfc621cc8880",
+            "expected_error": "SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH"
+        },
+        {
+            "name": "mutated_sibling",
+            "base": "two_leaf_op_true_with_op_false_sibling",
+            "leaf_script": "51",
+            "leaf_version": 192,
+            "control_block": "c1fbe97225114b26d9ef3e3bea70f90d08fec30d9833c50b23e4a6cf8c33e6b200",
+            "merkle_root": "a5c90fea49992780b06c4ecb4f5e9a047af3aa6de9161a71636ec69f00049b52",
+            "expected_error": "SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH"
+        },
+        {
+            "name": "unsorted_branch_preimage_when_spent_hash_sorts_after_sibling",
+            "base": "two_leaf_spent_hash_sorts_after_sibling",
+            "leaf_script": "5161",
+            "leaf_version": 192,
+            "wrong_branch_preimage": "8f089a16a7c9678a8513f5861ad4513beb923c2ce3794d0a476b86fc78af7f225c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "wrong_merkle_root": "9e2e8f105b14c9aebff9c4015620127ccde272127b6acbb720973861fb42020a",
+            "control_block": "c15c4bb09e52c01be092fe020458a377ba81f004203e232a808f562e248827c7a0",
+            "merkle_root": "9e2e8f105b14c9aebff9c4015620127ccde272127b6acbb720973861fb42020a",
+            "expected_error": "SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH"
+        },
+        {
+            "name": "wrong_address_root_commitment",
+            "base": "single_leaf_op_true",
+            "leaf_script": "51",
+            "leaf_version": 192,
+            "control_block": "c1",
+            "merkle_root": "4242424242424242424242424242424242424242424242424242424242424242",
+            "expected_error": "SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH"
+        }
+    ]
+}

--- a/src/test/descriptor_p2mr_tests.cpp
+++ b/src/test/descriptor_p2mr_tests.cpp
@@ -10,6 +10,7 @@
 #include <script/interpreter.h>
 #include <script/script.h>
 #include <script/signingprovider.h>
+#include <test/data/p2mr_vectors.json.h>
 #include <test/util/setup_common.h>
 #include <util/chaintype.h>
 #include <util/strencodings.h>
@@ -19,6 +20,7 @@
 #include <array>
 #include <optional>
 #include <string>
+#include <univalue.h>
 #include <vector>
 
 namespace {
@@ -264,6 +266,32 @@ BOOST_AUTO_TEST_CASE(rawmr_fixed_address_vector)
     BOOST_CHECK_EQUAL(EncodeDestination(output), "qb1zqqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0sjq57mw");
     SelectParams(ChainType::REGTEST);
     BOOST_CHECK_EQUAL(EncodeDestination(output), "qbrt1zqqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk8qarc0s8kqqny");
+    SelectParams(ChainType::MAIN);
+}
+
+BOOST_AUTO_TEST_CASE(rawmr_independent_p2mr_vectors)
+{
+    UniValue tests;
+    BOOST_REQUIRE(tests.read(json_tests::p2mr_vectors));
+    BOOST_REQUIRE(tests.isObject());
+    BOOST_CHECK_EQUAL(tests["version"].getInt<int>(), 1);
+
+    for (const auto& vec : tests["valid"].getValues()) {
+        const std::string root{vec["merkle_root"].get_str()};
+        const std::string desc{"rawmr(" + root + ")"};
+        FlatSigningProvider provider;
+        auto parsed = ParseSingleDescriptor(desc, provider);
+
+        FlatSigningProvider out_provider;
+        const CScript script_pubkey = ExpandSingleScript(*parsed, out_provider);
+        BOOST_CHECK_EQUAL(HexStr(script_pubkey), vec["scriptPubKey"].get_str());
+
+        const WitnessV2P2MR output = ExtractP2MROutput(script_pubkey);
+        SelectParams(ChainType::MAIN);
+        BOOST_CHECK_EQUAL(EncodeDestination(output), vec["mainnet_address"].get_str());
+        SelectParams(ChainType::REGTEST);
+        BOOST_CHECK_EQUAL(EncodeDestination(output), vec["regtest_address"].get_str());
+    }
     SelectParams(ChainType::MAIN);
 }
 

--- a/src/test/psbt_p2mr_tests.cpp
+++ b/src/test/psbt_p2mr_tests.cpp
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(psbt_p2mr_signing_canonicalizes_conflicting_merkle_root)
     const CPQCPubKey pubkey = key.GetPubKey();
     const CScript leaf_script = P2MRLeafScript(pubkey);
     const std::vector<unsigned char> leaf_script_bytes = Vec(leaf_script);
-    const uint256 leaf_hash = ComputeTapleafHash(P2MR_LEAF_VERSION_V1, leaf_script_bytes);
+    const uint256 leaf_hash = ComputeP2MRLeafHash(P2MR_LEAF_VERSION_V1, leaf_script_bytes);
     const std::vector<unsigned char> control_block = ControlBlock(static_cast<unsigned char>(P2MR_LEAF_VERSION_V1 | 1));
     const uint256 merkle_root = ComputeP2MRMerkleRoot(control_block, leaf_hash);
     const uint256 wrong_root = ByteHash(0xee);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -16,6 +16,7 @@
 #include <script/interpreter.h>
 #include <script/signingprovider.h>
 #include <script/script.h>
+#include <test/data/p2mr_vectors.json.h>
 #include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/strencodings.h>
@@ -274,6 +275,27 @@ BOOST_AUTO_TEST_CASE(rpc_parse_prevouts_p2mr)
     BOOST_CHECK(parsed.merkle_root == output.GetMerkleRoot());
     BOOST_CHECK_EQUAL(parsed.scripts.size(), 1U);
     BOOST_CHECK(parsed.scripts.contains({std::vector<unsigned char>{leaf_script.begin(), leaf_script.end()}, P2MR_LEAF_VERSION}));
+
+    UniValue p2mr_vectors;
+    BOOST_REQUIRE(p2mr_vectors.read(json_tests::p2mr_vectors));
+    const UniValue& vector = p2mr_vectors["valid"][0];
+    const std::vector<unsigned char> vector_leaf_script{ParseHex(vector["leaf_script"].get_str())};
+    const uint8_t vector_leaf_version{static_cast<uint8_t>(vector["leaf_version"].getInt<int>())};
+    const std::string vector_prevtxs = strprintf(
+        "[{\"txid\":\"%s\",\"vout\":0,\"scriptPubKey\":\"%s\",\"amount\":1.00000000,\"p2mrScript\":\"%s\",\"p2mrControlBlock\":\"%s\"}]",
+        "0404040404040404040404040404040404040404040404040404040404040404",
+        vector["scriptPubKey"].get_str(),
+        vector["leaf_script"].get_str(),
+        vector["control_block"].get_str());
+
+    FlatSigningProvider vector_provider;
+    std::map<COutPoint, Coin> vector_coins;
+    ParsePrevouts(JSON(vector_prevtxs), &vector_provider, vector_coins);
+    const WitnessV2P2MR vector_output{uint256{ParseHex(vector["merkle_root"].get_str())}};
+    P2MRSpendData vector_parsed;
+    BOOST_CHECK(vector_provider.GetP2MRSpendData(vector_output, vector_parsed));
+    BOOST_CHECK_EQUAL(vector_parsed.merkle_root, vector_output.GetMerkleRoot());
+    BOOST_CHECK(vector_parsed.scripts.contains({vector_leaf_script, vector_leaf_version}));
 
     const CScript anchor_script_pub_key = GetScriptForDestination(PayToAnchor{});
     const std::string anchor_prevtxs = strprintf(

--- a/src/test/script_p2mr_tests.cpp
+++ b/src/test/script_p2mr_tests.cpp
@@ -3,7 +3,9 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <addresstype.h>
+#include <chainparams.h>
 #include <crypto/pqc.h>
+#include <key_io.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/interpreter.h>
@@ -14,9 +16,11 @@
 #include <script/script_error.h>
 #include <streams.h>
 #include <test/data/p2mr_pqc_witness_vectors.json.h>
+#include <test/data/p2mr_vectors.json.h>
 #include <test/util/json.h>
 #include <test/util/setup_common.h>
 #include <test/util/transaction_utils.h>
+#include <util/chaintype.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
 
@@ -31,7 +35,10 @@
 #include <optional>
 #include <set>
 #include <span>
+#include <stdexcept>
+#include <string>
 #include <string_view>
+#include <univalue.h>
 #include <vector>
 
 namespace {
@@ -80,6 +87,41 @@ uint256 ComputeMerkleRootSingleLeaf(uint8_t leaf_version, const CScript& leaf_sc
 {
     const uint256 leaf_hash = ComputeP2MRLeafHash(leaf_version, ScriptBytes(leaf_script));
     return ComputeP2MRMerkleRoot(std::vector<unsigned char>{static_cast<unsigned char>(leaf_version | 1)}, leaf_hash);
+}
+
+std::vector<unsigned char> ExpectedP2MRLeafPreimage(uint8_t leaf_version, const std::vector<unsigned char>& leaf_script)
+{
+    std::vector<unsigned char> preimage{leaf_version, static_cast<unsigned char>(leaf_script.size())};
+    preimage.insert(preimage.end(), leaf_script.begin(), leaf_script.end());
+    return preimage;
+}
+
+UniValue P2MRVectorTestData()
+{
+    UniValue tests;
+    if (!tests.read(json_tests::p2mr_vectors) || !tests.isObject()) {
+        throw std::runtime_error("p2mr_vectors.json must contain a JSON object");
+    }
+    BOOST_CHECK_EQUAL(tests["version"].getInt<int>(), 1);
+    return tests;
+}
+
+uint256 VectorHash(const UniValue& obj, const std::string& field)
+{
+    const std::vector<unsigned char> bytes{ParseHex(obj[field].get_str())};
+    if (bytes.size() != uint256::size()) {
+        throw std::runtime_error("P2MR vector field is not a uint256: " + field);
+    }
+    return uint256{bytes};
+}
+
+ScriptError VectorScriptError(const std::string& name)
+{
+    if (name == "SCRIPT_ERR_P2MR_CONTROL_BIT0") return SCRIPT_ERR_P2MR_CONTROL_BIT0;
+    if (name == "SCRIPT_ERR_P2MR_WRONG_CONTROL_SIZE") return SCRIPT_ERR_P2MR_WRONG_CONTROL_SIZE;
+    if (name == "SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH") return SCRIPT_ERR_WITNESS_PROGRAM_MISMATCH;
+    BOOST_FAIL("unknown P2MR vector script error: " + name);
+    return SCRIPT_ERR_UNKNOWN_ERROR;
 }
 
 CScript BuildP2MRScriptPubKey(const uint256& merkle_root)
@@ -632,6 +674,115 @@ static_assert(MAX_STACK_SIZE == 1000);
 static_assert(MAX_STANDARD_TX_WEIGHT == 400'000);
 static_assert(OP_CHECKDATASIGPQC == 0xbc);
 static_assert(OP_CHECKDATASIGADDPQC == 0xbd);
+
+BOOST_AUTO_TEST_CASE(p2mr_independent_commitment_vectors)
+{
+    const UniValue tests{P2MRVectorTestData()};
+    const auto& vectors = tests["valid"].getValues();
+    BOOST_REQUIRE(!vectors.empty());
+
+    for (const auto& vec : vectors) {
+        const std::string name{vec["name"].get_str()};
+        BOOST_TEST_CONTEXT(name)
+        {
+            const std::vector<unsigned char> leaf_script_bytes{ParseHex(vec["leaf_script"].get_str())};
+            BOOST_REQUIRE_LT(leaf_script_bytes.size(), 253U);
+            const uint8_t leaf_version{static_cast<uint8_t>(vec["leaf_version"].getInt<int>())};
+
+            const std::vector<unsigned char> expected_leaf_preimage{ExpectedP2MRLeafPreimage(leaf_version, leaf_script_bytes)};
+            BOOST_CHECK_EQUAL(HexStr(expected_leaf_preimage), vec["leaf_preimage"].get_str());
+
+            const uint256 leaf_hash{ComputeP2MRLeafHash(leaf_version, leaf_script_bytes)};
+            BOOST_CHECK_EQUAL(HexStr(leaf_hash), vec["leaf_hash"].get_str());
+
+            const std::vector<unsigned char> control_block{ParseHex(vec["control_block"].get_str())};
+            BOOST_CHECK_EQUAL(control_block.front() & 1, 1);
+            BOOST_CHECK_EQUAL(control_block.front() & P2MR_LEAF_VERSION_MASK, leaf_version);
+
+            const auto& siblings = vec["siblings"].getValues();
+            const auto& branch_preimages = vec["branch_preimages"].getValues();
+            BOOST_REQUIRE_EQUAL(siblings.size(), branch_preimages.size());
+            BOOST_CHECK_EQUAL(control_block.size(), P2MR_CONTROL_BASE_SIZE + P2MR_CONTROL_NODE_SIZE * siblings.size());
+
+            uint256 branch_hash{leaf_hash};
+            std::vector<unsigned char> expected_control{static_cast<unsigned char>(leaf_version | 1)};
+            for (size_t i{0}; i < siblings.size(); ++i) {
+                const uint256 sibling{ParseHex(siblings[i].get_str())};
+                expected_control.insert(expected_control.end(), sibling.begin(), sibling.end());
+
+                const bool branch_first{std::lexicographical_compare(branch_hash.begin(), branch_hash.end(), sibling.begin(), sibling.end())};
+                std::vector<unsigned char> branch_preimage;
+                if (branch_first) {
+                    branch_preimage.insert(branch_preimage.end(), branch_hash.begin(), branch_hash.end());
+                    branch_preimage.insert(branch_preimage.end(), sibling.begin(), sibling.end());
+                } else {
+                    branch_preimage.insert(branch_preimage.end(), sibling.begin(), sibling.end());
+                    branch_preimage.insert(branch_preimage.end(), branch_hash.begin(), branch_hash.end());
+                }
+                BOOST_CHECK_EQUAL(HexStr(branch_preimage), branch_preimages[i].get_str());
+
+                branch_hash = ComputeP2MRBranchHash(branch_hash, sibling);
+            }
+            BOOST_CHECK(control_block == expected_control);
+
+            const uint256 merkle_root{VectorHash(vec, "merkle_root")};
+            BOOST_CHECK_EQUAL(ComputeP2MRMerkleRoot(control_block, leaf_hash), merkle_root);
+            BOOST_CHECK_EQUAL(branch_hash, merkle_root);
+            BOOST_CHECK_EQUAL(HexStr(BuildP2MRScriptPubKey(merkle_root)), vec["scriptPubKey"].get_str());
+            BOOST_CHECK_EQUAL(HexStr(GetScriptForDestination(WitnessV2P2MR{merkle_root})), vec["scriptPubKey"].get_str());
+
+            SelectParams(ChainType::MAIN);
+            BOOST_CHECK_EQUAL(EncodeDestination(WitnessV2P2MR{merkle_root}), vec["mainnet_address"].get_str());
+            SelectParams(ChainType::REGTEST);
+            BOOST_CHECK_EQUAL(EncodeDestination(WitnessV2P2MR{merkle_root}), vec["regtest_address"].get_str());
+
+            const CScript leaf_script{leaf_script_bytes.begin(), leaf_script_bytes.end()};
+            const P2MRSpendContext spend{BuildP2MRSpend(leaf_script, /*stack_items=*/{}, control_block, merkle_root)};
+            ScriptError err{SCRIPT_ERR_UNKNOWN_ERROR};
+            BOOST_CHECK(VerifySpend(spend, P2MR_SCRIPT_VERIFY_FLAGS, err));
+            BOOST_CHECK_EQUAL(err, SCRIPT_ERR_OK);
+        }
+    }
+    SelectParams(ChainType::MAIN);
+}
+
+BOOST_AUTO_TEST_CASE(p2mr_independent_negative_vectors)
+{
+    const UniValue tests{P2MRVectorTestData()};
+    const auto& vectors = tests["invalid"].getValues();
+    BOOST_REQUIRE(!vectors.empty());
+
+    for (const auto& vec : vectors) {
+        const std::string name{vec["name"].get_str()};
+        BOOST_TEST_CONTEXT(name)
+        {
+            const std::vector<unsigned char> leaf_script_bytes{ParseHex(vec["leaf_script"].get_str())};
+            BOOST_REQUIRE_LT(leaf_script_bytes.size(), 253U);
+            const uint8_t leaf_version{static_cast<uint8_t>(vec["leaf_version"].getInt<int>())};
+            const uint256 production_leaf_hash{ComputeP2MRLeafHash(leaf_version, leaf_script_bytes)};
+            const std::vector<unsigned char> expected_leaf_preimage{ExpectedP2MRLeafPreimage(leaf_version, leaf_script_bytes)};
+
+            if (!vec["wrong_leaf_preimage"].isNull()) {
+                BOOST_CHECK_NE(HexStr(expected_leaf_preimage), vec["wrong_leaf_preimage"].get_str());
+            }
+            if (!vec["wrong_leaf_hash"].isNull()) {
+                BOOST_CHECK_NE(HexStr(production_leaf_hash), vec["wrong_leaf_hash"].get_str());
+            }
+            if (!vec["wrong_merkle_root"].isNull()) {
+                BOOST_CHECK_EQUAL(vec["wrong_merkle_root"].get_str(), vec["merkle_root"].get_str());
+            }
+
+            const std::vector<unsigned char> control_block{ParseHex(vec["control_block"].get_str())};
+            const uint256 merkle_root{VectorHash(vec, "merkle_root")};
+            const CScript leaf_script{leaf_script_bytes.begin(), leaf_script_bytes.end()};
+            const P2MRSpendContext spend{BuildP2MRSpend(leaf_script, /*stack_items=*/{}, control_block, merkle_root)};
+
+            ScriptError err{SCRIPT_ERR_UNKNOWN_ERROR};
+            BOOST_CHECK(!VerifySpend(spend, P2MR_SCRIPT_VERIFY_FLAGS, err));
+            BOOST_CHECK_EQUAL(err, VectorScriptError(vec["expected_error"].get_str()));
+        }
+    }
+}
 
 BOOST_AUTO_TEST_CASE(p2mr_pubkey_leaf_helpers_roundtrip)
 {


### PR DESCRIPTION
Closes #44.

## Summary
- Add independent JSON vectors for P2MR leaf hashing, branch hashing, control blocks, merkle roots, scriptPubKeys, and mainnet/regtest addresses.
- Cover negative control-block and commitment cases including missing bit-0 marker, malformed size, wrong leaf version, wrong CompactSize/script length commitment, mutated sibling, unsorted branch preimage/root, and wrong root commitment.
- Reuse the vectors from script, descriptor, and RPC tests, and fix an existing PSBT P2MR test to use `ComputeP2MRLeafHash` instead of the Tapleaf helper.

## Tests
- `git diff --check`
- `DOCKER_BUILDKIT=1 docker build -t bitcoin-linter --file "./ci/lint_imagefile" .`
- `docker run --rm -v "$(pwd):/bitcoin" -v "/Users/miller/conductor/repos/qbit-v1/.git:/Users/miller/conductor/repos/qbit-v1/.git" bitcoin-linter`
- `cmake --build build_dev_mode --target test_bitcoin -j 8`
- `build_dev_mode/bin/test_qbit --run_test=script_p2mr_tests/p2mr_independent_commitment_vectors`
- `build_dev_mode/bin/test_qbit --run_test=script_p2mr_tests/p2mr_independent_negative_vectors`
- `build_dev_mode/bin/test_qbit --run_test=descriptor_p2mr_tests/rawmr_independent_p2mr_vectors`
- `build_dev_mode/bin/test_qbit --run_test=rpc_tests/rpc_parse_prevouts_p2mr`
- `build_dev_mode/bin/test_qbit --run_test=psbt_p2mr_tests/psbt_p2mr_signing_canonicalizes_conflicting_merkle_root`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785337308&installation_id=141183937&pr_number=47&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F47&signature=630b1261fdf077b5a936b61f27d7d67c466b2539f728a70a4579de5debe70758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only vectors and harness changes; production P2MR logic is exercised but not modified except for correcting a test to use the right leaf-hash API.
> 
> **Overview**
> Adds **`data/p2mr_vectors.json`** as a shared fixture for P2MR commitment math (leaf/branch preimages, control blocks, merkle roots, `scriptPubKey`, mainnet/regtest addresses) plus **`invalid`** cases for control-block and root mismatches.
> 
> Wires the file into **`test_bitcoin`** and new/extended tests: **`script_p2mr_tests`** (full valid/negative witness verification), **`descriptor_p2mr_tests`** (`rawmr` expansion/addresses), and **`rpc_tests`** (`ParsePrevouts` P2MR fields from the first valid vector).
> 
> Fixes **`psbt_p2mr_tests`** to use **`ComputeP2MRLeafHash`** instead of the Tapleaf helper when building leaf hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e01f7921399dc3ef9bf7856fa70bf3b0009f5b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->