### PR TITLE
Add P2MR data signature support to Qt Sign/Verify

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(bitcoin_common STATIC EXCLUDE_FROM_ALL
   common/interfaces.cpp
   common/messages.cpp
   common/netif.cpp
+  common/p2mr_data_signature.cpp
   common/pcp.cpp
   common/run_command.cpp
   common/settings.cpp

--- a/src/common/p2mr_data_signature.cpp
+++ b/src/common/p2mr_data_signature.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <common/p2mr_data_signature.h>
+
+#include <script/interpreter.h>
+#include <script/p2mr.h>
+
+#include <optional>
+#include <span>
+
+namespace common {
+
+P2MRDataSignatureVerification VerifyP2MRDataSignatureProof(const P2MRDataSignatureProof& proof)
+{
+    P2MRDataSignatureVerification result;
+
+    if (!proof.pubkey.IsValid()) {
+        result.error = "pubkey is invalid";
+        return result;
+    }
+
+    const std::optional<CPQCPubKey> leaf_pubkey{p2mr::MatchPK(proof.leaf_script)};
+    if (!leaf_pubkey || *leaf_pubkey != proof.pubkey) {
+        result.error = "leaf_script is not a single-key P2MR pubkey leaf for pubkey";
+        return result;
+    }
+
+    if (proof.leaf_version != P2MR_LEAF_VERSION_V1) {
+        result.error = "unsupported P2MR leaf version";
+        return result;
+    }
+
+    if (proof.control_block.size() < P2MR_CONTROL_BASE_SIZE || proof.control_block.size() > P2MR_CONTROL_MAX_SIZE ||
+        ((proof.control_block.size() - P2MR_CONTROL_BASE_SIZE) % P2MR_CONTROL_NODE_SIZE) != 0) {
+        result.error = "Invalid P2MR control block size";
+        return result;
+    }
+
+    if ((proof.control_block.front() & 1) == 0) {
+        result.error = "P2MR control byte bit 0 must be set";
+        return result;
+    }
+
+    if ((proof.control_block.front() & TAPROOT_LEAF_MASK) != proof.leaf_version) {
+        result.error = "leaf_version does not match control_block";
+        return result;
+    }
+
+    const std::vector<unsigned char> leaf_script_bytes{proof.leaf_script.begin(), proof.leaf_script.end()};
+    const uint256 leaf_hash{ComputeP2MRLeafHash(proof.leaf_version, leaf_script_bytes)};
+    const uint256 merkle_root{ComputeP2MRMerkleRoot(proof.control_block, leaf_hash)};
+    result.p2mr_merkle_root = merkle_root;
+    if (merkle_root != proof.output.GetMerkleRoot()) {
+        result.error = "leaf_script/control_block do not match address";
+        return result;
+    }
+
+    const uint256 datasig_hash{ComputeQbitDataSigPQCHash(std::span<const unsigned char>{proof.message_hash.begin(), proof.message_hash.end()})};
+    result.datasig_hash = datasig_hash;
+    if (datasig_hash != proof.datasig_hash) {
+        result.error = "datasig_hash does not match message_hash";
+        return result;
+    }
+
+    if (!proof.pubkey.Verify(datasig_hash, proof.signature)) {
+        result.error = "signature does not verify";
+        return result;
+    }
+
+    result.valid = true;
+    return result;
+}
+
+} // namespace common

--- a/src/common/p2mr_data_signature.h
+++ b/src/common/p2mr_data_signature.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef QBIT_COMMON_P2MR_DATA_SIGNATURE_H
+#define QBIT_COMMON_P2MR_DATA_SIGNATURE_H
+
+#include <addresstype.h>
+#include <crypto/pqc.h>
+#include <script/script.h>
+#include <uint256.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace common {
+
+static constexpr const char* P2MR_DATA_SIGNATURE_PROOF_MODE{"p2mr-pubkey"};
+static constexpr const char* P2MR_DATA_SIGNATURE_DOMAIN{"QbitDataSigPQC"};
+static constexpr const char* P2MR_DATA_SIGNATURE_ALGORITHM{"SLH-DSA-SHA2-128s-bounded30"};
+
+struct P2MRDataSignatureProof {
+    WitnessV2P2MR output;
+    uint256 message_hash;
+    uint256 datasig_hash;
+    CPQCPubKey pubkey;
+    std::vector<unsigned char> signature;
+    CScript leaf_script;
+    std::vector<unsigned char> control_block;
+    uint8_t leaf_version;
+};
+
+struct P2MRDataSignatureVerification {
+    bool valid{false};
+    std::string error;
+    uint256 datasig_hash;
+    uint256 p2mr_merkle_root;
+};
+
+P2MRDataSignatureVerification VerifyP2MRDataSignatureProof(const P2MRDataSignatureProof& proof);
+
+} // namespace common
+
+#endif // QBIT_COMMON_P2MR_DATA_SIGNATURE_H

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -63,6 +63,18 @@ struct WalletMigrationResult;
 using WalletOrderForm = std::vector<std::pair<std::string, std::string>>;
 using WalletValueMap = std::map<std::string, std::string>;
 
+struct P2MRDataSignatureResult {
+    WitnessV2P2MR output;
+    uint256 message_hash;
+    uint256 datasig_hash;
+    std::vector<unsigned char> pubkey;
+    std::vector<unsigned char> signature;
+    CScript leaf_script;
+    std::vector<unsigned char> control_block;
+    uint8_t leaf_version;
+    std::shared_ptr<const wallet::PQCUsageReport> pqc_usage;
+};
+
 //! Interface for accessing a wallet.
 class Wallet
 {
@@ -108,6 +120,9 @@ public:
 
     //! Sign message
     virtual SigningResult signMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) = 0;
+
+    //! Sign a 32-byte data hash with a PQC key committed by a wallet-owned P2MR address.
+    virtual util::Result<P2MRDataSignatureResult> signP2MRDataHash(const CTxDestination& dest, const uint256& message_hash) = 0;
 
     //! Return whether wallet has private key.
     virtual bool isSpendable(const CTxDestination& dest) = 0;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -348,8 +348,10 @@ void BitcoinGUI::createActions()
     verifyMessageAction = new QAction(tr("&Verify message…"), this);
     verifyMessageAction->setStatusTip(tr("Verify messages to ensure they were signed with specified qbit addresses"));
     if (IsP2MROnlyOutputChain()) {
-        signMessageAction->setStatusTip(tr("Legacy message signing is disabled on this chain"));
-        verifyMessageAction->setStatusTip(tr("Legacy message verification is disabled on this chain"));
+        signMessageAction->setText(tr("Sign data &hash…"));
+        signMessageAction->setStatusTip(tr("Sign a 32-byte hash with a wallet-owned P2MR/PQC key"));
+        verifyMessageAction->setText(tr("&Verify data proof…"));
+        verifyMessageAction->setStatusTip(tr("Verify a P2MR/PQC data-signature proof"));
     }
     m_load_psbt_action = new QAction(tr("&Load PSBT from file…"), this);
     m_load_psbt_action->setStatusTip(tr("Load Partially Signed Transaction (PSBT)"));
@@ -860,8 +862,8 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
     changePassphraseAction->setEnabled(enabled);
-    signMessageAction->setEnabled(enabled && !IsP2MROnlyOutputChain());
-    verifyMessageAction->setEnabled(enabled && !IsP2MROnlyOutputChain());
+    signMessageAction->setEnabled(enabled);
+    verifyMessageAction->setEnabled(enabled);
     usedSendingAddressesAction->setEnabled(enabled);
     usedReceivingAddressesAction->setEnabled(enabled);
     openAction->setEnabled(enabled);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -348,10 +348,10 @@ void BitcoinGUI::createActions()
     verifyMessageAction = new QAction(tr("&Verify message…"), this);
     verifyMessageAction->setStatusTip(tr("Verify messages to ensure they were signed with specified qbit addresses"));
     if (IsP2MROnlyOutputChain()) {
-        signMessageAction->setText(tr("Sign data &hash…"));
-        signMessageAction->setStatusTip(tr("Sign a 32-byte hash with a wallet-owned P2MR/PQC key"));
+        signMessageAction->setText(tr("Sign &data…"));
+        signMessageAction->setStatusTip(tr("Sign UTF-8 text or a 32-byte hash with a wallet-owned P2MR/PQC key"));
         verifyMessageAction->setText(tr("&Verify data proof…"));
-        verifyMessageAction->setStatusTip(tr("Verify a P2MR/PQC data-signature proof"));
+        verifyMessageAction->setStatusTip(tr("Verify a P2MR/PQC data-signature proof, optionally bound to original data"));
     }
     m_load_psbt_action = new QAction(tr("&Load PSBT from file…"), this);
     m_load_psbt_action->setStatusTip(tr("Load Partially Signed Transaction (PSBT)"));

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -95,6 +95,54 @@
         </layout>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="p2mrInputModeLayout_SM">
+         <item>
+          <widget class="QLabel" name="p2mrInputModeLabel_SM">
+           <property name="text">
+            <string>Input</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="p2mrDataInputMode_SM">
+           <item>
+            <property name="text">
+             <string>Text</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Hash</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="p2mrMessageHashLabel_SM">
+           <property name="text">
+            <string>Message hash</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="p2mrMessageHash_SM">
+           <property name="toolTip">
+            <string>The 32-byte hash that will be passed to the P2MR/PQC signing RPC</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QPlainTextEdit" name="messageIn_SM">
          <property name="toolTip">
           <string>Enter the message you want to sign here</string>
