### PR TITLE
Fix nightly CI runner and scanner setup

### DIFF
--- a/.github/workflows/ci-nightly-heavy.yml
+++ b/.github/workflows/ci-nightly-heavy.yml
@@ -134,7 +134,7 @@ jobs:
     env:
       SCANNER_SET: ${{ inputs.scanner_set || 'minimum' }}
       SCANNER_FAIL_POLICY: ${{ inputs.scanner_fail_policy || 'infra-and-secrets' }}
-      SKIP_BUILD_SCANNERS: ${{ inputs.skip_build_scanners || 'false' }}
+      SKIP_BUILD_SCANNERS: ${{ github.event_name == 'schedule' && 'true' || inputs.skip_build_scanners && 'true' || 'false' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/ci/scanners/gitleaks-allowlist.toml
+++ b/ci/scanners/gitleaks-allowlist.toml
@@ -1,0 +1,15 @@
+title = "qbit gitleaks allowlist"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Deterministic P2MR data-hash proof vector key material"
+condition = "AND"
+regexTarget = "line"
+paths = [
+  '''src/test/data/p2mr_datapqchash_vectors\.json''',
+]
+regexes = [
+  '''"(keygen_entropy|secret_key)": "[0-9a-f]+"''',
+]

--- a/ci/scanners/install-scanner-tools.sh
+++ b/ci/scanners/install-scanner-tools.sh
@@ -14,7 +14,7 @@ TOOL_ROOT="${QBIT_SCANNER_TOOL_ROOT:-${RUNNER_TOOL_CACHE:-$HOME/.cache/qbit}/sca
 BIN_DIR="${QBIT_SCANNER_BIN_DIR:-$TOOL_ROOT/bin}"
 CARGO_ROOT="${QBIT_SCANNER_CARGO_ROOT:-$TOOL_ROOT/cargo}"
 PYTHON_VENV="${QBIT_SCANNER_PYTHON_VENV:-$TOOL_ROOT/python}"
-CARGO_AUDIT_VERSION="${QBIT_SCANNER_CARGO_AUDIT_VERSION:-0.21.1}"
+CARGO_AUDIT_VERSION="${QBIT_SCANNER_CARGO_AUDIT_VERSION:-0.22.2}"
 
 mkdir -p "$BIN_DIR" "$CARGO_ROOT/bin"
 export PATH="$BIN_DIR:$CARGO_ROOT/bin:$PATH"
@@ -117,12 +117,49 @@ import json
 import os
 import re
 import sys
+import urllib.parse
 import urllib.request
 
 repo = sys.argv[1]
 asset_regex = re.compile(sys.argv[2])
 request = urllib.request.Request(
     f"https://api.github.com/repos/{repo}/releases/latest",
+    headers={
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "qbit-scanner-installer",
+    },
+)
+token = os.environ.get("GITHUB_TOKEN")
+if token:
+    request.add_header("Authorization", f"Bearer {token}")
+with urllib.request.urlopen(request, timeout=60) as response:
+    release = json.load(response)
+for asset in release.get("assets", []):
+    name = str(asset.get("name", ""))
+    if asset_regex.search(name):
+        print(asset["browser_download_url"])
+        raise SystemExit(0)
+raise SystemExit(f"No release asset matching {asset_regex.pattern!r} found in {repo} {release.get('tag_name', '')}")
+PY
+}
+
+github_release_asset_url() {
+    local repo="$1"
+    local tag="$2"
+    local asset_regex="$3"
+    python3 - "$repo" "$tag" "$asset_regex" <<'PY'
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+repo = sys.argv[1]
+tag = urllib.parse.quote(sys.argv[2], safe="")
+asset_regex = re.compile(sys.argv[3])
+request = urllib.request.Request(
+    f"https://api.github.com/repos/{repo}/releases/tags/{tag}",
     headers={
         "Accept": "application/vnd.github+json",
         "User-Agent": "qbit-scanner-installer",
@@ -156,8 +193,8 @@ install_plain_binary() {
     local name="$1"
     local repo="$2"
     local asset_regex="$3"
-    if need_cmd "$name"; then
-        log "$name already available"
+    if [[ -x "$BIN_DIR/$name" ]]; then
+        log "$name already available in scanner tool cache"
         return
     fi
 
@@ -175,8 +212,8 @@ install_tar_binary() {
     local name="$1"
     local repo="$2"
     local asset_regex="$3"
-    if need_cmd "$name"; then
-        log "$name already available"
+    if [[ -x "$BIN_DIR/$name" ]]; then
+        log "$name already available in scanner tool cache"
         return
     fi
 
@@ -237,12 +274,8 @@ ensure_scan_build() {
 
 install_python_tool() {
     local name="$1"
-    if need_cmd "$name"; then
-        log "$name already available"
-        return
-    fi
 
-    log "Installing $name"
+    log "Installing or upgrading $name"
     if [[ ! -x "$PYTHON_VENV/bin/python" ]]; then
         python3 -m venv "$PYTHON_VENV"
         "$PYTHON_VENV/bin/python" -m pip install --upgrade pip wheel
@@ -251,20 +284,59 @@ install_python_tool() {
     ln -sf "$PYTHON_VENV/bin/$name" "$BIN_DIR/$name"
 }
 
+cargo_audit_target() {
+    case "$(uname -m)" in
+        x86_64)
+            printf 'x86_64-unknown-linux-musl'
+            ;;
+        aarch64|arm64)
+            printf 'aarch64-unknown-linux-gnu'
+            ;;
+        armv7l)
+            printf 'armv7-unknown-linux-gnueabihf'
+            ;;
+        *)
+            echo "Unsupported cargo-audit release architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+}
+
 install_cargo_audit() {
     local current_version=""
-    if cargo audit --version >/dev/null 2>&1; then
-        current_version="$(cargo audit --version | awk '{print $2}')"
-        if [[ "$current_version" == "$CARGO_AUDIT_VERSION" ]]; then
-            log "cargo-audit $CARGO_AUDIT_VERSION already available"
-            return
+    if [[ -x "$BIN_DIR/cargo-audit" ]]; then
+        if current_version="$("$BIN_DIR/cargo-audit" --version 2>/dev/null | awk '{print $2}')"; then
+            if [[ "$current_version" == "$CARGO_AUDIT_VERSION" ]]; then
+                log "cargo-audit $CARGO_AUDIT_VERSION already available"
+                return
+            fi
+            log "Replacing cargo-audit ${current_version:-unknown} with $CARGO_AUDIT_VERSION"
+        else
+            log "Replacing broken cached cargo-audit with $CARGO_AUDIT_VERSION"
         fi
-        log "Replacing cargo-audit $current_version with $CARGO_AUDIT_VERSION"
     else
         log "Installing cargo-audit $CARGO_AUDIT_VERSION"
     fi
 
-    cargo install cargo-audit --version "$CARGO_AUDIT_VERSION" --locked --root "$CARGO_ROOT" --force
+    local tmp
+    tmp="$(mktemp -d)"
+    local target
+    target="$(cargo_audit_target)"
+    local url
+    url="$(github_release_asset_url \
+        rustsec/rustsec \
+        "cargo-audit/v${CARGO_AUDIT_VERSION}" \
+        "^cargo-audit-${target}-v${CARGO_AUDIT_VERSION}\\.tgz$")"
+    download "$url" "$tmp/cargo-audit.tar.gz"
+    tar -xzf "$tmp/cargo-audit.tar.gz" -C "$tmp"
+    local candidate
+    candidate="$(find "$tmp" -type f -name cargo-audit | head -n 1)"
+    if [[ -z "$candidate" ]]; then
+        echo "Unable to find cargo-audit in downloaded archive" >&2
+        exit 1
+    fi
+    install -m 0755 "$candidate" "$BIN_DIR/cargo-audit"
+    rm -rf "$tmp"
 }
 
 show_versions() {

--- a/ci/scanners/run-scanners.py
+++ b/ci/scanners/run-scanners.py
@@ -38,6 +38,7 @@ SCANNER_TRIAGED_DISPOSITIONS = {
     "not_security",
     "routed_to_track",
 }
+MIN_ZIZMOR_VERSION = (1, 24, 0)
 README_PREAMBLE = (
     f"{OUTPUT_ROOT_README_TITLE}\n\n"
     "Raw scanner output may contain sensitive paths or secret-adjacent context and is private by default.\n"
@@ -869,6 +870,18 @@ def tool_version(executable: str) -> str:
     return ""
 
 
+def version_tuple_from_text(text: str) -> tuple[int, int, int] | None:
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", text)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def zizmor_version_supported(version_text: str) -> bool:
+    version = version_tuple_from_text(version_text)
+    return version is not None and version >= MIN_ZIZMOR_VERSION
+
+
 def git_worktree_dirty(source: Path) -> bool:
     completed = subprocess.run(
         ["git", "-C", str(source), "status", "--porcelain"],
@@ -1523,6 +1536,26 @@ def run_scanner(tool: str, args: argparse.Namespace, output_root: Path) -> dict[
         write_json(summary_path, summary)
         return summary
 
+    external_tool_version = tool_version(spec.executable)
+    if tool == "zizmor" and not zizmor_version_supported(external_tool_version):
+        summary = create_summary(
+            args=args,
+            spec=spec,
+            status="skipped",
+            tool_version_value=external_tool_version,
+            commands=[],
+            raw_paths=[],
+            counts=empty_counts(),
+            triage_path=triage_path,
+            coverage_gaps=[
+                "zizmor is too old for qbit workflow syntax; install zizmor >= "
+                + ".".join(str(part) for part in MIN_ZIZMOR_VERSION)
+                + "."
+            ],
+        )
+        write_json(summary_path, summary)
+        return summary
+
     commands, report = external_commands(tool, args.source, raw_dir, args)
     exit_codes = []
     for index, command in enumerate(commands):
@@ -1546,7 +1579,7 @@ def run_scanner(tool: str, args: argparse.Namespace, output_root: Path) -> dict[
         args=args,
         spec=spec,
         status=status,
-        tool_version_value=tool_version(spec.executable),
+        tool_version_value=external_tool_version,
         commands=commands,
         raw_paths=raw_paths,
         counts=counts,

--- a/ci/scanners/test_run_scanners.py
+++ b/ci/scanners/test_run_scanners.py
@@ -34,6 +34,12 @@ run_scanners = load_run_scanners()
 
 
 class RunScannersTest(unittest.TestCase):
+    def test_zizmor_version_gate_rejects_old_python38_compatible_release(self) -> None:
+        self.assertFalse(run_scanners.zizmor_version_supported("zizmor 1.2.0"))
+
+    def test_zizmor_version_gate_accepts_anchor_compatible_release(self) -> None:
+        self.assertTrue(run_scanners.zizmor_version_supported("zizmor 1.24.1"))
+
     def test_ls_remote_ref_oid_accepts_exact_peeled_tag_ref(self) -> None:
         stdout = "ac72d1\trefs/tags/v0.3.0^{}\n456aaf\trefs/tags/v0.3.0\n"
 

--- a/ci/test/02_run_container.py
+++ b/ci/test/02_run_container.py
@@ -3,11 +3,45 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or https://opensource.org/license/mit/.
 
+import hashlib
 import os
 import re
 import shlex
 import subprocess
 import sys
+
+MAX_DOCKER_NAME_LEN = 63
+CI_NETWORK_PREFIX = "ci-ip6net-"
+MAX_CI_CONTAINER_NAME_LEN = MAX_DOCKER_NAME_LEN - len(CI_NETWORK_PREFIX)
+
+
+def sanitize_name_part(value):
+    return re.sub(r"[^A-Za-z0-9_.-]", "-", value)
+
+
+def short_hash(value, length=10):
+    return hashlib.sha256(value.encode("utf8")).hexdigest()[:length]
+
+
+def ci_container_name(base, run_id, run_attempt, job, runner_name):
+    base = sanitize_name_part(base or "ci")
+    unique_id = "-".join(
+        sanitize_name_part(part)
+        for part in (
+            run_id or "local",
+            run_attempt or "0",
+            job or "job",
+            f"r{short_hash(runner_name or 'runner')}",
+        )
+        if part
+    )
+    candidate = f"{base}-{unique_id}"
+    if len(candidate) <= MAX_CI_CONTAINER_NAME_LEN:
+        return candidate
+
+    digest = short_hash(candidate)
+    prefix_len = MAX_CI_CONTAINER_NAME_LEN - len(digest) - 1
+    return f"{candidate[:prefix_len].rstrip('-')}-{digest}"
 
 
 def run(cmd, **kwargs):
@@ -34,17 +68,15 @@ def main():
         "CI_FAILFAST_TEST_LEAVE_DANGLING",
     ])
 
-    # Make container/env-file names unique per workflow run to avoid collisions
-    # between concurrent jobs sharing one Docker daemon.
-    unique_id = "{run_id}-{attempt}-{job}".format(
-        run_id=os.getenv("GITHUB_RUN_ID", "local"),
-        attempt=os.getenv("GITHUB_RUN_ATTEMPT", "0"),
-        job=os.getenv("GITHUB_JOB", "job"),
-    )
-    unique_id = re.sub(r"[^A-Za-z0-9_.-]", "-", unique_id)
-    container_name = "{base}-{suffix}".format(
+    # Make container/env-file names unique per runner instance. GitHub sets the
+    # same GITHUB_JOB for every matrix entry, while qbit self-hosted runner
+    # instances can share one Docker daemon.
+    container_name = ci_container_name(
         base=os.getenv("CONTAINER_NAME", "ci"),
-        suffix=unique_id,
+        run_id=os.getenv("GITHUB_RUN_ID", "local"),
+        run_attempt=os.getenv("GITHUB_RUN_ATTEMPT", "0"),
+        job=os.getenv("GITHUB_JOB", "job"),
+        runner_name=os.getenv("RUNNER_NAME", "runner"),
     )
     env_file = "/tmp/env-{u}-{c}".format(
         u=os.getenv("USER", "ci"),

--- a/ci/test/test_02_run_container.py
+++ b/ci/test/test_02_run_container.py
@@ -1,0 +1,61 @@
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or https://opensource.org/license/mit/.
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+def load_run_container():
+    script_path = Path(__file__).with_name("02_run_container.py")
+    spec = importlib.util.spec_from_file_location("run_container", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+RUN_CONTAINER = load_run_container()
+
+
+class RunContainerTest(unittest.TestCase):
+    def test_container_name_keeps_derived_network_name_within_docker_limit(self):
+        name = RUN_CONTAINER.ci_container_name(
+            base="ci_native_nowallet_libbitcoinkernel",
+            run_id="28956539484",
+            run_attempt="12",
+            job="nightly-heavy-linux-aarch64-cross-build",
+            runner_name=(
+                "qbit-self-hosted-linux-runner-with-a-name-long-enough-to-"
+                "exceed-docker-name-limits"
+            ),
+        )
+
+        self.assertLessEqual(len(name), RUN_CONTAINER.MAX_CI_CONTAINER_NAME_LEN)
+        self.assertLessEqual(
+            len(RUN_CONTAINER.CI_NETWORK_PREFIX + name),
+            RUN_CONTAINER.MAX_DOCKER_NAME_LEN,
+        )
+
+    def test_container_name_distinguishes_runner_instances(self):
+        kwargs = {
+            "base": "ci_arm_linux",
+            "run_id": "28956539484",
+            "run_attempt": "1",
+            "job": "nightly-heavy",
+        }
+
+        name_a = RUN_CONTAINER.ci_container_name(
+            runner_name="qbit-self-hosted-runner-a",
+            **kwargs,
+        )
+        name_b = RUN_CONTAINER.ci_container_name(
+            runner_name="qbit-self-hosted-runner-b",
+            **kwargs,
+        )
+
+        self.assertNotEqual(name_a, name_b)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the nightly CI failures seen in the scheduled run by tightening runner identity and scanner setup:

- include `RUNNER_NAME` in CI container/env-file names so ARM matrix shards sharing a Docker daemon do not collide
- refresh managed scanner tools instead of accepting stale global binaries
- install `cargo-audit` from RustSec release assets so the scanner is not blocked by the runner Rust toolchain
- skip build-backed scanners by default for scheduled nightly runs
- add a narrow Gitleaks allowlist for deterministic P2MR data-hash test-vector key material while preserving default rules

## Testing

- [ ] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [x] Not run. Reason: full build was not run; this is a CI harness/scanner change validated with focused script, scanner, and workflow checks.

Focused checks run:

- `bash -n ci/scanners/install-scanner-tools.sh ci/test/02_run_container.sh`
- `python3 -m py_compile ci/test/02_run_container.py ci/scanners/run-scanners.py`
- `python3 ci/scanners/test_run_scanners.py`
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest .github/workflows/ci-nightly-heavy.yml`
- `python3 ci/scanners/run-scanners.py --mode nightly --scanner gitleaks --scanner cargo_audit --scanner clang_static_analyzer --source . --source-commit "$(git rev-parse HEAD)" --freeze-commit "$(git rev-parse HEAD)" --history-diff-base-ref origin/main --output-root .context/scanner-local-main-pr-after --skip-build-scanners --fail-policy infra-and-secrets`
- `git diff --check`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: CI-only change. Scheduled workflows that checkout a release branch will use the workflow changes from `main`; script/config changes must also be present on the checked-out branch for those steps to consume them directly.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: CI harness maintenance only.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI harness and scanner installer only; Gitleaks allowlist is path- and regex-scoped to one test-vector file.
> 
> **Overview**
> Fixes scheduled nightly CI failures by making **container names unique per self-hosted runner** (hash of `RUNNER_NAME`, with truncation so `ci-ip6net-` + name stays within Docker’s 63-character limit) instead of relying only on run/job, which collide when matrix jobs share `GITHUB_JOB` on one Docker daemon.
> 
> **Scanner setup** is tightened: managed tools are taken from the scanner cache (not stale global binaries), `cargo-audit` is bumped to **0.22.2** and installed from **RustSec release assets** (avoiding runner Rust toolchain issues), Python scanner tools are upgraded on install, and **zizmor &lt; 1.24.0** is skipped with a clear gap message. Scheduled nightly runs now default **`SKIP_BUILD_SCANNERS=true`**; manual dispatch still respects the workflow input.
> 
> Adds a narrow **`gitleaks-allowlist.toml`** for deterministic hex `keygen_entropy` / `secret_key` fields in `p2mr_datapqchash_vectors.json` while keeping default Gitleaks rules elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b3f60dd3eb79110ebf275f887cbc2e62080426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786113163&installation_id=141183937&pr_number=71&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F71&signature=ef0daae840adbbf12551713841d5d3c53ffc36f570667b9413927ce2c5d88902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->