### PR TITLE
Validate witness-pruned assumevalid before wiping chainstate

### DIFF
--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -17,6 +17,7 @@
 #include <txdb.h>
 #include <uint256.h>
 #include <util/fs.h>
+#include <util/result.h>
 #include <util/signalinterrupt.h>
 #include <util/time.h>
 #include <util/translation.h>
@@ -33,7 +34,8 @@ namespace node {
 // to ChainstateManager::InitializeChainstate().
 static ChainstateLoadResult CompleteChainstateInitialization(
     ChainstateManager& chainman,
-    const ChainstateLoadOptions& options) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+    const ChainstateLoadOptions& options,
+    bool snapshot_chainstate_loaded) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     if (chainman.m_interrupt) return {ChainstateLoadStatus::INTERRUPTED, {}};
 
@@ -64,17 +66,28 @@ static ChainstateLoadResult CompleteChainstateInitialization(
     }
 
     if (options.wipe_chainstate_db && chainman.m_blockman.m_have_witness_pruned) {
-        if (chainman.AssumedValidBlock().IsNull()) {
-            return {ChainstateLoadStatus::FAILURE_FATAL,
-                    _("Cannot use -reindex-chainstate on a witness-pruned node without "
-                      "-assumevalid=<hash>. Without an assumed-valid checkpoint, historical "
-                      "script validation requires witness data that has been stripped. Pass "
-                      "-assumevalid=<block hash> to skip historical script validation, or "
-                      "delete the data directory and perform a fresh sync.")};
+        auto assumevalid_check{chainman.CheckAssumeValidCoversWitnessPrunedHistory()};
+        if (!assumevalid_check) {
+            return {ChainstateLoadStatus::FAILURE_FATAL, util::ErrorString(assumevalid_check)};
         }
         LogInfo("Witness-pruned node: -reindex-chainstate proceeding under assumevalid=%s. "
-                "The supplied hash must be above the witness-pruned range.",
+                "The supplied hash covers the witness-pruned range.",
                 chainman.AssumedValidBlock().ToString());
+    }
+
+    if (options.wipe_chainstate_db) {
+        bool has_snapshot{snapshot_chainstate_loaded};
+        if (!has_snapshot) {
+            // Delay snapshot activation until after the witness-pruned preflight
+            // so an unusable -assumevalid value cannot delete snapshot state.
+            has_snapshot = chainman.DetectSnapshotChainstate();
+        }
+        if (has_snapshot) {
+            LogInfo("[snapshot] deleting snapshot chainstate due to reindexing");
+            if (!chainman.DeleteSnapshotChainstate()) {
+                return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Couldn't remove snapshot chainstate.")};
+            }
+        }
     }
 
     // At this point blocktree args are consistent with what's on disk.
@@ -187,17 +200,15 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     // Load the fully validated chainstate.
     chainman.InitializeChainstate(options.mempool);
 
-    // Load a chain created from a UTXO snapshot, if any exist.
-    bool has_snapshot = chainman.DetectSnapshotChainstate();
-
-    if (has_snapshot && options.wipe_chainstate_db) {
-        LogInfo("[snapshot] deleting snapshot chainstate due to reindexing");
-        if (!chainman.DeleteSnapshotChainstate()) {
-            return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Couldn't remove snapshot chainstate.")};
-        }
+    // Load a chain created from a UTXO snapshot, if any exist. When the
+    // chainstate will be wiped, this is delayed until after the block index is
+    // loaded and any witness-pruned assumevalid preflight has succeeded.
+    bool snapshot_chainstate_loaded{false};
+    if (!options.wipe_chainstate_db) {
+        snapshot_chainstate_loaded = chainman.DetectSnapshotChainstate();
     }
 
-    auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options);
+    auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options, snapshot_chainstate_loaded);
     if (init_status != ChainstateLoadStatus::SUCCESS) {
         return {init_status, init_error};
     }
@@ -233,7 +244,7 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         // for the fully validated chainstate.
         chainman.ActiveChainstate().ClearBlockIndexCandidates();
 
-        auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options);
+        auto [init_status, init_error] = CompleteChainstateInitialization(chainman, options, /*snapshot_chainstate_loaded=*/false);
         if (init_status != ChainstateLoadStatus::SUCCESS) {
             return {init_status, init_error};
         }

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -254,6 +254,51 @@ BOOST_FIXTURE_TEST_CASE(needs_witness_for_validation_gate, TestingSetup)
     });
 }
 