@@ -295,6 +343,89 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="p2mrVerifyModeLayout_VM">
+         <item>
+          <widget class="QLabel" name="p2mrVerifyModeLabel_VM">
+           <property name="text">
+            <string>Input</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="p2mrVerifyInputMode_VM">
+           <item>
+            <property name="text">
+             <string>Text + proof</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Hash + proof</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Proof only</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="p2mrVerifyMessageHashLabel_VM">
+           <property name="text">
+            <string>Message hash</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="p2mrVerifyMessageHash_VM">
+           <property name="toolTip">
+            <string>The 32-byte hash that must match the proof JSON</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QLabel" name="p2mrVerifyDataLabel_VM">
+         <property name="text">
+          <string>Data</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPlainTextEdit" name="p2mrDataIn_VM">
+         <property name="toolTip">
+          <string>Enter the signed data to bind to the proof JSON</string>
+         </property>
+         <property name="placeholderText">
+          <string>Enter the signed data to bind to the proof JSON</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="p2mrProofLabel_VM">
+         <property name="text">
+          <string>Proof JSON</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QPlainTextEdit" name="messageIn_VM">

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -120,7 +120,13 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QLineEdit" name="signatureOut_SM">
+          <widget class="QPlainTextEdit" name="signatureOut_SM">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>96</height>
+            </size>
+           </property>
            <property name="placeholderText">
             <string>Click "Sign Message" to generate signature</string>
            </property>

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -164,18 +164,8 @@ bool ParseP2MRProofJson(const QString& proof_json, common::P2MRDataSignatureProo
     std::vector<unsigned char> bytes;
     if (!ParseProofHexField(object, "message_hash", uint256::size(), bytes, error)) return false;
     proof.message_hash = uint256{std::span<const unsigned char>{bytes.data(), bytes.size()}};
-
-    const UniValue& datasig_hash_field{object.find_value("datasig_hash")};
-    if (datasig_hash_field.isNull()) {
-        proof.datasig_hash = ComputeQbitDataSigPQCHash(std::span<const unsigned char>{proof.message_hash.begin(), proof.message_hash.end()});
-    } else {
-        if (!datasig_hash_field.isStr()) {
-            error = SignVerifyMessageDialog::tr("Proof field \"datasig_hash\" must be a string.");
-            return false;
-        }
-        if (!ParseHexBytes(QString::fromStdString(datasig_hash_field.get_str()), "datasig_hash", uint256::size(), bytes, error)) return false;
-        proof.datasig_hash = uint256{std::span<const unsigned char>{bytes.data(), bytes.size()}};
-    }
+    proof.datasig_hash = ComputeQbitDataSigPQCHash(
+        std::span<const unsigned char>{proof.message_hash.begin(), proof.message_hash.end()});
 
     if (!ParseProofHexField(object, "pubkey", PQC_PUBKEY_SIZE, bytes, error)) return false;
     proof.pubkey = CPQCPubKey{bytes};
@@ -480,10 +470,6 @@ void SignVerifyMessageDialog::updateP2MRSignHashPreview()
             return;
         }
     } else {
-        if (ui->messageIn_SM->document()->isEmpty()) {
-            ui->p2mrMessageHash_SM->clear();
-            return;
-        }
         message_hash = HashP2MRUtf8Text(ui->messageIn_SM->document()->toPlainText());
     }
 
@@ -533,10 +519,6 @@ void SignVerifyMessageDialog::updateP2MRVerifyHashPreview()
             return;
         }
     } else {
-        if (ui->p2mrDataIn_VM->document()->isEmpty()) {
-            ui->p2mrVerifyMessageHash_VM->clear();
-            return;
-        }
         message_hash = HashP2MRUtf8Text(ui->p2mrDataIn_VM->document()->toPlainText());
     }
 
@@ -722,7 +704,6 @@ void SignVerifyMessageDialog::on_clearButton_SM_clicked()
     ui->messageIn_SM->clear();
     ui->signatureOut_SM->clear();
     ui->statusLabel_SM->clear();
-    ui->p2mrMessageHash_SM->clear();
 
     ui->addressIn_SM->setFocus();
 }
@@ -849,7 +830,6 @@ void SignVerifyMessageDialog::on_clearButton_VM_clicked()
     ui->signatureIn_VM->clear();
     ui->messageIn_VM->clear();
     ui->p2mrDataIn_VM->clear();
