### PR TITLE
Enable CI validation on 1.0.0

### DIFF
--- a/.github/rulesets/1.0.0.json
+++ b/.github/rulesets/1.0.0.json
@@ -1,0 +1,60 @@
+{
+  "name": "public-maintenance-1.0.0",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/heads/1.0.0"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "creation"
+    },
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "Required Merge Gate"
+          }
+        ],
+        "strict_required_status_checks_policy": true
+      }
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": [
+          "squash",
+          "rebase"
+        ],
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": true,
+        "required_approving_review_count": 1,
+        "required_review_thread_resolution": true
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,19 @@ on:
       - unlabeled
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
   push:
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
   merge_group:
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
   workflow_dispatch:  # Manual trigger for full validation on any branch

--- a/.github/workflows/core-checks.yml
+++ b/.github/workflows/core-checks.yml
@@ -8,16 +8,19 @@ on:
   pull_request:
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
   push:
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
   merge_group:
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
 

--- a/.github/workflows/required-merge-gate.yml
+++ b/.github/workflows/required-merge-gate.yml
@@ -15,16 +15,19 @@ on:
       - unlabeled
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
   push:
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
   merge_group:
     branches:
       - main
+      - 1.0.0
       - 0.1.x
       - develop
 
@@ -498,7 +501,11 @@ jobs:
           import json
           from pathlib import Path
 
-          for path in (Path(".github/rulesets/main.json"), Path(".github/rulesets/0.1.x.json")):
+          for path in (
+              Path(".github/rulesets/main.json"),
+              Path(".github/rulesets/1.0.0.json"),
+              Path(".github/rulesets/0.1.x.json"),
+          ):
               data = json.loads(path.read_text(encoding="utf8"))
               contexts = []
               for rule in data.get("rules", []):


### PR DESCRIPTION
## Summary

- Add `1.0.0` to the Full Validation, Core Checks, and Required Merge Gate branch filters for pull requests, pushes, and merge groups.
- Add a `1.0.0` branch ruleset matching the `0.1.x` Required Merge Gate enforcement.
- Include the `1.0.0` ruleset in the metadata gate validation.

## Testing

- [ ] Built locally. Not applicable; this only changes workflow and ruleset metadata.
- [ ] Ran focused unit or functional tests for the changed area. Not applicable; no runtime code changed.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Ran:

- `git diff --check origin/1.0.0...HEAD`
- `jq empty .github/rulesets/*.json .github/repository-settings/*.json`
- `python3 ci/checks/classify_merge_profile.py --changed-files <changed-file-list>`
- Docker lint via `ci/lint_imagefile` with `COMMIT_RANGE=HEAD~1..HEAD`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: CI and repository ruleset metadata only.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: CI/repository metadata only.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786127963&installation_id=141183937&pr_number=73&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F73&signature=afd04f767bf846fd76ee6cddbb6bfe4f62a7a42f786d620911a45af6ed71599f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions triggers and ruleset JSON; no application or consensus code is modified.
> 
> **Overview**
> Treats **`1.0.0`** as a first-class maintenance branch alongside **`main`**, **`0.1.x`**, and **`develop`** for CI and merge policy.
> 
> **Workflow triggers:** **`1.0.0`** is added to pull request, push, and merge group branch filters in **Full Validation** (`ci.yml`), **Core Checks**, and **Required Merge Gate**.
> 
> **Branch protection metadata:** New **`.github/rulesets/1.0.0.json`** targets `refs/heads/1.0.0` with the same pattern as **`0.1.x`**: linear history, squash/rebase merges, one approval, last-push approval, resolved review threads, and a single required check context **`Required Merge Gate`**.
> 
> **Gate validation:** The github-metadata path in **Required Merge Gate** now asserts that **`1.0.0.json`** (with **`main.json`** and **`0.1.x.json`**) requires exactly **`Required Merge Gate`** as its status check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb54d6a503151cb2ea6b1764a96a3813110e5f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->