### PR TITLE
Split MSan depends CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,6 +708,7 @@ jobs:
       CI_DOCKER_RUN_CPUS: ${{ matrix.container-cpus || '8' }}
       CI_DOCKER_RUN_MEMORY: ${{ matrix.container-memory || '48g' }}
       CI_ENFORCE_INTERNAL_REGISTRY: ${{ github.repository == 'Qbit-Org/qbit' && matrix.file-env != './ci/test/00_setup_env_native_centos.sh' && '1' || '0' }}
+      MSAN_CI_PART: ${{ matrix.msan-ci-part || '' }}
 
     strategy:
       fail-fast: false
@@ -755,11 +756,19 @@ jobs:
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_tsan.sh'
 
-          - name: 'MSan, depends'
+          - name: 'MSan, depends, unit tests'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_msan.sh'
+            msan-ci-part: 'unit'
+
+          - name: 'MSan, depends, functional tests'
+            cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
+            fallback-runner: 'ubuntu-24.04'
+            timeout-minutes: 200
+            file-env: './ci/test/00_setup_env_native_msan.sh'
+            msan-ci-part: 'functional'
 
     steps:
       - *CHECKOUT
@@ -783,7 +792,7 @@ jobs:
         run: sed -i "s|\${INSTALL_BCC_TRACING_TOOLS}|true|g" ./ci/test/00_setup_env_native_asan.sh
 
       - name: Set mmap_rnd_bits
-        if: ${{ env.CONTAINER_NAME == 'ci_native_tsan' || env.CONTAINER_NAME == 'ci_native_msan' }}
+        if: ${{ env.CONTAINER_NAME == 'ci_native_tsan' || startsWith(env.CONTAINER_NAME, 'ci_native_msan') }}
         # Sanitizers can crash when ASLR entropy is too high (vm.mmap_rnd_bits > 28).
         # Some runners block sysctl writes but already have a compliant value.
         run: |

--- a/ci/test/00_setup_env_native_msan.sh
+++ b/ci/test/00_setup_env_native_msan.sh
@@ -32,3 +32,39 @@ export BITCOIN_CONFIG="\
  -DAPPEND_CPPFLAGS='-U_FORTIFY_SOURCE' \
 "
 export USE_INSTRUMENTED_LIBCPP="MemoryWithOrigins"
+
+case "${MSAN_CI_PART:-}" in
+  "")
+    ;;
+  "unit")
+    export CONTAINER_NAME="ci_native_msan_unit"
+    export GOAL="all"
+    export RUN_UNIT_TESTS=true
+    export RUN_FUNCTIONAL_TESTS=false
+    BITCOIN_CONFIG+="\
+ -DBUILD_BITCOIN_BIN=OFF \
+ -DBUILD_DAEMON=OFF \
+ -DBUILD_CLI=OFF \
+ -DBUILD_TX=OFF \
+ -DBUILD_UTIL=OFF \
+ -DBUILD_WALLET_TOOL=OFF \
+"
+    ;;
+  "functional")
+    export CONTAINER_NAME="ci_native_msan_functional"
+    export RUN_UNIT_TESTS=false
+    export RUN_FUNCTIONAL_TESTS=true
+    BITCOIN_CONFIG+="\
+ -DBUILD_TESTS=OFF \
+ -DBUILD_TX=ON \
+ -DBUILD_UTIL=ON \
+ -DBUILD_WALLET_TOOL=ON \
+"
+    ;;
+  *)
+    echo "Unknown MSAN_CI_PART '${MSAN_CI_PART}'" >&2
+    exit 1
+    ;;
+esac
+
+export BITCOIN_CONFIG


### PR DESCRIPTION
## Summary

Split the existing `MSan, depends` CI matrix entry into two smaller jobs targeting the same MSan environment:

- `MSan, depends, unit tests`
- `MSan, depends, functional tests`

The split is selected with `MSAN_CI_PART` in the MSan env file. The default unset behavior remains unchanged for local/manual use. The unit job skips functional tests and non-test executables, while the functional job skips `BUILD_TESTS` but keeps the functional-test tools enabled so tool-dependent functional coverage is not silently skipped.

## Testing

- [ ] Built locally.
- [ ] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Checks run:

- `bash -n ci/test/00_setup_env_native_msan.sh ci/test/03_test_script.sh ci/test/00_setup_env.sh`
- Parsed `.github/workflows/ci.yml` with Ruby YAML and PyYAML.
- `git diff --check origin/main...HEAD`
- Verified the `MSAN_CI_PART` env resolution for default, `unit`, and `functional` paths through `ci/test/00_setup_env.sh`.
- Docker repo lint image build and lint runner passed.
- Dockerized actionlint was also run; it reports existing workflow findings already present on the base workflow, so those broader workflow cleanups are left out of scope for this PR.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: CI behavior changes only. Runtime consensus, wallet, P2P, script, crypto, and release code are unchanged.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: CI-only job scheduling change.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

N/A; `src/libbitcoinpqc` is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785615079&installation_id=141183937&pr_number=67&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F67&signature=030e7a7d632f49d53ae16888a39eea6c3c30ef516685282b1fe553b9e4015335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI scheduling and build flags only; no runtime product code changes. Slightly higher operational risk if one split job misconfigures test toggles and silently drops coverage.
> 
> **Overview**
> **Splits the single MSan depends CI job into two parallel matrix jobs** so unit and functional MSan coverage run separately with smaller, targeted builds.
> 
> The workflow passes **`MSAN_CI timeout-minutes`** from the matrix into the job env. **`00_setup_env_native_msan.sh`** branches on **`MSAN_CI_PART`**: the **unit** job sets **`ci_native_msan_unit`**, runs unit tests only, uses **`GOAL=all`**, and turns off GUI/daemon/CLI and other non-test binaries; the **functional** job sets **`ci_native_msan_functional`**, skips unit tests, disables **`BUILD_TESTS`**, and keeps **`qbit-tx`**, **`qbit-util`**, and **`qbit-wallet`** for functional coverage. Unset **`MSAN_CI_PART`** keeps the prior combined behavior for local runs.
> 
> The **Set mmap_rnd_bits** step now applies to any container whose name starts with **`ci_native_msan`**, not only the legacy single name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a78714827f9aee3275989df735400fd5ff7009a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->