-    ui->p2mrVerifyMessageHash_VM->clear();
     ui->statusLabel_VM->clear();
 
     if (isP2MRDataMode()) {

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -10,16 +10,269 @@
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
 
+#include <common/p2mr_data_signature.h>
 #include <common/signmessage.h>
+#include <interfaces/wallet.h>
 #include <key_io.h>
 #include <outputtype.h>
+#include <script/interpreter.h>
+#include <util/strencodings.h>
+#include <util/translation.h>
+#include <wallet/pqc_usage.h>
 #include <wallet/wallet.h>
 
+#include <optional>
+#include <span>
 #include <string>
 #include <variant>
 #include <vector>
 
 #include <QClipboard>
+#include <QPlainTextEdit>
+#include <QStringList>
+
+#include <univalue.h>
+
+namespace {
+
+QString BilingualToQString(const bilingual_str& message)
+{
+    return QString::fromStdString(message.translated.empty() ? message.original : message.translated);
+}
+
+std::string HashToHexString(const uint256& hash)
+{
+    return HexStr(std::span<const unsigned char>{hash.begin(), hash.end()});
+}
+
+QString ToQString(const std::string& text)
+{
+    return QString::fromStdString(text);
+}
+
+bool ParseHexBytes(const QString& text, std::string_view name, size_t expected_size, std::vector<unsigned char>& bytes, QString& error)
+{
+    const std::string value{text.trimmed().toStdString()};
+    if (!IsHex(value)) {
+        error = SignVerifyMessageDialog::tr("%1 must be hex.").arg(QString::fromStdString(std::string{name}));
+        return false;
+    }
+    bytes = ParseHex(value);
+    if (bytes.size() != expected_size) {
+        error = SignVerifyMessageDialog::tr("%1 must be exactly %2 bytes.").arg(QString::fromStdString(std::string{name})).arg(expected_size);
+        return false;
+    }
+    return true;
+}
+
+bool ParseDataHash(const QString& text, uint256& hash, QString& error)
+{
+    std::vector<unsigned char> bytes;
+    if (!ParseHexBytes(text, "message_hash", uint256::size(), bytes, error)) {
+        return false;
+    }
+    hash = uint256{std::span<const unsigned char>{bytes.data(), bytes.size()}};
+    return true;
+}
+
+bool ReadRequiredString(const UniValue& object, const char* name, std::string& value, QString& error)
+{
+    const UniValue& field{object.find_value(name)};
+    if (!field.isStr()) {
+        error = SignVerifyMessageDialog::tr("Proof field \"%1\" must be a string.").arg(name);
+        return false;
+    }
+    value = field.get_str();
+    return true;
+}
+
+bool ParseProofHexField(const UniValue& object, const char* name, size_t expected_size, std::vector<unsigned char>& bytes, QString& error)
+{
+    std::string text;
+    if (!ReadRequiredString(object, name, text, error)) return false;
+    return ParseHexBytes(QString::fromStdString(text), name, expected_size, bytes, error);
+}
+
+bool ParseProofScriptField(const UniValue& object, const char* name, CScript& script, QString& error)
+{
+    std::string text;
+    if (!ReadRequiredString(object, name, text, error)) return false;
+    if (!IsHex(text)) {
+        error = SignVerifyMessageDialog::tr("Proof field \"%1\" must be hex.").arg(name);
+        return false;
+    }
+    const std::vector<unsigned char> bytes{ParseHex(text)};
+    script = CScript{bytes.begin(), bytes.end()};
+    return true;
+}
+
+bool ParseP2MRProofJson(const QString& proof_json, common::P2MRDataSignatureProof& proof, QString& error)
+{
+    UniValue object;
+    if (!object.read(proof_json.toStdString()) || !object.isObject()) {
+        error = SignVerifyMessageDialog::tr("Proof must be a JSON object.");
+        return false;
+    }
+
+    std::string proof_mode;
+    if (!ReadRequiredString(object, "proof_mode", proof_mode, error)) return false;
+    if (proof_mode != common::P2MR_DATA_SIGNATURE_PROOF_MODE) {
+        error = SignVerifyMessageDialog::tr("Unsupported proof_mode.");
+        return false;
+    }
+
+    std::string address;
+    if (!ReadRequiredString(object, "address", address, error)) return false;
+    const CTxDestination dest{DecodeDestination(address)};
+    if (!IsValidDestination(dest)) {
+        error = SignVerifyMessageDialog::tr("Proof address is invalid.");
+        return false;
+    }
+    const auto* output{std::get_if<WitnessV2P2MR>(&dest)};
+    if (!output) {
+        error = SignVerifyMessageDialog::tr("Proof address is not a P2MR address.");
+        return false;
+    }
+    proof.output = *output;
+
+    std::vector<unsigned char> bytes;
+    if (!ParseProofHexField(object, "message_hash", uint256::size(), bytes, error)) return false;
+    proof.message_hash = uint256{std::span<const unsigned char>{bytes.data(), bytes.size()}};
+
+    const UniValue& datasig_hash_field{object.find_value("datasig_hash")};
+    if (datasig_hash_field.isNull()) {
+        proof.datasig_hash = ComputeQbitDataSigPQCHash(std::span<const unsigned char>{proof.message_hash.begin(), proof.message_hash.end()});
+    } else {
+        if (!datasig_hash_field.isStr()) {
+            error = SignVerifyMessageDialog::tr("Proof field \"datasig_hash\" must be a string.");
+            return false;
+        }
+        if (!ParseHexBytes(QString::fromStdString(datasig_hash_field.get_str()), "datasig_hash", uint256::size(), bytes, error)) return false;
+        proof.datasig_hash = uint256{std::span<const unsigned char>{bytes.data(), bytes.size()}};
+    }
+
+    if (!ParseProofHexField(object, "pubkey", PQC_PUBKEY_SIZE, bytes, error)) return false;
+    proof.pubkey = CPQCPubKey{bytes};
+
+    if (!ParseProofHexField(object, "signature", PQC_SIG_SIZE, proof.signature, error)) return false;
+
+    if (!ParseProofScriptField(object, "leaf_script", proof.leaf_script, error)) return false;
+
+    std::string control_block;
+    if (!ReadRequiredString(object, "control_block", control_block, error)) return false;
+    if (!IsHex(control_block)) {
+        error = SignVerifyMessageDialog::tr("Proof field \"control_block\" must be hex.");
+        return false;
+    }
+    proof.control_block = ParseHex(control_block);
+
+    const UniValue& leaf_version{object.find_value("leaf_version")};
+    if (!leaf_version.isNum()) {
+        error = SignVerifyMessageDialog::tr("Proof field \"leaf_version\" must be a number.");
+        return false;
+    }
+    const int leaf_version_int{leaf_version.getInt<int>()};
+    if (leaf_version_int < 0 || leaf_version_int > 0xff) {
+        error = SignVerifyMessageDialog::tr("Proof field \"leaf_version\" is out of range.");
+        return false;
+    }
+    proof.leaf_version = static_cast<uint8_t>(leaf_version_int);
+    return true;
+}
+
+void AppendPQCUsageJson(UniValue& object, const wallet::PQCUsageReport& report)
+{
+    if (report.key_states.empty()) return;
+
+    UniValue key_states(UniValue::VARR);
+    for (const wallet::PQCUsageSnapshot& key_state : report.key_states) {
+        UniValue state(UniValue::VOBJ);
+        state.pushKV("pubkey", HexStr(std::span<const unsigned char>{key_state.pubkey.begin(), key_state.pubkey.end()}));
+        state.pushKV("pqc_signature_count", static_cast<int64_t>(key_state.signature_count));
+        state.pushKV("pqc_signature_limit", static_cast<int64_t>(key_state.signature_limit));
+        state.pushKV("pqc_signatures_remaining", static_cast<int64_t>(key_state.signatures_remaining));
+        state.pushKV("pqc_limit_state", std::string{wallet::PQCSignatureLimitStateName(key_state.limit_state)});
+        key_states.push_back(std::move(state));
+    }
+    object.pushKV("pqc_key_states", std::move(key_states));
+
+    if (report.overall_state.has_value()) {
+        object.pushKV("pqc_overall_limit_state", std::string{wallet::PQCSignatureLimitStateName(*report.overall_state)});
+    }
+    if (report.key_states.size() == 1) {
+        const wallet::PQCUsageSnapshot& key_state{report.key_states.front()};
+        object.pushKV("pqc_signature_count", static_cast<int64_t>(key_state.signature_count));
+        object.pushKV("pqc_signature_limit", static_cast<int64_t>(key_state.signature_limit));
+        object.pushKV("pqc_signatures_remaining", static_cast<int64_t>(key_state.signatures_remaining));
+        object.pushKV("pqc_limit_state", std::string{wallet::PQCSignatureLimitStateName(key_state.limit_state)});
+    }
+
+    const std::vector<bilingual_str> warnings{wallet::FormatPQCUsageWarnings(report.warnings)};
+    if (!warnings.empty()) {
+        UniValue warning_values(UniValue::VARR);
+        for (const bilingual_str& warning : warnings) {
+            warning_values.push_back(warning.translated.empty() ? warning.original : warning.translated);
+        }
+        object.pushKV("warnings", std::move(warning_values));
+    }
+}
+
+QString FormatPQCUsageStatus(const wallet::PQCUsageReport& report)
+{
+    QStringList lines;
+    if (report.overall_state.has_value()) {
+        lines.append(SignVerifyMessageDialog::tr("PQC usage state after signing: %1.")
+            .arg(QString::fromStdString(std::string{wallet::PQCSignatureLimitStateName(*report.overall_state)})));
+    }
+    if (report.key_states.size() == 1) {
+        const wallet::PQCUsageSnapshot& key_state{report.key_states.front()};
+        lines.append(SignVerifyMessageDialog::tr("Signatures remaining for this key: %1 of %2.")
+            .arg(key_state.signatures_remaining)
+            .arg(key_state.signature_limit));
+    }
+    for (const bilingual_str& warning : wallet::FormatPQCUsageWarnings(report.warnings)) {
+        lines.append(BilingualToQString(warning));
+    }
+    return lines.join("\n");
+}
+
+common::P2MRDataSignatureProof MakeP2MRDataSignatureProof(const interfaces::P2MRDataSignatureResult& result)
+{
+    return {
+        .output = result.output,
+        .message_hash = result.message_hash,
+        .datasig_hash = result.datasig_hash,
+        .pubkey = CPQCPubKey{std::span<const unsigned char>{result.pubkey.data(), result.pubkey.size()}},
+        .signature = result.signature,
+        .leaf_script = result.leaf_script,
+        .control_block = result.control_block,
+        .leaf_version = result.leaf_version,
+    };
+}
+
+UniValue BuildP2MRProofJson(const interfaces::P2MRDataSignatureResult& result)
+{
+    const common::P2MRDataSignatureProof proof{MakeP2MRDataSignatureProof(result)};
+    UniValue object(UniValue::VOBJ);
+    object.pushKV("address", EncodeDestination(CTxDestination{proof.output}));
+    object.pushKV("message_hash", HashToHexString(proof.message_hash));
+    object.pushKV("datasig_hash", HashToHexString(proof.datasig_hash));
+    object.pushKV("domain", common::P2MR_DATA_SIGNATURE_DOMAIN);
+    object.pushKV("algorithm", common::P2MR_DATA_SIGNATURE_ALGORITHM);
+    object.pushKV("proof_mode", common::P2MR_DATA_SIGNATURE_PROOF_MODE);
+    object.pushKV("pubkey", HexStr(std::span<const unsigned char>{proof.pubkey.begin(), proof.pubkey.end()}));
+    object.pushKV("signature", HexStr(proof.signature));
+    object.pushKV("leaf_version", static_cast<int>(proof.leaf_version));
+    object.pushKV("leaf_script", HexStr(proof.leaf_script));
+    object.pushKV("control_block", HexStr(proof.control_block));
+    object.pushKV("p2mr_merkle_root", HashToHexString(proof.output.GetMerkleRoot()));
+    if (result.pqc_usage) {
+        AppendPQCUsageJson(object, *result.pqc_usage);
+    }
+    return object;
+}
+
+} // namespace
 
 SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformStyle, QWidget *parent) :
     QDialog(parent, GUIUtil::dialog_flags),
@@ -50,6 +303,8 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformS
     ui->signatureOut_SM->setFont(GUIUtil::fixedPitchFont());
     ui->signatureIn_VM->setFont(GUIUtil::fixedPitchFont());
 
+    updateP2MRDataModeUi();
+
     GUIUtil::handleCloseWindowShortcut(this);
 }
 
@@ -61,6 +316,49 @@ SignVerifyMessageDialog::~SignVerifyMessageDialog()
 void SignVerifyMessageDialog::setModel(WalletModel *_model)
 {
     this->model = _model;
+    updateP2MRDataModeUi();
+}
+
+bool SignVerifyMessageDialog::isP2MRDataMode() const
+{
+    return IsP2MROnlyOutputChain();
+}
+
+void SignVerifyMessageDialog::updateP2MRDataModeUi()
+{
+    const bool p2mr_mode{isP2MRDataMode()};
+    if (p2mr_mode) {
+        setWindowTitle(tr("P2MR/PQC Data Signatures"));
+        ui->tabWidget->setTabText(0, tr("&Sign Data Hash"));
+        ui->tabWidget->setTabText(1, tr("&Verify Proof"));
+        ui->infoLabel_SM->setText(tr("Sign a caller-supplied 32-byte hash with a PQC key committed by a wallet-owned P2MR address. Signing consumes PQC signature budget for that key."));
+        ui->addressIn_SM->setToolTip(tr("The wallet-owned P2MR address to sign with"));
+        ui->messageIn_SM->setToolTip(tr("Enter the 32-byte message hash as 64 hex characters"));
+        ui->messageIn_SM->setPlaceholderText(tr("Enter the 32-byte message hash as 64 hex characters"));
+        ui->signatureLabel_SM->setText(tr("Proof JSON"));
+        ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Data Hash\" to generate proof JSON"));
+        ui->copySignatureButton_SM->setToolTip(tr("Copy the current proof JSON to the clipboard"));
+        ui->signMessageButton_SM->setText(tr("Sign &Data Hash"));
+        ui->signMessageButton_SM->setToolTip(tr("Sign the data hash with the selected P2MR/PQC key"));
+        ui->clearButton_SM->setToolTip(tr("Reset all sign data-hash fields"));
+
+        ui->infoLabel_VM->setText(tr("Paste a P2MR/PQC data-signature proof JSON object to verify the address commitment, P2MR control block, data-signature domain, and PQC signature."));
+        ui->addressIn_VM->setVisible(false);
+        ui->addressBookButton_VM->setVisible(false);
+        ui->signatureIn_VM->setVisible(false);
+        ui->messageIn_VM->setToolTip(tr("Paste proof JSON to verify"));
+        ui->messageIn_VM->setPlaceholderText(tr("Paste proof JSON to verify"));
+        ui->verifyMessageButton_VM->setText(tr("Verify &Proof"));
+        ui->verifyMessageButton_VM->setToolTip(tr("Verify the P2MR/PQC proof JSON"));
+        ui->clearButton_VM->setToolTip(tr("Reset the proof field"));
+    } else {
+        setWindowTitle(tr("Signatures - Sign / Verify a Message"));
+        ui->tabWidget->setTabText(0, tr("&Sign Message"));
+        ui->tabWidget->setTabText(1, tr("&Verify Message"));
+        ui->addressIn_VM->setVisible(true);
+        ui->addressBookButton_VM->setVisible(true);
+        ui->signatureIn_VM->setVisible(true);
+    }
 }
 
 void SignVerifyMessageDialog::setAddress_SM(const QString &address)
