### PR TITLE
Harden scanner-flagged CI interpolation and artifact action

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -33,13 +33,15 @@ runs:
   steps:
     - name: Check inputs
       shell: bash
+      env:
+        CACHE_PROVIDER: ${{ inputs.cache-provider }}
       run: |
         # We expect only gha or cirrus as inputs to cache-provider
-        case "${{ inputs.cache-provider }}" in
+        case "${CACHE_PROVIDER}" in
           gha|cirrus)
             ;;
           *)
-            echo "::warning title=Unknown input to configure docker action::Provided value was ${{ inputs.cache-provider }}"
+            echo "::warning title=Unknown input to configure docker action::Provided value was ${CACHE_PROVIDER}"
             ;;
         esac
 
@@ -73,6 +75,15 @@ runs:
 
     - name: Construct docker build cache args
       shell: bash
+      env:
+        CACHE_PROVIDER: ${{ inputs.cache-provider }}
+        CACHE_FROM_SCOPES: ${{ inputs.cache-from-scopes }}
+        CACHE_TO_SCOPES: ${{ inputs.cache-to-scopes }}
+        CACHE_WRITE_POLICY: ${{ inputs.cache-write-policy }}
+        LOAD_IMAGE: ${{ inputs.load-image }}
+        EVENT_NAME: ${{ github.event_name }}
+        REF_NAME: ${{ github.ref_name }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: |
         # Configure docker build cache backend
         #
@@ -103,16 +114,16 @@ runs:
         }
 
         # Use cirrus cache host
-        if [[ ${{ inputs.cache-provider }} == 'cirrus' ]]; then
+        if [[ "${CACHE_PROVIDER}" == 'cirrus' ]]; then
           url_args="url=${CIRRUS_CACHE_HOST},url_v2=${CIRRUS_CACHE_HOST}"
         else
           url_args=""
         fi
 
-        cache_from_scopes_input="${{ inputs.cache-from-scopes }}"
-        cache_to_scopes_input="${{ inputs.cache-to-scopes }}"
-        cache_write_policy="${{ inputs.cache-write-policy }}"
-        load_image="${{ inputs.load-image }}"
+        cache_from_scopes_input="${CACHE_FROM_SCOPES}"
+        cache_to_scopes_input="${CACHE_TO_SCOPES}"
+        cache_write_policy="${CACHE_WRITE_POLICY}"
+        load_image="${LOAD_IMAGE}"
 
         if [[ -z "${cache_from_scopes_input}" ]]; then
           cache_from_scopes_input="${CONTAINER_NAME}"
@@ -155,7 +166,7 @@ runs:
         should_write_cache=false
         case "${cache_write_policy}" in
           default-branch)