+BOOST_FIXTURE_TEST_CASE(assumevalid_covers_witness_pruned_history_gate, TestingSetup)
+{
+    auto& chainman{*Assert(m_node.chainman)};
+
+    WITH_LOCK(::cs_main, {
+        const uint32_t n_bits{chainman.ActiveChain()[0]->nBits};
+        CBlockIndex proof_index;
+        proof_index.nBits = n_bits;
+        const arith_uint256 proof{GetBlockProof(proof_index)};
+        BOOST_REQUIRE(proof != 0);
+
+        auto& mutable_opts = const_cast<ChainstateManager::Options&>(chainman.m_options);
+        mutable_opts.minimum_chain_work = proof;
+
+        auto& base = InsertTestBlockIndex(chainman, uint256{10}, nullptr, 0, n_bits, proof);
+        auto& highest_pruned = InsertTestBlockIndex(chainman, uint256{11}, &base, 1, n_bits, proof * 2);
+        auto& assumed = InsertTestBlockIndex(chainman, uint256{12}, &highest_pruned, 2, n_bits, proof * 3);
+        auto& best = InsertTestBlockIndex(chainman, uint256{13}, &assumed, 3, n_bits, proof * 4);
+        highest_pruned.nStatus |= BLOCK_OPT_WITNESS_PRUNED;
+        chainman.m_best_header = &best;
+
+        mutable_opts.assumed_valid_block = uint256::ZERO;
+        BOOST_CHECK(!chainman.CheckAssumeValidCoversWitnessPrunedHistory());
+
+        mutable_opts.assumed_valid_block = uint256{14};
+        BOOST_CHECK(!chainman.CheckAssumeValidCoversWitnessPrunedHistory());
+
+        auto& alternate = InsertTestBlockIndex(chainman, uint256{15}, &base, 1, n_bits, proof * 2);
+        mutable_opts.assumed_valid_block = alternate.GetBlockHash();
+        BOOST_CHECK(!chainman.CheckAssumeValidCoversWitnessPrunedHistory());
+
+        mutable_opts.assumed_valid_block = base.GetBlockHash();
+        BOOST_CHECK(!chainman.CheckAssumeValidCoversWitnessPrunedHistory());
+
+        mutable_opts.assumed_valid_block = highest_pruned.GetBlockHash();
+        BOOST_CHECK(chainman.CheckAssumeValidCoversWitnessPrunedHistory());
+
+        mutable_opts.assumed_valid_block = assumed.GetBlockHash();
+        BOOST_CHECK(chainman.CheckAssumeValidCoversWitnessPrunedHistory());
+
+        mutable_opts.minimum_chain_work = best.nChainWork + proof;
+        BOOST_CHECK(!chainman.CheckAssumeValidCoversWitnessPrunedHistory());
+    });
+}
+
 struct PreSegwitValidationSetup : TestingSetup {
     PreSegwitValidationSetup()
         : TestingSetup{ChainType::REGTEST, {.extra_args = {"-testactivationheight=segwit@200"}}}

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2439,6 +2439,82 @@ bool ChainstateManager::CanSkipScriptChecks(const CBlockIndex& block_index, bool
     return GetBlockProofEquivalentTime(*m_best_header, block_index, *m_best_header, GetConsensus()) > 60 * 60 * 24 * 7 * 2;
 }
 
+util::Result<void> ChainstateManager::CheckAssumeValidCoversWitnessPrunedHistory() const
+    EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+{
+    AssertLockHeld(::cs_main);
+
+    const uint256& assumed_valid_block{AssumedValidBlock()};
+    if (assumed_valid_block.IsNull()) {
+        return util::Error{_(
+            "Cannot use -reindex-chainstate on a witness-pruned node without "
+            "-assumevalid=<hash>. Without an assumed-valid checkpoint, historical "
+            "script validation requires witness data that has been stripped. Pass "
+            "-assumevalid=<block hash> to skip historical script validation, or "
+            "delete the data directory and perform a fresh sync.")};
+    }
+
+    if (!m_best_header) {
+        return util::Error{strprintf(
+            _("Cannot use -reindex-chainstate on a witness-pruned node with "
+              "-assumevalid=%s because no best header is loaded."),
+            assumed_valid_block.ToString())};
+    }
+
+    if (m_best_header->nChainWork < MinimumChainWork()) {
+        return util::Error{strprintf(
+            _("Cannot use -reindex-chainstate on a witness-pruned node with "
+              "-assumevalid=%s because the best header does not satisfy "
+              "nMinimumChainWork."),
+            assumed_valid_block.ToString())};
+    }
+
+    const auto assumed_it{m_blockman.m_block_index.find(assumed_valid_block)};
+    if (assumed_it == m_blockman.m_block_index.end()) {
+        return util::Error{strprintf(
+            _("Cannot use -reindex-chainstate on a witness-pruned node with "
+              "unknown -assumevalid block %s. Pass a block hash from the "
+              "best-header chain that covers the witness-pruned range, or "
+              "delete the data directory and perform a fresh sync."),
+            assumed_valid_block.ToString())};
+    }
+
+    const CBlockIndex& assumed_index{assumed_it->second};
+    if (m_best_header->GetAncestor(assumed_index.nHeight) != &assumed_index) {
+        return util::Error{strprintf(
+            _("Cannot use -reindex-chainstate on a witness-pruned node with "
+              "-assumevalid=%s because that block is not on the best-header "
+              "chain. Pass a block hash from the best-header chain that covers "
+              "the witness-pruned range, or delete the data directory and "
+              "perform a fresh sync."),
+            assumed_valid_block.ToString())};
+    }
+
+    const CBlockIndex* highest_witness_pruned{nullptr};
+    for (const CBlockIndex* index{m_best_header}; index != nullptr; index = index->pprev) {
+        if (m_blockman.IsWitnessPruned(*index) && RequiresWitnessForPeerBlock(*index)) {
+            highest_witness_pruned = index;
+            break;
+        }
+    }
+
+    if (highest_witness_pruned &&
+        assumed_index.GetAncestor(highest_witness_pruned->nHeight) != highest_witness_pruned) {
+        return util::Error{strprintf(
+            _("Cannot use -reindex-chainstate on a witness-pruned node with "
+              "-assumevalid=%s because it does not cover witness-pruned block "
+              "%s at height %d. Pass an assumed-valid block on the best-header "
+              "chain at or above height %d, or delete the data directory and "
+              "perform a fresh sync."),
+            assumed_valid_block.ToString(),
+            highest_witness_pruned->GetBlockHash().ToString(),
+            highest_witness_pruned->nHeight,
+            highest_witness_pruned->nHeight)};
+    }
+
+    return {};
+}
+
 static bool CheckBlockWeight(const CBlock& block, BlockValidationState& state, const char* check_name);
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.

--- a/src/validation.h
+++ b/src/validation.h
@@ -1037,6 +1037,8 @@ public:
      * witness-pruned chainstate).
      */
     bool NeedsWitnessForValidation(const CBlockIndex& block_index) const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+    /** Validate that -assumevalid is usable before replaying witness-pruned history. */