@@ -93,7 +391,7 @@ void SignVerifyMessageDialog::on_addressBookButton_SM_clicked()
 {
     if (model && model->getAddressTableModel())
     {
-        model->refresh(/*pk_hash_only=*/true);
+        model->refresh(/*pk_hash_only=*/!isP2MRDataMode());
         AddressBookPage dlg(platformStyle, AddressBookPage::ForSelection, AddressBookPage::ReceivingTab, this);
         dlg.setModel(model->getAddressTableModel());
         if (dlg.exec())
@@ -116,18 +414,64 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
     /* Clear old signature to ensure users don't get confused on error with an old signature displayed */
     ui->signatureOut_SM->clear();
 
-    if (IsP2MROnlyOutputChain()) {
-        ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
-        ui->statusLabel_SM->setText(tr("Legacy message signing is disabled on this chain."));
-        return;
-    }
-
     CTxDestination destination = DecodeDestination(ui->addressIn_SM->text().toStdString());
     if (!IsValidDestination(destination)) {
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_SM->setText(tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."));
         return;
     }
+
+    if (isP2MRDataMode()) {
+        if (!std::holds_alternative<WitnessV2P2MR>(destination)) {
+            ui->addressIn_SM->setValid(false);
+            ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_SM->setText(tr("The entered address is not a P2MR address. Please check the address and try again."));
+            return;
+        }
+
+        uint256 message_hash;
+        QString parse_error;
+        if (!ParseDataHash(ui->messageIn_SM->document()->toPlainText(), message_hash, parse_error)) {
+            ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_SM->setText(parse_error);
+            return;
+        }
+
+        WalletModel::UnlockContext ctx(model->requestUnlock());
+        if (!ctx.isValid())
+        {
+            ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_SM->setText(tr("Wallet unlock was cancelled."));
+            return;
+        }
+
+        util::Result<interfaces::P2MRDataSignatureResult> result{model->wallet().signP2MRDataHash(destination, message_hash)};
+        if (!result) {
+            ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_SM->setText(BilingualToQString(util::ErrorString(result)));
+            return;
+        }
+
+        const common::P2MRDataSignatureProof proof{MakeP2MRDataSignatureProof(*result)};
+        const common::P2MRDataSignatureVerification verification{common::VerifyP2MRDataSignatureProof(proof)};
+        if (!verification.valid) {
+            ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_SM->setText(tr("Generated proof failed local verification: %1").arg(ToQString(verification.error)));
+            return;
+        }
+
+        ui->signatureOut_SM->setPlainText(QString::fromStdString(BuildP2MRProofJson(*result).write(2)));
+        QString status{tr("P2MR/PQC data-hash proof signed.")};
+        const QString pqc_usage_status{result->pqc_usage ? FormatPQCUsageStatus(*result->pqc_usage) : QString{}};
+        if (!pqc_usage_status.isEmpty()) {
+            status.append("\n");
+            status.append(pqc_usage_status);
+        }
+        ui->statusLabel_SM->setStyleSheet("QLabel { color: green; }");
+        ui->statusLabel_SM->setText(status);
+        return;
+    }
+
     const PKHash* pkhash = std::get_if<PKHash>(&destination);
     if (!pkhash) {
         ui->addressIn_SM->setValid(false);
@@ -171,12 +515,12 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
     ui->statusLabel_SM->setStyleSheet("QLabel { color: green; }");
     ui->statusLabel_SM->setText(QString("<nobr>") + tr("Message signed.") + QString("</nobr>"));
 
-    ui->signatureOut_SM->setText(QString::fromStdString(signature));
+    ui->signatureOut_SM->setPlainText(QString::fromStdString(signature));
 }
 
 void SignVerifyMessageDialog::on_copySignatureButton_SM_clicked()
 {
-    GUIUtil::setClipboard(ui->signatureOut_SM->text());
+    GUIUtil::setClipboard(ui->signatureOut_SM->toPlainText());
 }
 
 void SignVerifyMessageDialog::on_clearButton_SM_clicked()
@@ -204,9 +548,25 @@ void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
 
 void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
 {
-    if (IsP2MROnlyOutputChain()) {
-        ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
-        ui->statusLabel_VM->setText(tr("Legacy message verification is disabled on this chain."));
+    if (isP2MRDataMode()) {
+        common::P2MRDataSignatureProof proof;
+        QString parse_error;
+        if (!ParseP2MRProofJson(ui->messageIn_VM->document()->toPlainText(), proof, parse_error)) {
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_VM->setText(parse_error);
+            return;
+        }
+
+        const common::P2MRDataSignatureVerification result{common::VerifyP2MRDataSignatureProof(proof)};
+        if (result.valid) {
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: green; }");
+            ui->statusLabel_VM->setText(
+                tr("P2MR/PQC proof verified for %1.").arg(QString::fromStdString(EncodeDestination(CTxDestination{proof.output})))
+            );
+        } else {
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_VM->setText(tr("P2MR/PQC proof verification failed: %1").arg(ToQString(result.error)));
+        }
         return;
     }
 
@@ -267,7 +627,11 @@ void SignVerifyMessageDialog::on_clearButton_VM_clicked()
     ui->messageIn_VM->clear();
     ui->statusLabel_VM->clear();
 
-    ui->addressIn_VM->setFocus();
+    if (isP2MRDataMode()) {
+        ui->messageIn_VM->setFocus();
+    } else {
+        ui->addressIn_VM->setFocus();
+    }
 }
 
 bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -12,6 +12,7 @@
 
 #include <common/p2mr_data_signature.h>
 #include <common/signmessage.h>
+#include <crypto/sha256.h>
 #include <interfaces/wallet.h>
 #include <key_io.h>
 #include <outputtype.h>
@@ -27,7 +28,9 @@
 #include <variant>
 #include <vector>
 
+#include <QByteArray>
 #include <QClipboard>
+#include <QComboBox>
 #include <QPlainTextEdit>
 #include <QStringList>
 
@@ -48,6 +51,29 @@ std::string HashToHexString(const uint256& hash)
 QString ToQString(const std::string& text)
 {
     return QString::fromStdString(text);
+}
+
+constexpr int P2MR_SIGN_INPUT_HASH{1};
+constexpr int P2MR_VERIFY_INPUT_TEXT{0};
+constexpr int P2MR_VERIFY_INPUT_HASH{1};
+constexpr int P2MR_VERIFY_INPUT_PROOF_ONLY{2};
+constexpr const char* P2MR_MESSAGE_HASH_SOURCE_UTF8_TEXT{"utf8-text"};
+constexpr const char* P2MR_MESSAGE_HASH_SOURCE_HEX_HASH{"hex-hash"};
+constexpr const char* P2MR_MESSAGE_HASH_ALGORITHM_SHA256{"sha256"};
+
+struct P2MRMessageHashMetadata {
+    std::optional<std::string> source;
+    std::optional<std::string> algorithm;
+};
+
+uint256 HashP2MRUtf8Text(const QString& text)
+{
+    const QByteArray bytes{text.toUtf8()};
+    uint256 hash;
+    CSHA256()
+        .Write(reinterpret_cast<const unsigned char*>(bytes.constData()), static_cast<size_t>(bytes.size()))
+        .Finalize(hash.begin());
+    return hash;
 }
 
 bool ParseHexBytes(const QString& text, std::string_view name, size_t expected_size, std::vector<unsigned char>& bytes, QString& error)
@@ -250,12 +276,18 @@ common::P2MRDataSignatureProof MakeP2MRDataSignatureProof(const interfaces::P2MR
     };
 }
 
-UniValue BuildP2MRProofJson(const interfaces::P2MRDataSignatureResult& result)
+UniValue BuildP2MRProofJson(const interfaces::P2MRDataSignatureResult& result, const P2MRMessageHashMetadata& metadata)
 {
     const common::P2MRDataSignatureProof proof{MakeP2MRDataSignatureProof(result)};
     UniValue object(UniValue::VOBJ);
     object.pushKV("address", EncodeDestination(CTxDestination{proof.output}));
     object.pushKV("message_hash", HashToHexString(proof.message_hash));
+    if (metadata.source.has_value()) {
+        object.pushKV("message_hash_source", *metadata.source);
+    }
+    if (metadata.algorithm.has_value()) {
+        object.pushKV("message_hash_algorithm", *metadata.algorithm);
+    }
     object.pushKV("datasig_hash", HashToHexString(proof.datasig_hash));
     object.pushKV("domain", common::P2MR_DATA_SIGNATURE_DOMAIN);
     object.pushKV("algorithm", common::P2MR_DATA_SIGNATURE_ALGORITHM);
@@ -302,6 +334,17 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformS
 
     ui->signatureOut_SM->setFont(GUIUtil::fixedPitchFont());
     ui->signatureIn_VM->setFont(GUIUtil::fixedPitchFont());
+    ui->p2mrMessageHash_SM->setFont(GUIUtil::fixedPitchFont());
+    ui->p2mrVerifyMessageHash_VM->setFont(GUIUtil::fixedPitchFont());
+
+    connect(ui->p2mrDataInputMode_SM, qOverload<int>(&QComboBox::currentIndexChanged), this, [this] {
+        updateP2MRSignModeUi();
+    });
+    connect(ui->messageIn_SM, &QPlainTextEdit::textChanged, this, &SignVerifyMessageDialog::updateP2MRSignHashPreview);
+    connect(ui->p2mrVerifyInputMode_VM, qOverload<int>(&QComboBox::currentIndexChanged), this, [this] {
+        updateP2MRVerifyModeUi();
+    });
+    connect(ui->p2mrDataIn_VM, &QPlainTextEdit::textChanged, this, &SignVerifyMessageDialog::updateP2MRVerifyHashPreview);
 
     updateP2MRDataModeUi();
 
@@ -329,20 +372,24 @@ void SignVerifyMessageDialog::updateP2MRDataModeUi()
     const bool p2mr_mode{isP2MRDataMode()};
     if (p2mr_mode) {
         setWindowTitle(tr("P2MR/PQC Data Signatures"));
-        ui->tabWidget->setTabText(0, tr("&Sign Data Hash"));
+        ui->tabWidget->setTabText(0, tr("&Sign Data"));
         ui->tabWidget->setTabText(1, tr("&Verify Proof"));
-        ui->infoLabel_SM->setText(tr("Sign a caller-supplied 32-byte hash with a PQC key committed by a wallet-owned P2MR address. Signing consumes PQC signature budget for that key."));
+        ui->infoLabel_SM->setText(tr("Sign UTF-8 text by hashing it with SHA256, or sign a caller-supplied 32-byte hash, "
+                                     "using a PQC key committed by a wallet-owned P2MR address. Signing consumes PQC "
+                                     "signature budget for that key."));
         ui->addressIn_SM->setToolTip(tr("The wallet-owned P2MR address to sign with"));
-        ui->messageIn_SM->setToolTip(tr("Enter the 32-byte message hash as 64 hex characters"));
-        ui->messageIn_SM->setPlaceholderText(tr("Enter the 32-byte message hash as 64 hex characters"));
         ui->signatureLabel_SM->setText(tr("Proof JSON"));
-        ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Data Hash\" to generate proof JSON"));
+        ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Data\" to generate proof JSON"));
         ui->copySignatureButton_SM->setToolTip(tr("Copy the current proof JSON to the clipboard"));