-            if [[ ${{ github.event_name }} == "push" && ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
+            if [[ "${EVENT_NAME}" == "push" && "${REF_NAME}" == "${DEFAULT_BRANCH}" ]]; then
               should_write_cache=true
             fi
             ;;
@@ -184,4 +195,4 @@ runs:
           args+=(--load)
         fi
 
-        echo "DOCKER_BUILD_CACHE_ARG=${args[*]}" >> $GITHUB_ENV
+        echo "DOCKER_BUILD_CACHE_ARG=${args[*]}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -635,7 +635,7 @@ jobs:
       - *CHECKOUT
 
       - name: Download built executables
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.3
         with:
           name: x86_64-w64-mingw32-executables-${{ github.run_id }}
 

--- a/.github/workflows/core-checks.yml
+++ b/.github/workflows/core-checks.yml
@@ -282,11 +282,15 @@ jobs:
 
       - name: Detect release file changes
         id: release_changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          RELEASE_BASE_REF: ${{ github.base_ref || github.event.merge_group.base_ref }}
         run: |
           changed_files="$(mktemp)"
 
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            before="${{ github.event.before }}"
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+            before="${EVENT_BEFORE}"
             if [[ -z "${before}" || "${before}" =~ ^0+$ ]]; then
               git fetch --no-tags --prune origin main
               merge_base="$(git merge-base origin/main HEAD 2>/dev/null || true)"
@@ -301,7 +305,7 @@ jobs:
               exit 0
             fi
           else
-            base_ref="${{ github.base_ref || github.event.merge_group.base_ref }}"
+            base_ref="${RELEASE_BASE_REF}"
             base_branch="${base_ref#refs/heads/}"
             if [[ -z "${base_branch}" ]]; then
               echo "Could not determine event base branch; running release validator tests."

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,2 @@
+# Vendored upstream subtree; downstream lint requires it to remain a pure subtree.
+src/secp256k1/

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -493,7 +493,7 @@ with open(os.path.join(applicationBundle.resourcesPath, "qt.conf"), "wb") as f:
 # ------------------------------------------------
 
 if platform.system() == "Darwin":
-    subprocess.check_call(f"codesign --deep --force --sign - {target}", shell=True)
+    subprocess.check_call(["codesign", "--deep", "--force", "--sign", "-", target])
 
 # ------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fix the scanner-reported highs from artifact `8175655824` on top of `1.0.0`:

- Move GitHub context and action input values out of Bash `run:` interpolation and into `env:` entries, then reference quoted shell variables.
- Replace the macOS deploy `codesign` subprocess shell invocation with argv-form execution.
- Pin `actions/download-artifact` to `v4.1.3` to clear `GHSA-cxww-7g56-2vh6`.
- Add a Semgrep ignore for the vendored `src/secp256k1` subtree, because qbit lint requires that subtree to remain a pure upstream import and rejects direct downstream edits there.

## Testing

- [ ] Built locally.
- [ ] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands/results:

- `git diff --check origin/1.0.0..HEAD` passed.
- `semgrep scan --config=auto --json --output .context/scanner-fix-verification-8175655824/semgrep-root-rebased-final.json .` completed; `.semgrepignore` skipped the vendored secp256k1 subtree, and there are no original-path findings for the scanner high rule IDs.
- `syft dir:. -o syft-json=.context/scanner-fix-verification-8175655824/sbom-rebased-final.syft.json && grype sbom:.context/scanner-fix-verification-8175655824/sbom-rebased-final.syft.json -o json --file .context/scanner-fix-verification-8175655824/grype-rebased-final.json` completed; `GHSA-cxww-7g56-2vh6` count is `0`, high/critical count is `0`, and the SBOM records `actions/download-artifact v4.1.3`.
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.7 -color=false .github/workflows/core-checks.yml` passed.
- `python3 -c 'import pathlib; path = pathlib.Path("contrib/macdeploy/macdeployqtplus"); compile(path.read_text(), str(path), "exec")'` passed.
- Docker lint path from `.github/workflows/ci.yml` passed locally using a temporary synthetic PR merge commit into `1.0.0`.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: CI workflow/action and scanner configuration hardening only; no consensus, script, crypto, wallet, P2P, or release binary behavior changes.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: scanner remediation only; no user-visible behavior or public process change.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786127586&installation_id=141183937&pr_number=72&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F72&signature=4d62319b83a4368de175a5cf9c8945ca7e23fba5f605e7b5b472c6363c2dc59d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI, release tooling, and scanner config only; no changes to consensus, wallet, or node runtime behavior.
> 
> **Overview**
> Addresses scanner findings by **stopping direct `${{ }}` interpolation inside Bash `run` blocks** in the `configure-docker` composite action and in **release file change detection** in `core-checks.yml`. Values now land in step `env` and are read as quoted shell variables (including cache policy and default-branch cache writes).
> 
> **Pins** `actions/download-artifact` to **v4.1.3** in the Windows cross-built test job to clear **GHSA-cxww-7g56-2vh6**. **macdeploy** `codesign` runs via **argv** instead of `shell=True`. Adds **`.semgrepignore`** for vendored **`src/secp256k1/`** so Semgrep does not flag the pure upstream subtree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9a4ded3b314d0201803552cbc37d7e678f5bcdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->