### PR TITLE
Remove unused P2MR wallet test import

### DIFF
--- a/src/wallet/test/wallet_p2mr_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_tests.cpp
@@ -22,7 +22,6 @@
 #include <hash.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
-#include <node/blockstorage.h>
 #include <policy/policy.h>
 #include <rpc/server.h>
 #include <scheduler.h>
@@ -48,8 +47,6 @@
 #include <univalue.h>
 
 #include <chrono>
-
-using node::MAX_BLOCKFILE_SIZE;
 
 namespace wallet {
 


### PR DESCRIPTION
## Summary
- Remove the unused `MAX_BLOCKFILE_SIZE` using-declaration from the P2MR wallet tests.
- Drop the now-unused `node/blockstorage.h` include.

## Rationale
PR #43's tidy run fails with `misc-unused-using-decls` on this declaration. The issue is present on `0.1.x`, so fixing it on the branch unblocks the dependent PR.

## Validation
- `git diff --check origin/0.1.x...HEAD`
- Docker lint image passed.
- Docker native tidy `run-clang-tidy-20` phase completed successfully across all 603 compile database entries, including `src/wallet/test/wallet_p2mr_tests.cpp`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785351836&installation_id=141183937&pr_number=58&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F58&signature=e57498cd165bfa03eeeac487e9dc118c4c280fa963724484271e74f71f6d12dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-file-only include cleanup with no runtime or wallet logic changes.
> 
> **Overview**
> Removes dead includes from `wallet_p2mr_tests.cpp` so clang-tidy stops flagging `misc-unused-using-decls`.
> 
> The PR drops `#include <node/blockstorage.h>` and the unused `using node::MAX_BLOCKFILE_SIZE` declaration. **No test logic or wallet behavior changes**—only header hygiene to unblock tidy on dependent work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9ae3fc90ce6bd8bbdfc2dd61453202f3f400824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->