-        ui->signMessageButton_SM->setText(tr("Sign &Data Hash"));
-        ui->signMessageButton_SM->setToolTip(tr("Sign the data hash with the selected P2MR/PQC key"));
-        ui->clearButton_SM->setToolTip(tr("Reset all sign data-hash fields"));
+        ui->clearButton_SM->setToolTip(tr("Reset all sign data fields"));
+        ui->p2mrInputModeLabel_SM->setVisible(true);
+        ui->p2mrDataInputMode_SM->setVisible(true);
+        ui->p2mrMessageHashLabel_SM->setVisible(true);
+        ui->p2mrMessageHash_SM->setVisible(true);
 
-        ui->infoLabel_VM->setText(tr("Paste a P2MR/PQC data-signature proof JSON object to verify the address commitment, P2MR control block, data-signature domain, and PQC signature."));
+        ui->infoLabel_VM->setText(tr("Verify a P2MR/PQC data-signature proof JSON object. When original text or a 32-byte "
+                                     "hash is entered, it must match the proof's message_hash before the P2MR commitment "
+                                     "and PQC signature are verified."));
         ui->addressIn_VM->setVisible(false);
         ui->addressBookButton_VM->setVisible(false);
         ui->signatureIn_VM->setVisible(false);
@@ -350,15 +397,150 @@ void SignVerifyMessageDialog::updateP2MRDataModeUi()
         ui->messageIn_VM->setPlaceholderText(tr("Paste proof JSON to verify"));
         ui->verifyMessageButton_VM->setText(tr("Verify &Proof"));
         ui->verifyMessageButton_VM->setToolTip(tr("Verify the P2MR/PQC proof JSON"));
-        ui->clearButton_VM->setToolTip(tr("Reset the proof field"));
+        ui->clearButton_VM->setToolTip(tr("Reset the proof and data fields"));
+        ui->p2mrVerifyModeLabel_VM->setVisible(true);
+        ui->p2mrVerifyInputMode_VM->setVisible(true);
+        ui->p2mrProofLabel_VM->setVisible(true);
+
+        updateP2MRSignModeUi();
+        updateP2MRVerifyModeUi();
     } else {
         setWindowTitle(tr("Signatures - Sign / Verify a Message"));
         ui->tabWidget->setTabText(0, tr("&Sign Message"));
         ui->tabWidget->setTabText(1, tr("&Verify Message"));
+        ui->infoLabel_SM->setText(tr("You can sign messages/agreements with your legacy (P2PKH) addresses to prove you can "
+                                     "receive QBT sent to them. Be careful not to sign anything vague or random, as phishing "
+                                     "attacks may try to trick you into signing your identity over to them. Only sign "
+                                     "fully-detailed statements you agree to."));
+        ui->addressIn_SM->setToolTip(tr("The qbit address to sign the message with"));
+        ui->messageIn_SM->setToolTip(tr("Enter the message you want to sign here"));
+        ui->messageIn_SM->setPlaceholderText(tr("Enter the message you want to sign here"));
+        ui->signatureLabel_SM->setText(tr("Signature"));
+        ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Message\" to generate signature"));
+        ui->copySignatureButton_SM->setToolTip(tr("Copy the current signature to the clipboard"));
+        ui->signMessageButton_SM->setText(tr("Sign &Message"));
+        ui->signMessageButton_SM->setToolTip(tr("Sign the message to prove you own this qbit address"));
+        ui->clearButton_SM->setToolTip(tr("Reset all sign message fields"));
+        ui->p2mrInputModeLabel_SM->setVisible(false);
+        ui->p2mrDataInputMode_SM->setVisible(false);
+        ui->p2mrMessageHashLabel_SM->setVisible(false);
+        ui->p2mrMessageHash_SM->setVisible(false);
+
+        ui->infoLabel_VM->setText(tr("Enter the receiver's address, message (ensure you copy line breaks, spaces, tabs, etc. "
+                                     "exactly) and signature below to verify the message. Be careful not to read more into "
+                                     "the signature than what is in the signed message itself, to avoid being tricked by a "
+                                     "man-in-the-middle attack. Note that this only proves the signing party receives with "
+                                     "the address, it cannot prove sendership of any transaction!"));
         ui->addressIn_VM->setVisible(true);
         ui->addressBookButton_VM->setVisible(true);
         ui->signatureIn_VM->setVisible(true);
+        ui->messageIn_VM->setToolTip(tr("The signed message to verify"));
+        ui->messageIn_VM->setPlaceholderText(tr("The signed message to verify"));
+        ui->verifyMessageButton_VM->setText(tr("Verify &Message"));
+        ui->verifyMessageButton_VM->setToolTip(tr("Verify the message to ensure it was signed with the specified qbit address"));
+        ui->clearButton_VM->setToolTip(tr("Reset all verify message fields"));
+        ui->p2mrVerifyModeLabel_VM->setVisible(false);
+        ui->p2mrVerifyInputMode_VM->setVisible(false);
+        ui->p2mrVerifyMessageHashLabel_VM->setVisible(false);
+        ui->p2mrVerifyMessageHash_VM->setVisible(false);
+        ui->p2mrVerifyDataLabel_VM->setVisible(false);
+        ui->p2mrDataIn_VM->setVisible(false);
+        ui->p2mrProofLabel_VM->setVisible(false);
     }
