### PR TITLE
qt: recommend wallet encryption by default

### DIFF
--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -25,7 +25,7 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
         ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(!text.isEmpty());
     });
 
-    connect(ui->encrypt_wallet_checkbox, &QCheckBox::toggled, [this](bool checked) {
+    const auto update_encrypt_wallet_options = [this](bool checked) {
         // Disable the disable_privkeys_checkbox and external_signer_checkbox when isEncryptWalletChecked is
         // set to true, enable it when isEncryptWalletChecked is false.
         ui->disable_privkeys_checkbox->setEnabled(!checked);
@@ -42,19 +42,20 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
             ui->external_signer_checkbox->setChecked(false);
         }
 
-    });
+    };
+    connect(ui->encrypt_wallet_checkbox, &QCheckBox::toggled, update_encrypt_wallet_options);
 
     connect(ui->external_signer_checkbox, &QCheckBox::toggled, [this](bool checked) {
-        ui->encrypt_wallet_checkbox->setEnabled(!checked);
-        ui->blank_wallet_checkbox->setEnabled(!checked);
-        ui->disable_privkeys_checkbox->setEnabled(!checked);
-
         // The external signer checkbox is only enabled when a device is detected.
-        // In that case it is checked by default. Toggling it restores the other
-        // options to their default.
-        ui->encrypt_wallet_checkbox->setChecked(false);
+        // Toggling it restores the normal wallet defaults, including recommended
+        // encryption when external signing is disabled.
+        ui->encrypt_wallet_checkbox->setChecked(!checked);
         ui->disable_privkeys_checkbox->setChecked(checked);
         ui->blank_wallet_checkbox->setChecked(false);
+
+        ui->encrypt_wallet_checkbox->setEnabled(!checked);
+        ui->blank_wallet_checkbox->setEnabled(!checked);
+        ui->disable_privkeys_checkbox->setEnabled(!checked && !ui->encrypt_wallet_checkbox->isChecked());
     });
 
     connect(ui->disable_privkeys_checkbox, &QCheckBox::toggled, [this](bool checked) {
@@ -76,9 +77,10 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
 
     connect(ui->blank_wallet_checkbox, &QCheckBox::toggled, [this](bool checked) {
         // Disable the disable_privkeys_checkbox when blank_wallet_checkbox is checked
-        // as blank-ness only pertains to wallets with private keys.
-        ui->disable_privkeys_checkbox->setEnabled(!checked);
-        if (checked) {
+        // as blank-ness only pertains to wallets with private keys. Keep it
+        // disabled while wallet encryption is selected as well.
+        ui->disable_privkeys_checkbox->setEnabled(!checked && !ui->encrypt_wallet_checkbox->isChecked());
+        if (!ui->disable_privkeys_checkbox->isEnabled()) {
             ui->disable_privkeys_checkbox->setChecked(false);
         }
     });
@@ -90,6 +92,7 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
         ui->external_signer_checkbox->setChecked(false);
 #endif
 
+    update_encrypt_wallet_options(ui->encrypt_wallet_checkbox->isChecked());
 }
 
 CreateWalletDialog::~CreateWalletDialog()

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -86,13 +86,13 @@
    <item>
     <widget class="QCheckBox" name="encrypt_wallet_checkbox">
      <property name="toolTip">
-      <string>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</string>
+      <string>Encrypt the wallet with a passphrase of your choice. This protects private keys and enables authenticated wallet loads that avoid repeated plaintext PQC key validation.</string>
      </property>
      <property name="text">
-      <string>Encrypt Wallet</string>
+      <string>Encrypt Wallet (recommended)</string>
      </property>
      <property name="checked">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
## Summary

New qbit-qt wallets now default to encrypted creation for normal wallets with private keys. The Create Wallet dialog labels encryption as recommended and explains that encryption protects private keys while enabling authenticated wallet loads that avoid repeated plaintext PQC key validation.

The dialog constructor now applies the encryption checkbox state during initialization, so incompatible options such as disabled private keys and external signer are synchronized immediately when encryption starts checked by default.

## Testing

- [ ] Built locally.
- [ ] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [x] Not run. Reason: Full GUI build and focused Qt tests were not run; this is a Qt dialog default/copy change validated with XML parsing, whitespace checks, signed commit verification, and Docker lint.

Checks run:

- `xmllint --noout src/qt/forms/createwalletdialog.ui`
- `git diff --check`
- `DOCKER_BUILDKIT=1 docker build -t bitcoin-linter --file "./ci/lint_imagefile" ./`
- `docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp [...] bitcoin-linter`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: Wallet creation behavior changes in qbit-qt: encryption is now the default for newly created normal wallets. Users can still opt out by unchecking the box.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: The Create Wallet dialog copy explains the new recommended default directly; no integration or process guidance changes.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Upstream fix is merged into the maintained libbitcoinpqc branch used by qbit.
- [ ] Curated branch `qbit-subtree` was refreshed with prune.
- [ ] Subtree update was done with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/git-subtree-check.sh -r src/libbitcoinpqc` passes locally.
- [ ] Followed `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785416694&installation_id=141183937&pr_number=62&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F62&signature=33208d15292bc3a891c6eb33ca09fbc036181b7d5bb36b165ed46a27d82abb41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default wallet creation security in the GUI (encryption on unless opted out); logic is dialog-only but affects how new wallets are created.
> 
> **Overview**
> **qbit-qt’s Create Wallet flow now treats encryption as the default** for normal wallets with private keys. The encrypt checkbox starts **checked**, the label reads **Encrypt Wallet (recommended)**, and the tooltip explains passphrase protection plus authenticated loads that skip repeated plaintext PQC key validation.
> 
> Dialog logic was tightened so that default lines up with the other options on first open. Encryption-side effects are centralized in `update_encrypt_wallet_options`, which runs once at the end of construction (so incompatible advanced options are disabled/unchecked immediately, not only after the user toggles encryption). Turning **external signer** off again re-checks encryption instead of leaving it off; **blank wallet** and **external signer** handlers now keep **disable private keys** disabled when encryption is on.
> 
> Users can still create an unencrypted wallet by unchecking the box; hardware-wallet / `setSigners` paths still force encryption off when external signing is selected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 175957104f77ff4a14fc66f19102b0b71952e367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->