### PR TITLE
Record release trust for v0.1.2-testnet4

### DIFF
--- a/doc/release-trust-0.1.2-testnet4.md
+++ b/doc/release-trust-0.1.2-testnet4.md
@@ -1,0 +1,32 @@
+# qbit 0.1.2-testnet4 Release Trust Reference
+
+This note anchors the reviewed policy/tooling commit used by the
+`release-publish.yml` workflow for qbit 0.1.2-testnet4.
+
+Release source:
+
+- Release tag: `v0.1.2-testnet4`
+- Tag object: `bc715e6933507c4755d33628bf77a222ed0bb7f6`
+- Tag target: `6f29b4a5e5d2ad41bd9cebd100439b43a8b81eef`
+
+The `trusted_release_ref` supplied to the publish workflow must be the full
+40-character SHA of a reviewed commit in `Qbit-Org/qbit` whose history contains
+the release tag target. It must not be the release tag object or the release tag
+target commit.
+
+The trusted commit must retain the public release validators, publish workflow,
+testnet posture verifier, and operator key policy used to validate the final
+artifact set:
+
+- `.github/workflows/release-publish.yml`
+- `ci/release/validate_release_artifacts.py`
+- `ci/release/validate_builder_attestations.py`
+- `ci/release/validate_key_metadata.py`
+- `ci/release/verify_testnet_release_posture.py`
+- `contrib/keys/operator-keys/keys.json`
+- `contrib/keys/operator-keys/public-keys/operator-01-release.asc`
+- `contrib/keys/operator-keys/public-keys/operator-02-release.asc`
+- `contrib/keys/operator-keys/public-keys/operator-03-release.asc`
+
+After this note is reviewed and merged, use the resulting full 40-character
+`Qbit-Org/qbit` commit SHA as `trusted_release_ref`.


### PR DESCRIPTION
Adds the public release trust reference for v0.1.2-testnet4 after the signed release tag was created.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change on the existing release-policy allowlist; no runtime, auth, or release tooling code is modified.
> 
> **Overview**
> Adds **`doc/release-trust-0.1.2-testnet4.md`**, the public release-trust note for **qbit 0.1.2-testnet4**, following the same pattern as prior `doc/release-trust-*.md` files.
> 
> The doc records the signed tag **`v0.1.2-testnet4`** (tag object and target SHAs), explains that **`trusted_release_ref`** for `release-publish.yml` must be a full 40-character reviewed commit—not the tag object or tag target—and lists the validator, workflow, testnet posture, and operator key paths that commit must still contain. Operators are instructed to use **this PR’s merge commit SHA** as `trusted_release_ref` after review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 332577e2fafa29f40d7330d415e85ae2ecd42002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785613437&installation_id=141183937&pr_number=66&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F66&signature=756e9f36debceda3fbc14feffdb90a65c471d33e9d314d5aff92c49c7fb182e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->