+}
+
+void SignVerifyMessageDialog::updateP2MRSignModeUi()
+{
+    if (!isP2MRDataMode()) return;
+
+    const bool hash_mode{ui->p2mrDataInputMode_SM->currentIndex() == P2MR_SIGN_INPUT_HASH};
+    if (hash_mode) {
+        ui->messageIn_SM->setToolTip(tr("Enter the 32-byte message hash as 64 hex characters"));
+        ui->messageIn_SM->setPlaceholderText(tr("Enter the 32-byte message hash as 64 hex characters"));
+        ui->signMessageButton_SM->setText(tr("Sign Data &Hash"));
+        ui->signMessageButton_SM->setToolTip(tr("Sign the caller-supplied data hash with the selected P2MR/PQC key"));
+    } else {
+        ui->messageIn_SM->setToolTip(tr("Enter the UTF-8 text data to sign"));
+        ui->messageIn_SM->setPlaceholderText(tr("Enter the UTF-8 text data to sign"));
+        ui->signMessageButton_SM->setText(tr("Sign &Data"));
+        ui->signMessageButton_SM->setToolTip(tr("Hash the text with SHA256, then sign the hash with the selected P2MR/PQC key"));
+    }
+    updateP2MRSignHashPreview();
+}
+
+void SignVerifyMessageDialog::updateP2MRSignHashPreview()
+{
+    if (!isP2MRDataMode()) return;
+
+    uint256 message_hash;
+    if (ui->p2mrDataInputMode_SM->currentIndex() == P2MR_SIGN_INPUT_HASH) {
+        QString parse_error;
+        if (!ParseDataHash(ui->messageIn_SM->document()->toPlainText(), message_hash, parse_error)) {
+            ui->p2mrMessageHash_SM->clear();
+            return;
+        }
+    } else {
+        if (ui->messageIn_SM->document()->isEmpty()) {
+            ui->p2mrMessageHash_SM->clear();
+            return;
+        }
+        message_hash = HashP2MRUtf8Text(ui->messageIn_SM->document()->toPlainText());
+    }
+
+    ui->p2mrMessageHash_SM->setText(QString::fromStdString(HashToHexString(message_hash)));
+}
+
+void SignVerifyMessageDialog::updateP2MRVerifyModeUi()
+{
+    if (!isP2MRDataMode()) return;
+
+    const int mode{ui->p2mrVerifyInputMode_VM->currentIndex()};
+    const bool proof_only{mode == P2MR_VERIFY_INPUT_PROOF_ONLY};
+    const bool hash_mode{mode == P2MR_VERIFY_INPUT_HASH};
+
+    ui->p2mrVerifyDataLabel_VM->setVisible(!proof_only);
+    ui->p2mrDataIn_VM->setVisible(!proof_only);
+    ui->p2mrVerifyMessageHashLabel_VM->setVisible(!proof_only);
+    ui->p2mrVerifyMessageHash_VM->setVisible(!proof_only);
+
+    if (hash_mode) {
+        ui->p2mrVerifyDataLabel_VM->setText(tr("Message hash"));
+        ui->p2mrDataIn_VM->setToolTip(tr("Enter the 32-byte message hash as 64 hex characters"));
+        ui->p2mrDataIn_VM->setPlaceholderText(tr("Enter the 32-byte message hash as 64 hex characters"));
+    } else {
+        ui->p2mrVerifyDataLabel_VM->setText(tr("Data"));
+        ui->p2mrDataIn_VM->setToolTip(tr("Enter the signed UTF-8 text data to bind to the proof JSON"));
+        ui->p2mrDataIn_VM->setPlaceholderText(tr("Enter the signed UTF-8 text data to bind to the proof JSON"));
+    }
+    updateP2MRVerifyHashPreview();
+}
+
+void SignVerifyMessageDialog::updateP2MRVerifyHashPreview()
+{
+    if (!isP2MRDataMode()) return;
+
+    const int mode{ui->p2mrVerifyInputMode_VM->currentIndex()};
+    if (mode == P2MR_VERIFY_INPUT_PROOF_ONLY) {
+        ui->p2mrVerifyMessageHash_VM->clear();
+        return;
+    }
+
+    uint256 message_hash;
+    if (mode == P2MR_VERIFY_INPUT_HASH) {
+        QString parse_error;
+        if (!ParseDataHash(ui->p2mrDataIn_VM->document()->toPlainText(), message_hash, parse_error)) {
+            ui->p2mrVerifyMessageHash_VM->clear();
+            return;
+        }
+    } else {
+        if (ui->p2mrDataIn_VM->document()->isEmpty()) {
+            ui->p2mrVerifyMessageHash_VM->clear();
+            return;
+        }
+        message_hash = HashP2MRUtf8Text(ui->p2mrDataIn_VM->document()->toPlainText());
+    }
+
+    ui->p2mrVerifyMessageHash_VM->setText(QString::fromStdString(HashToHexString(message_hash)));
 }
 
 void SignVerifyMessageDialog::setAddress_SM(const QString &address)
@@ -430,12 +612,21 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
         }
 
         uint256 message_hash;
-        QString parse_error;
-        if (!ParseDataHash(ui->messageIn_SM->document()->toPlainText(), message_hash, parse_error)) {
-            ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
-            ui->statusLabel_SM->setText(parse_error);
-            return;
+        P2MRMessageHashMetadata metadata;
+        if (ui->p2mrDataInputMode_SM->currentIndex() == P2MR_SIGN_INPUT_HASH) {
+            QString parse_error;
+            if (!ParseDataHash(ui->messageIn_SM->document()->toPlainText(), message_hash, parse_error)) {
+                ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
+                ui->statusLabel_SM->setText(parse_error);
+                return;
+            }
+            metadata.source = P2MR_MESSAGE_HASH_SOURCE_HEX_HASH;
+        } else {
+            message_hash = HashP2MRUtf8Text(ui->messageIn_SM->document()->toPlainText());
+            metadata.source = P2MR_MESSAGE_HASH_SOURCE_UTF8_TEXT;
+            metadata.algorithm = P2MR_MESSAGE_HASH_ALGORITHM_SHA256;
         }
+        ui->p2mrMessageHash_SM->setText(QString::fromStdString(HashToHexString(message_hash)));
 
         WalletModel::UnlockContext ctx(model->requestUnlock());
         if (!ctx.isValid())
@@ -460,8 +651,10 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
             return;
         }
 
-        ui->signatureOut_SM->setPlainText(QString::fromStdString(BuildP2MRProofJson(*result).write(2)));
-        QString status{tr("P2MR/PQC data-hash proof signed.")};
+        ui->signatureOut_SM->setPlainText(QString::fromStdString(BuildP2MRProofJson(*result, metadata).write(2)));
+        QString status{metadata.algorithm.has_value() ?
+            tr("P2MR/PQC data proof signed.") :
+            tr("P2MR/PQC data-hash proof signed.")};
         const QString pqc_usage_status{result->pqc_usage ? FormatPQCUsageStatus(*result->pqc_usage) : QString{}};
         if (!pqc_usage_status.isEmpty()) {
             status.append("\n");
@@ -529,6 +722,7 @@ void SignVerifyMessageDialog::on_clearButton_SM_clicked()
     ui->messageIn_SM->clear();
     ui->signatureOut_SM->clear();
     ui->statusLabel_SM->clear();
+    ui->p2mrMessageHash_SM->clear();
 
     ui->addressIn_SM->setFocus();
 }
@@ -557,12 +751,41 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
             return;
         }
 