+    [[nodiscard]] util::Result<void> CheckAssumeValidCoversWitnessPrunedHistory() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool RequiresArchivePeersForValidation() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     const CBlockIndex* PendingWitnessRecovery() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool ScheduleWitnessRecovery(const CBlockIndex& block_index) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);

--- a/test/functional/feature_witness_pruning.py
+++ b/test/functional/feature_witness_pruning.py
@@ -4,10 +4,12 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Exercise explicit witness pruning against archive-by-default nodes."""
 
+import hashlib
 import http.client
 from pathlib import Path
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.authproxy import JSONRPCException
+from test_framework.blocktools import COINBASE_MATURITY, create_block, create_coinbase
 from test_framework.messages import (
     CBlock,
     CBlockHeader,
@@ -85,6 +87,20 @@ def snapshot_blk_sizes(blocks_path: Path):
     return {p.name: p.stat().st_size for p in blocks_path.glob("blk[0-9][0-9][0-9][0-9][0-9].dat")}
 
 
+def snapshot_dir_state(path: Path):
+    if not path.exists():
+        return None
+    return sorted(
+        (
+            str(p.relative_to(path)),
+            p.stat().st_size,
+            hashlib.sha256(p.read_bytes()).hexdigest(),
+        )
+        for p in path.rglob("*")
+        if p.is_file()
+    )
+
+
 class WitnessPruningTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
@@ -145,6 +161,45 @@ class WitnessPruningTest(BitcoinTestFramework):
             node.rpc_connected = False
             node.wait_for_rpc_connection(wait_for_import=False)
             return node.getbestblockhash()
+
+    @staticmethod
+    def is_witness_pruned_block(node, block_hash):
+        try:
+            node.getblock(block_hash, 1)
+        except JSONRPCException as e:
+            return VERBOSE_WITNESS_PRUNED_ERROR in e.error["message"]
+        return False
+
+    def assert_reindex_chainstate_assumevalid_fails_without_wipe(
+        self,
+        node,
+        assumevalid_hash,
+        expected_msg,
+        snapshot_path=None,
+    ):
+        chainstate_path = node.chain_path / "chainstate"
+        chainstate_before = snapshot_dir_state(chainstate_path)
+        snapshot_before = snapshot_dir_state(snapshot_path) if snapshot_path else None
+        log_pos = node.debug_log_path.stat().st_size if node.debug_log_path.exists() else 0
+
+        extra_args = ["-fastprune", "-reindex-chainstate"]
+        if assumevalid_hash is not None:
+            extra_args.append(f"-assumevalid={assumevalid_hash}")
+        node.assert_start_raises_init_error(
+            extra_args=extra_args,
+            expected_msg=expected_msg,
+            match=ErrorMatch.PARTIAL_REGEX,
+        )
+
+        assert_equal(snapshot_dir_state(chainstate_path), chainstate_before)
+        if snapshot_path is not None:
+            assert_equal(snapshot_dir_state(snapshot_path), snapshot_before)
+
+        with node.debug_log_path.open("rb") as debug_log:
+            debug_log.seek(log_pos)
+            new_log = debug_log.read().decode("utf-8", errors="replace")
+        assert "Wiping LevelDB" not in new_log
+        assert "[snapshot] deleting snapshot chainstate due to reindexing" not in new_log
 
     def run_test(self):
         pruned_node = self.nodes[0]
@@ -341,6 +396,32 @@ class WitnessPruningTest(BitcoinTestFramework):
         self.connect_nodes(0, 1)
         self.sync_blocks([pruned_node, archive_node])
 
+        self.log.info("Find the highest witness-pruned block for reindex-chainstate guard boundaries")
+        highest_witness_pruned_height = next(
+            height
+            for height in range(tip_height, 0, -1)
+            if self.is_witness_pruned_block(pruned_node, pruned_node.getblockhash(height))
+        )
+        highest_witness_pruned_hash = pruned_node.getblockhash(highest_witness_pruned_height)
+        first_unpruned_after_witness_pruned_hash = pruned_node.getblockhash(highest_witness_pruned_height + 1)
+        assert self.is_witness_pruned_block(pruned_node, highest_witness_pruned_hash)
+        assert not self.is_witness_pruned_block(pruned_node, first_unpruned_after_witness_pruned_hash)
+        assert pruned_height < highest_witness_pruned_height
+
+        self.log.info("Create a known off-best-header-chain hash for the reindex-chainstate assumevalid guard")
+        side_parent_height = tip_height - 2
+        side_parent_hash = pruned_node.getblockhash(side_parent_height)
+        side_parent_header = pruned_node.getblockheader(side_parent_hash)
+        offchain_block = create_block(
+            int(side_parent_hash, 16),
+            create_coinbase(side_parent_height + 1),
+            side_parent_header["time"] + 1,
+        )
+        offchain_block.solve()
+        offchain_assumevalid_hash = offchain_block.hash_hex
+        pruned_node.submitheader(CBlockHeader(offchain_block).serialize().hex())
+        assert_equal(pruned_node.getblockheader(offchain_assumevalid_hash)["hash"], offchain_assumevalid_hash)
+
         self.log.info("Guard: -txindex on a witness-pruned datadir should fail")
         self.stop_node(0)
         pruned_node.assert_start_raises_init_error(
@@ -361,19 +442,61 @@ class WitnessPruningTest(BitcoinTestFramework):
             ),
         )
 
-        self.log.info("Guard: -reindex-chainstate without assumevalid should fail")
-        pruned_node.assert_start_raises_init_error(
-            extra_args=["-fastprune", "-reindex-chainstate"],
+        self.log.info("Guard: -reindex-chainstate without assumevalid should fail before chainstate wipe")
+        self.assert_reindex_chainstate_assumevalid_fails_without_wipe(
+            pruned_node,
+            assumevalid_hash=None,
             expected_msg=(
                 "Error: Cannot use -reindex-chainstate on a witness-pruned node without "
-                "-assumevalid=<hash>. Without an assumed-valid checkpoint, historical script "
-                "validation requires witness data that has been stripped. Pass -assumevalid=<block hash> "
-                "to skip historical script validation, or delete the data directory and perform a fresh sync."
+                "-assumevalid=<hash>"
             ),
         )
 
-        self.log.info("Guard: -reindex-chainstate with assumevalid above the pruned range succeeds")
-        assumevalid_hash = archive_node.getblockhash(tip_height - 5)
+        self.log.info("Guard: unusable assumevalid values should fail before chainstate or snapshot wipe")
+        snapshot_path = pruned_node.chain_path / "chainstate_snapshot"
+        assert not snapshot_path.exists()
+        snapshot_path.mkdir()
+        (snapshot_path / "base_blockhash").write_bytes(b"z" * 32)
+        unknown_hash = "1".zfill(64)
+        below_pruned_range_hash = archive_node.getblockhash(start_height)
+        self.assert_reindex_chainstate_assumevalid_fails_without_wipe(
+            pruned_node,
+            assumevalid_hash=unknown_hash,
+            expected_msg="Error: Cannot use -reindex-chainstate on a witness-pruned node with unknown -assumevalid block",
+            snapshot_path=snapshot_path,
+        )
+        self.assert_reindex_chainstate_assumevalid_fails_without_wipe(
+            pruned_node,
+            assumevalid_hash=offchain_assumevalid_hash,
+            expected_msg=(
+                "Error: Cannot use -reindex-chainstate on a witness-pruned node with "
+                f"-assumevalid={offchain_assumevalid_hash} because that block is not on the best-header chain"
+            ),
+            snapshot_path=snapshot_path,
+        )
+        self.assert_reindex_chainstate_assumevalid_fails_without_wipe(
+            pruned_node,
+            assumevalid_hash=below_pruned_range_hash,
+            expected_msg="Error: Cannot use -reindex-chainstate on a witness-pruned node with -assumevalid=.*does not cover witness-pruned block",
+            snapshot_path=snapshot_path,
+        )
+        self.assert_reindex_chainstate_assumevalid_fails_without_wipe(
+            pruned_node,
+            assumevalid_hash=pruned_hash,
+            expected_msg="Error: Cannot use -reindex-chainstate on a witness-pruned node with -assumevalid=.*does not cover witness-pruned block",
+            snapshot_path=snapshot_path,
+        )
+        (snapshot_path / "base_blockhash").unlink()
+        snapshot_path.rmdir()
+
+        self.log.info("Guard: -reindex-chainstate with assumevalid at the highest witness-pruned block succeeds")
+        self.start_node(0, extra_args=["-fastprune", "-reindex-chainstate", f"-assumevalid={highest_witness_pruned_hash}"])
+        pruned_node = self.nodes[0]
+        assert_equal(pruned_node.getblockcount(), tip_height)
+
+        self.log.info("Guard: -reindex-chainstate with assumevalid immediately above the pruned range succeeds")
+        self.stop_node(0)
+        assumevalid_hash = first_unpruned_after_witness_pruned_hash
         self.start_node(0, extra_args=["-fastprune", "-reindex-chainstate", f"-assumevalid={assumevalid_hash}"])
         pruned_node = self.nodes[0]
         assert_equal(pruned_node.getblockcount(), tip_height)


### PR DESCRIPTION
## Summary

Closes #53.

This adds a witness-pruned `-reindex-chainstate` preflight that validates the supplied `-assumevalid` hash before any local chainstate or snapshot chainstate wipe can run. The check now rejects null, unknown, off-best-header-chain, insufficient-work, and too-low hashes before destructive startup paths.

Snapshot chainstate detection/deletion for wipe runs is delayed until after the block index is loaded and the preflight succeeds, preserving the existing valid reindex behavior while making failed startup fail closed.

## Tests

- `cmake --build build --target test_qbit qbitd qbit-cli -j 8`
- `build/bin/test_qbit --run_test=validation_chainstatemanager_tests/assumevalid_covers_witness_pruned_history_gate`
- `build/bin/test_qbit --run_test=validation_chainstatemanager_tests`
- `ulimit -n 1024 && build/test/functional/test_runner.py feature_witness_pruning.py`
- `git diff --check`
- Docker lint through the repository lint image, running `ci/lint/06_script.sh` inside the container

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785357540&installation_id=141183937&pr_number=59&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F59&signature=ae928c0e0ad82f195e085de687172f606ce31b7b95feb939c560d7ee78ddecb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches critical node startup and chainstate/snapshot deletion order; mistakes could wipe data or allow invalid reindex, but behavior is narrowly scoped and heavily tested.
> 
> **Overview**
> Adds a **witness-pruned `-reindex-chainstate` preflight** via `ChainstateManager::CheckAssumeValidCoversWitnessPrunedHistory()` that runs after the block index is loaded and **before** any chainstate or snapshot wipe. It rejects missing, unknown, off–best-header, insufficient-work, and too-low `-assumevalid` hashes with explicit errors.
> 
> **Startup ordering** changes so snapshot detection/deletion on wipe no longer runs at the start of `LoadChainstate`; snapshot load is skipped when wiping until the preflight passes, avoiding destructive cleanup on bad `-assumevalid`.
> 
> Unit and functional tests cover the gate and assert failed startups leave chainstate/snapshot dirs unchanged (no LevelDB wipe).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00600958d61be9ca00d8b8ad933f3a7fbcc67a00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->