### PR TITLE
Split release tag rulesets

### DIFF
--- a/.github/rulesets/release-tags-v-creation.json
+++ b/.github/rulesets/release-tags-v-creation.json
@@ -1,0 +1,30 @@
+{
+  "name": "public-release-tags-v-creation",
+  "target": "tag",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 18321137,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/tags/v*"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "creation"
+    }
+  ]
+}

--- a/.github/rulesets/release-tags-v-immutability.json
+++ b/.github/rulesets/release-tags-v-immutability.json
@@ -1,5 +1,5 @@
 {
-  "name": "public-release-tags-v",
+  "name": "public-release-tags-v-immutability",
   "target": "tag",
   "enforcement": "active",
   "bypass_actors": [
@@ -18,9 +18,6 @@
     }
   },
   "rules": [
-    {
-      "type": "creation"
-    },
     {
       "type": "update",
       "parameters": {

--- a/doc/development/public-branch-and-rulesets.md
+++ b/doc/development/public-branch-and-rulesets.md
@@ -35,10 +35,11 @@ Public release tags use signed, annotated `v*` tags:
 | `v0.1.0-testnet4` | Final v0.1.0 testnet4 release tag. |
 | `v0.1.N-testnet4` | Future v0.1.x patch or reset tags, when needed. |
 
-Tag updates and deletions are not part of normal release operations. If a tag
-must be corrected before announcement, delete and recreate it only through the
-release-maintainer path, and record the replacement rationale in the release
-checklist.
+Tag updates and deletions are not part of normal release operations. Release
+maintainers may create `v*` tags, but they must not be able to update or delete
+them after creation. If a tag must be corrected before announcement, delete and
+recreate it only through an organization-admin break-glass path, and record the
+replacement rationale in the release checklist.
 
 ## Ruleset Templates
 
@@ -48,7 +49,8 @@ Ruleset JSON templates are the public-safe files below:
 | --- | --- | --- |
 | `.github/rulesets/main.json` | `refs/heads/main` | Require pull requests, one approval, resolved conversations, squash/rebase merge methods only, linear history, `Required Merge Gate`, block deletion, and block non-fast-forward updates. |
 | `.github/rulesets/0.1.x.json` | `refs/heads/0.1.x` | Restrict branch creation to bypass actors, require pull requests, one approval, resolved conversations, squash/rebase merge methods only, linear history, `Required Merge Gate`, block deletion, and block non-fast-forward updates. |
-| `.github/rulesets/release-tags-v.json` | `refs/tags/v*` | Restrict tag creation, updates, and deletion to bypass actors. |
+| `.github/rulesets/release-tags-v-creation.json` | `refs/tags/v*` | Restrict tag creation to organization admins and the release-maintainers team. |
+| `.github/rulesets/release-tags-v-immutability.json` | `refs/tags/v*` | Restrict tag updates and deletion to organization admins only. |
 | `.github/rulesets/upstream-refs.json` | `refs/heads/upstream/**` | Lock optional upstream reference branches so only bypass actors can create, update, or delete them. |
 
 ## Repository Merge Settings
@@ -68,11 +70,15 @@ temporarily set `allow_merge_commit` to `true`, perform the merge, record the
 reason in the relevant pull request or release checklist, and immediately
 restore this default template.
 
-Templates that restrict ref creation, update, or deletion intentionally use
-`OrganizationAdmin` as the only portable bypass actor. Before applying them to
-the public repository, maintainers should replace or supplement that bypass
-with the final public release-maintainer team, user, or repository-role actor
-IDs.
+Templates that restrict ref creation, update, or deletion use
+`OrganizationAdmin` as the portable bypass actor. The `v*` tag creation template
+also includes a `Team` bypass actor for the release-maintainers team. GitHub
+rulesets require the numeric team ID as `actor_id`; the current public
+`release-maintainers` team ID is `18321137`.
+
+The `v*` tag immutability template intentionally does not include the
+release-maintainers team. Release maintainers can create release tags, but only
+organization admins can update or delete them.
 
 GitHub's ruleset `required_signatures` rule checks commit signatures, not the
 release tag object. Do not rely on rulesets alone for the signed annotated tag
@@ -97,6 +103,15 @@ gh api \
 
 Use the same command with the other template paths after reviewing their target
 refs and ruleset IDs.
+
+When migrating the live `v*` tag policy, replace the former combined
+`public-release-tags-v` ruleset with both split rulesets. Confirm the
+`release-maintainers` team ID before applying
+`.github/rulesets/release-tags-v-creation.json`:
+
+```sh
+gh api orgs/Qbit-Org/teams/release-maintainers --jq .id
+```
 
 Apply the repository-wide merge-method policy with the repository API:
 


### PR DESCRIPTION
## Summary

Split the `v*` release tag ruleset into separate creation and immutability templates. Release maintainers can bypass tag creation through the `release-maintainers` team, while tag updates and deletions stay limited to organization admins.

Updated the public branch and ruleset model to document the split rulesets, the `release-maintainers` team ID, and the migration path for replacing the old combined live ruleset.

## Testing

- [ ] Built locally.
- [ ] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason: Build and unit/functional tests were not run because this is a GitHub metadata and process-docs-only change.

Validation run:

```sh
jq empty .github/rulesets/*.json .github/repository-settings/*.json
git diff --check origin/main...HEAD
python3 ci/checks/classify_merge_profile.py --changed-files <(git diff --name-only origin/main...HEAD) --require-profile github-metadata
```

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: Release tag governance changes only. The PR does not change node runtime behavior.

## Docs / Process Impact

Choose exactly one:

- [x] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [ ] No public docs update needed. Reason:

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785681609&installation_id=141183937&pr_number=68&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F68&signature=d924992802f2b6d52edb54c6160cac8329216d1d76f69cc93e7250d81211badf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release tag access control on GitHub; misapplied rulesets could block releases or leave tags mutable, but node runtime is unaffected.
> 
> **Overview**
> **Release tag governance** is split from one combined `v*` ruleset into two templates: **creation** and **immutability**.
> 
> The new **creation** ruleset lets organization admins and the **release-maintainers** team (team ID `18321137`) create `refs/tags/v*` tags. The **immutability** ruleset keeps **update** and **deletion** restricted to organization admins only—release maintainers are explicitly **not** bypass actors there, so they cannot rewrite or remove tags after creation.
> 
> `public-branch-and-rulesets.md` documents the two-template model, the break-glass path for tag fixes (org admin only), and migration steps to replace the old combined live ruleset, including verifying the release-maintainers team ID before apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28061303a1b9fabb5a1c32bff98dd89c56e56fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->