+        std::optional<uint256> expected_message_hash;
+        const int verify_mode{ui->p2mrVerifyInputMode_VM->currentIndex()};
+        if (verify_mode == P2MR_VERIFY_INPUT_HASH) {
+            uint256 parsed_hash;
+            if (!ParseDataHash(ui->p2mrDataIn_VM->document()->toPlainText(), parsed_hash, parse_error)) {
+                ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+                ui->statusLabel_VM->setText(parse_error);
+                return;
+            }
+            expected_message_hash = parsed_hash;
+        } else if (verify_mode == P2MR_VERIFY_INPUT_TEXT) {
+            expected_message_hash = HashP2MRUtf8Text(ui->p2mrDataIn_VM->document()->toPlainText());
+        }
+
+        if (expected_message_hash.has_value() && *expected_message_hash != proof.message_hash) {
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_VM->setText(
+                tr("Entered data hashes to %1, but the proof signed %2.")
+                    .arg(QString::fromStdString(HashToHexString(*expected_message_hash)))
+                    .arg(QString::fromStdString(HashToHexString(proof.message_hash)))
+            );
+            return;
+        }
+
         const common::P2MRDataSignatureVerification result{common::VerifyP2MRDataSignatureProof(proof)};
         if (result.valid) {
             ui->statusLabel_VM->setStyleSheet("QLabel { color: green; }");
-            ui->statusLabel_VM->setText(
-                tr("P2MR/PQC proof verified for %1.").arg(QString::fromStdString(EncodeDestination(CTxDestination{proof.output})))
-            );
+            QString status{tr("P2MR/PQC proof verified for %1.")
+                .arg(QString::fromStdString(EncodeDestination(CTxDestination{proof.output})))};
+            if (expected_message_hash.has_value()) {
+                status.append("\n");
+                status.append(tr("Entered data matches message hash %1.")
+                    .arg(QString::fromStdString(HashToHexString(*expected_message_hash))));
+            }
+            ui->statusLabel_VM->setText(status);
         } else {
             ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
             ui->statusLabel_VM->setText(tr("P2MR/PQC proof verification failed: %1").arg(ToQString(result.error)));
@@ -625,6 +848,8 @@ void SignVerifyMessageDialog::on_clearButton_VM_clicked()
     ui->addressIn_VM->clear();
     ui->signatureIn_VM->clear();
     ui->messageIn_VM->clear();
+    ui->p2mrDataIn_VM->clear();
+    ui->p2mrVerifyMessageHash_VM->clear();
     ui->statusLabel_VM->clear();
 
     if (isP2MRDataMode()) {

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -34,6 +34,9 @@ protected:
     void changeEvent(QEvent* e) override;
 
 private:
+    bool isP2MRDataMode() const;
+    void updateP2MRDataModeUi();
+
     Ui::SignVerifyMessageDialog *ui;
     WalletModel* model{nullptr};
     const PlatformStyle *platformStyle;

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -36,6 +36,10 @@ protected:
 private:
     bool isP2MRDataMode() const;
     void updateP2MRDataModeUi();
+    void updateP2MRSignModeUi();
+    void updateP2MRSignHashPreview();
+    void updateP2MRVerifyModeUi();
+    void updateP2MRVerifyHashPreview();
 
     Ui::SignVerifyMessageDialog *ui;
     WalletModel* model{nullptr};

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -53,6 +53,7 @@
 #include <QComboBox>
 #include <QElapsedTimer>
 #include <QEvent>
+#include <QLineEdit>
 #include <QObject>
 #include <QPointer>
 #include <QPlainTextEdit>
@@ -775,25 +776,61 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
 
     QTabWidget* tab_widget = sign_verify_dialog.findChild<QTabWidget*>("tabWidget");
     QVERIFY(tab_widget);
-    QCOMPARE(tab_widget->tabText(0), QString("&Sign Data Hash"));
+    QCOMPARE(tab_widget->tabText(0), QString("&Sign Data"));
     QCOMPARE(tab_widget->tabText(1), QString("&Verify Proof"));
 
     QLabel* signature_label = sign_verify_dialog.findChild<QLabel*>("signatureLabel_SM");
     QVERIFY(signature_label);
     QCOMPARE(signature_label->text(), QString("Proof JSON"));
 
+    QComboBox* sign_input_mode = sign_verify_dialog.findChild<QComboBox*>("p2mrDataInputMode_SM");
+    QVERIFY(sign_input_mode);
+    QCOMPARE(sign_input_mode->count(), 2);
+    QCOMPARE(sign_input_mode->currentText(), QString("Text"));
+
+    QPlainTextEdit* sign_input = sign_verify_dialog.findChild<QPlainTextEdit*>("messageIn_SM");
+    QVERIFY(sign_input);
+    QVERIFY(sign_input->placeholderText().contains("UTF-8 text"));
+
+    QLineEdit* sign_hash_preview = sign_verify_dialog.findChild<QLineEdit*>("p2mrMessageHash_SM");
+    QVERIFY(sign_hash_preview);
+    sign_input->setPlainText("abc");
+    QCOMPARE(sign_hash_preview->text(), QString("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"));
+
+    sign_input_mode->setCurrentIndex(1);
+    QVERIFY(sign_input->placeholderText().contains("64 hex"));
+    sign_input->setPlainText(QString(64, '0'));
+    QCOMPARE(sign_hash_preview->text(), QString(64, '0'));
+
     QPushButton* sign_button = sign_verify_dialog.findChild<QPushButton*>("signMessageButton_SM");
     QVERIFY(sign_button);
-    QCOMPARE(sign_button->text(), QString("Sign &Data Hash"));
+    QCOMPARE(sign_button->text(), QString("Sign Data &Hash"));
 
     QPlainTextEdit* proof_output = sign_verify_dialog.findChild<QPlainTextEdit*>("signatureOut_SM");
     QVERIFY(proof_output);
     QVERIFY(proof_output->minimumHeight() >= 96);
-    QVERIFY(proof_output->placeholderText().contains("Sign Data Hash"));
+    QVERIFY(proof_output->placeholderText().contains("Sign Data"));
 
     QPlainTextEdit* proof_input = sign_verify_dialog.findChild<QPlainTextEdit*>("messageIn_VM");
     QVERIFY(proof_input);
     QVERIFY(proof_input->placeholderText().contains("proof JSON"));
+
+    QComboBox* verify_input_mode = sign_verify_dialog.findChild<QComboBox*>("p2mrVerifyInputMode_VM");
+    QVERIFY(verify_input_mode);
+    QCOMPARE(verify_input_mode->count(), 3);
+    QCOMPARE(verify_input_mode->currentText(), QString("Text + proof"));
+
+    QPlainTextEdit* verify_data_input = sign_verify_dialog.findChild<QPlainTextEdit*>("p2mrDataIn_VM");
+    QVERIFY(verify_data_input);
+    verify_data_input->setPlainText("abc");
+
+    QLineEdit* verify_hash_preview = sign_verify_dialog.findChild<QLineEdit*>("p2mrVerifyMessageHash_VM");
+    QVERIFY(verify_hash_preview);
+    QCOMPARE(verify_hash_preview->text(), QString("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"));
+
+    verify_input_mode->setCurrentIndex(2);
+    QVERIFY(verify_data_input->isHidden());
+    QVERIFY(verify_hash_preview->isHidden());
 
     QValidatedLineEdit* verify_address = sign_verify_dialog.findChild<QValidatedLineEdit*>("addressIn_VM");
     QVERIFY(verify_address);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -794,6 +794,7 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
 
     QLineEdit* sign_hash_preview = sign_verify_dialog.findChild<QLineEdit*>("p2mrMessageHash_SM");
     QVERIFY(sign_hash_preview);
+    QCOMPARE(sign_hash_preview->text(), QString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
     sign_input->setPlainText("abc");
     QCOMPARE(sign_hash_preview->text(), QString("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"));
 
@@ -822,10 +823,11 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
 
     QPlainTextEdit* verify_data_input = sign_verify_dialog.findChild<QPlainTextEdit*>("p2mrDataIn_VM");
     QVERIFY(verify_data_input);
-    verify_data_input->setPlainText("abc");
 
     QLineEdit* verify_hash_preview = sign_verify_dialog.findChild<QLineEdit*>("p2mrVerifyMessageHash_VM");
     QVERIFY(verify_hash_preview);
+    QCOMPARE(verify_hash_preview->text(), QString("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+    verify_data_input->setPlainText("abc");
     QCOMPARE(verify_hash_preview->text(), QString("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"));
 
     verify_input_mode->setCurrentIndex(2);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -23,6 +23,7 @@
 #include <qt/recentrequeststablemodel.h>
 #include <qt/sendcoinsdialog.h>
 #include <qt/sendcoinsentry.h>
+#include <qt/signverifymessagedialog.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
 #include <qt/walletmodel.h>
@@ -33,6 +34,7 @@
 #include <script/solver.h>
 #include <consensus/consensus.h>
 #include <test/util/setup_common.h>
+#include <util/translation.h>
 #include <validation.h>
 #include <wallet/pqc_usage.h>
 #include <wallet/test/util.h>
@@ -53,7 +55,9 @@
 #include <QEvent>
 #include <QObject>
 #include <QPointer>
+#include <QPlainTextEdit>
 #include <QPushButton>
+#include <QTabWidget>
 #include <QTimer>
 #include <QVBoxLayout>
 #include <QTextEdit>
@@ -480,6 +484,7 @@ public:
     util::Result<CTxDestination> getNewDestination(const OutputType, const std::string&) override { return CTxDestination{PKHash{}}; }
     bool getPubKey(const CScript&, const CKeyID&, CPubKey&) override { return false; }
     SigningResult signMessage(const std::string&, const PKHash&, std::string&) override { return SigningResult::PRIVATE_KEY_NOT_AVAILABLE; }
+    util::Result<interfaces::P2MRDataSignatureResult> signP2MRDataHash(const CTxDestination&, const uint256&) override { return util::Error{Untranslated("P2MR data-hash signing unavailable")}; }
     bool isSpendable(const CTxDestination&) override { return false; }
     bool setAddressBook(const CTxDestination&, const std::string&, const std::optional<wallet::AddressPurpose>&) override { return false; }
     bool delAddressBook(const CTxDestination&) override { return false; }
@@ -764,6 +769,43 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     QCOMPARE(address_type->currentData().toInt(), static_cast<int>(OutputType::P2MR));
     QCOMPARE(address_type->itemText(0), QString("P2MR"));
     QVERIFY(!address_type->isVisibleTo(&receiveCoinsDialog));
+
+    SignVerifyMessageDialog sign_verify_dialog(platformStyle.get(), nullptr);
+    sign_verify_dialog.setModel(mini_gui.walletModel.get());
+
+    QTabWidget* tab_widget = sign_verify_dialog.findChild<QTabWidget*>("tabWidget");
+    QVERIFY(tab_widget);
+    QCOMPARE(tab_widget->tabText(0), QString("&Sign Data Hash"));
+    QCOMPARE(tab_widget->tabText(1), QString("&Verify Proof"));
+
+    QLabel* signature_label = sign_verify_dialog.findChild<QLabel*>("signatureLabel_SM");
+    QVERIFY(signature_label);
+    QCOMPARE(signature_label->text(), QString("Proof JSON"));
+
+    QPushButton* sign_button = sign_verify_dialog.findChild<QPushButton*>("signMessageButton_SM");
+    QVERIFY(sign_button);
+    QCOMPARE(sign_button->text(), QString("Sign &Data Hash"));
+
+    QPlainTextEdit* proof_output = sign_verify_dialog.findChild<QPlainTextEdit*>("signatureOut_SM");
+    QVERIFY(proof_output);
+    QVERIFY(proof_output->minimumHeight() >= 96);
+    QVERIFY(proof_output->placeholderText().contains("Sign Data Hash"));
+
+    QPlainTextEdit* proof_input = sign_verify_dialog.findChild<QPlainTextEdit*>("messageIn_VM");
+    QVERIFY(proof_input);
+    QVERIFY(proof_input->placeholderText().contains("proof JSON"));
+
+    QValidatedLineEdit* verify_address = sign_verify_dialog.findChild<QValidatedLineEdit*>("addressIn_VM");
+    QVERIFY(verify_address);
+    QVERIFY(verify_address->isHidden());
+
+    QValidatedLineEdit* verify_signature = sign_verify_dialog.findChild<QValidatedLineEdit*>("signatureIn_VM");
+    QVERIFY(verify_signature);
+    QVERIFY(verify_signature->isHidden());
+
+    QPushButton* verify_button = sign_verify_dialog.findChild<QPushButton*>("verifyMessageButton_VM");
+    QVERIFY(verify_button);
+    QCOMPARE(verify_button->text(), QString("Verify &Proof"));
 }
 
 void TestSendPQCReportPropagation(interfaces::Node& node)

--- a/src/rpc/signmessage.cpp
+++ b/src/rpc/signmessage.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <common/signmessage.h>
+#include <common/p2mr_data_signature.h>
 #include <crypto/pqc.h>
 #include <key.h>
 #include <key_io.h>
@@ -225,11 +226,6 @@ static RPCHelpMan verifydatapqchash()
 
             const std::vector<unsigned char> leaf_script_bytes{ParseHexV(proof.find_value("leaf_script"), "leaf_script")};
             const CScript leaf_script{leaf_script_bytes.begin(), leaf_script_bytes.end()};
-            const std::optional<CPQCPubKey> leaf_pubkey{p2mr::MatchPK(leaf_script)};
-            if (!leaf_pubkey || *leaf_pubkey != pubkey) {
-                return InvalidDataPQCProof("leaf_script is not a single-key P2MR pubkey leaf for pubkey");
-            }
-
             const int leaf_version_int{proof.find_value("leaf_version").getInt<int>()};
             if (leaf_version_int < 0 || leaf_version_int > 0xff) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "leaf_version out of range");
@@ -251,15 +247,20 @@ static RPCHelpMan verifydatapqchash()
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "leaf_version does not match control_block");
             }
 
-            const uint256 leaf_hash{ComputeP2MRLeafHash(leaf_version, leaf_script_bytes)};
-            const uint256 merkle_root{ComputeP2MRMerkleRoot(control_block, leaf_hash)};
-            if (merkle_root != output->GetMerkleRoot()) {
-                return InvalidDataPQCProof("leaf_script/control_block do not match address");
-            }
-
             const uint256 datasig_hash{ComputeQbitDataSigPQCHash(std::span<const unsigned char>{message_hash.begin(), message_hash.end()})};
-            if (!pubkey.Verify(datasig_hash, signature)) {
-                return InvalidDataPQCProof("signature does not verify");
+            const common::P2MRDataSignatureProof data_proof{
+                .output = *output,
+                .message_hash = message_hash,
+                .datasig_hash = datasig_hash,
+                .pubkey = pubkey,
+                .signature = signature,
+                .leaf_script = leaf_script,
+                .control_block = control_block,
+                .leaf_version = leaf_version,
+            };
+            const common::P2MRDataSignatureVerification verification{common::VerifyP2MRDataSignatureProof(data_proof)};
+            if (!verification.valid) {
+                return InvalidDataPQCProof(verification.error);
             }
 
             UniValue result{UniValue::VOBJ};
@@ -269,7 +270,7 @@ static RPCHelpMan verifydatapqchash()
             result.pushKV("datasig_hash", HashToHex(datasig_hash));
             result.pushKV("pubkey", HexStr(pubkey_bytes));
             result.pushKV("proof_mode", proof_mode);
-            result.pushKV("p2mr_merkle_root", HashToHex(merkle_root));
+            result.pushKV("p2mr_merkle_root", HashToHex(verification.p2mr_merkle_root));
             return result;
         },
     };

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -26,6 +26,7 @@
 #include <wallet/load.h>
 #include <wallet/pqc_usage.h>
 #include <wallet/receive.h>
+#include <wallet/rpc/util.h>
 #include <wallet/rpc/wallet.h>
 #include <wallet/spend.h>
 #include <wallet/wallet.h>
@@ -42,6 +43,7 @@ using interfaces::Chain;
 using interfaces::FoundBlock;
 using interfaces::Handler;
 using interfaces::MakeSignalHandler;
+using interfaces::P2MRDataSignatureResult;
 using interfaces::Wallet;
 using interfaces::WalletAddress;
 using interfaces::WalletBalances;
@@ -188,6 +190,40 @@ public:
     {
         if (GetPQCKeyValidationSigningError(*m_wallet)) return SigningResult::SIGNING_FAILED;
         return m_wallet->SignMessage(message, pkhash, str_sig);
+    }
+    util::Result<P2MRDataSignatureResult> signP2MRDataHash(const CTxDestination& dest, const uint256& message_hash) override
+    {
+        if (const auto error{GetPQCKeyValidationSigningError(*m_wallet)}) return util::Error{*error};
+
+        const auto* output{std::get_if<WitnessV2P2MR>(&dest)};
+        if (!output) {
+            return util::Error{Untranslated("Address is not a P2MR address")};
+        }
+
+        PQCUsageRecorder pqc_usage_recorder;
+        util::Result<DataPQCSignatureProof> proof{m_wallet->SignDataPQCHash(
+            *output,
+            message_hash,
+            /*requested_pubkey=*/std::nullopt,
+            /*requested_leaf_script=*/std::nullopt,
+            /*requested_control_block=*/std::nullopt,
+            pqc_usage_recorder.GetObserver())};
+        if (!proof) {
+            return util::Error{util::ErrorString(proof)};
+        }
+
+        P2MRDataSignatureResult result;
+        result.output = proof->output;
+        result.message_hash = proof->message_hash;
+        result.datasig_hash = proof->datasig_hash;
+        result.pubkey.assign(proof->pubkey.begin(), proof->pubkey.end());
+        result.signature = proof->signature;
+        result.leaf_script = proof->leaf_script;
+        result.control_block = proof->control_block;
+        result.leaf_version = proof->leaf_version;
+        result.pqc_usage = std::make_shared<const PQCUsageReport>(BuildSigningPQCUsageReport(pqc_usage_recorder));
+        LogPQCUsageWarnings(*m_wallet, *result.pqc_usage);
+        return result;
     }
     bool isSpendable(const CTxDestination& dest) override
     {


### PR DESCRIPTION
## Summary

Adds P2MR/PQC data-hash signing and proof verification to the existing Qt Sign/Verify dialog on P2MR-only chains.

This PR:

- re-enables the Sign/Verify menu actions on P2MR-only chains with P2MR data-proof labels
- lets the Qt dialog sign 32-byte hashes with wallet-owned P2MR/PQC keys and emit proof JSON compatible with `signdatapqchash`
- lets the Qt dialog verify pasted P2MR/PQC proof JSON compatible with `verifydatapqchash`
- shares the P2MR proof verification logic between Qt and the RPC verifier
- surfaces PQC signature budget state after Qt signing
- adds Qt wallet test coverage for the P2MR-only dialog mode

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Checks run:

- `git diff --check`
- `cmake --build build_qt_p2mr --target qbit-qt test_qbit test_qbit-qt -j 8`
- `cmake --build build_qt_p2mr --target qbitd qbit-cli -j 8`
- `build_qt_p2mr/bin/test_qbit --run_test=wallet_p2mr_descriptor_tests/P2MRDataHashSigningRetriesLaterLeavesAfterRuntimeFailure --catch_system_errors=no --log_level=test_suite`
- `ulimit -n 1024; python3 test/functional/feature_p2mr.py --configfile build_qt_p2mr/test/config.ini`
- `ulimit -n 1024; QT_QPA_PLATFORM=offscreen build_qt_p2mr/bin/test_qbit-qt`
- Docker lint image from `ci/lint_imagefile`, running the default lint entrypoint. The local checkout is a git worktree, so the run mounted the shared git metadata as well as the worktree.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- The shared verifier is used by `verifydatapqchash` and Qt proof verification.
- Qt signing calls the existing wallet P2MR data-hash signing path and locally verifies generated proofs before displaying them.
- Legacy message signing behavior is preserved on non-P2MR-only chains.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this exposes existing P2MR data-signature RPC behavior in the Qt dialog; the dialog labels, tooltips, and generated proof JSON provide the user-facing guidance.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Upstream fix is merged into the maintained libbitcoinpqc branch used by qbit.
- [ ] Curated branch `qbit-subtree` was refreshed with prune.
- [ ] Subtree update was done with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/git-subtree-check.sh -r src/libbitcoinpqc` passes locally.
- [ ] Followed `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785419785&installation_id=141183937&pr_number=63&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F63&signature=82f98ee40f4712ce67873a837887ae896a77f67e8f48ba865afa4e88d4d3dfdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet PQC signing (consumes signature budget) and shared crypto/P2MR verification, but mostly surfaces existing RPC behavior and deduplicates verifier logic rather than changing consensus.
> 
> **Overview**
> On **P2MR-only chains**, the Sign/Verify menu is turned back on and the existing dialog becomes **P2MR/PQC data signing**: UTF-8 text (SHA256) or a raw 32-byte hash, wallet-owned P2MR addresses, and **proof JSON** aligned with `signdatapqchash` / `verifydatapqchash`. Legacy P2PKH message sign/verify is unchanged on other chains.
> 
> A new **`common::VerifyP2MRDataSignatureProof`** path centralizes P2MR commitment + PQC signature checks; **`verifydatapqchash`** and the Qt verifier both call it. The wallet **`interfaces::Wallet::signP2MRDataHash`** wraps the existing `SignDataPQCHash` flow and returns PQC usage for the UI. Qt signing locally re-verifies proofs before display and reports **PQC signature budget** after sign.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04072187632a5f3b05f7e559b2786f3ab50e17d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->