### PR TITLE
Pin GitHub Actions and fix CodeQL/RUSTSEC scanner findings

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -54,7 +54,7 @@ runs:
         bash "${GITHUB_ACTION_PATH}/buildkit-config.sh"
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       with:
         # Use host network to allow access to cirrus gha cache running on the host
         driver-opts: |
@@ -63,7 +63,7 @@ runs:
 
     # This is required to allow buildkit to access the actions cache
     - name: Expose actions cache variables
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
       with:
         script: |
           Object.keys(process.env).forEach(function (key) {

--- a/.github/actions/restore-caches/action.yml
+++ b/.github/actions/restore-caches/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Restore Ccache cache
       id: ccache-cache
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@6c7f0b3de56f6bfc89a4bac3dbc0d0475b263642 # v4
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ env.CONTAINER_NAME }}-${{ github.run_id }}
@@ -20,7 +20,7 @@ runs:
 
     - name: Restore depends sources cache
       id: depends-sources
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@6c7f0b3de56f6bfc89a4bac3dbc0d0475b263642 # v4
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
@@ -29,7 +29,7 @@ runs:
 
     - name: Restore built depends cache
       id: depends-built
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@6c7f0b3de56f6bfc89a4bac3dbc0d0475b263642 # v4
       with:
         path: ${{ env.BASE_CACHE }}
         key: depends-built-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
@@ -38,7 +38,7 @@ runs:
 
     - name: Restore previous releases cache
       id: previous-releases
-      uses: cirruslabs/cache/restore@v4
+      uses: cirruslabs/cache/restore@6c7f0b3de56f6bfc89a4bac3dbc0d0475b263642 # v4
       with:
         path: ${{ env.PREVIOUS_RELEASES_DIR }}
         key: previous-releases-${{ env.CONTAINER_NAME }}-${{ env.PREVIOUS_RELEASES_HASH }}

--- a/.github/actions/save-caches/action.yml
+++ b/.github/actions/save-caches/action.yml
@@ -18,28 +18,28 @@ runs:
         echo "previous releases direct cache hit to primary key: ${{ env.previous-releases-cache-hit }}"
 
     - name: Save Ccache cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@6c7f0b3de56f6bfc89a4bac3dbc0d0475b263642 # v4
       if: ${{ ((github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch)) || ((github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.repository)) }}
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ccache-${{ env.CONTAINER_NAME }}-${{ github.run_id }}
 
     - name: Save depends sources cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@6c7f0b3de56f6bfc89a4bac3dbc0d0475b263642 # v4
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.depends-sources-cache-hit != 'true') }}
       with:
         path: ${{ env.SOURCES_PATH }}
         key: depends-sources-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
 
     - name: Save built depends cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@6c7f0b3de56f6bfc89a4bac3dbc0d0475b263642 # v4
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.depends-built-cache-hit != 'true' )}}
       with:
         path: ${{ env.BASE_CACHE }}
         key: depends-built-${{ env.CONTAINER_NAME }}-${{ env.DEPENDS_HASH }}
 
     - name: Save previous releases cache
-      uses: cirruslabs/cache/save@v4
+      uses: cirruslabs/cache/save@6c7f0b3de56f6bfc89a4bac3dbc0d0475b263642 # v4
       if: ${{ (github.event_name == 'push') && (github.ref_name == github.event.repository.default_branch) && (env.previous-releases-cache-hit != 'true' )}}
       with:
         path: ${{ env.PREVIOUS_RELEASES_DIR }}

--- a/.github/workflows/ci-nightly-heavy.yml
+++ b/.github/workflows/ci-nightly-heavy.yml
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event_name == 'schedule' && '0.1.x' || github.ref }}
           fetch-depth: 0
@@ -137,7 +137,7 @@ jobs:
       SKIP_BUILD_SCANNERS: ${{ inputs.skip_build_scanners || 'false' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event_name == 'schedule' && '0.1.x' || github.ref }}
           fetch-depth: 0
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload scanner summaries
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: qbit-scanner-evidence-${{ github.run_id }}
           if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       source_validation_required: ${{ steps.classify.outputs.source_validation_required }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -155,14 +155,14 @@ jobs:
   test-each-commit:
     name: 'test each commit'
     runs-on: *qbit_runs_on
-    if: false # Disabled: runner OS (Ubuntu 20.04) lacks required packages (mold, qt6)
+    if: ${{ github.event_name == 'pull_request' && vars.QBIT_ENABLE_TEST_EACH_COMMIT == 'true' && (github.event.pull_request.head.repo.full_name == github.repository || contains(github.event.pull_request.labels.*.name, 'ci:qbit-trusted')) }} # Disabled by default: runner OS (Ubuntu 20.04) lacks required packages (mold, qt6)
     timeout-minutes: 360  # Use maximum time, see https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes. Assuming a worst case time of 1 hour per commit, this leads to a --max-count=6 below.
     env:
       MAX_COUNT: 6
     steps:
       - name: Determine fetch depth
         run: echo "FETCH_DEPTH=$((${{ github.event.pull_request.commits }} + 2))" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.FETCH_DEPTH }}
@@ -189,12 +189,12 @@ jobs:
           # ancestors from the rev-list output as described in:
           # https://git-scm.com/docs/git-rev-list
           MERGE_BASE=$(git rev-list -n1 --merges HEAD)
-          EXCLUDE_MERGE_BASE_ANCESTORS=
+          exclude_merge_base_ancestors=()
           # MERGE_BASE can be empty due to limited fetch-depth
           if test -n "$MERGE_BASE"; then
-            EXCLUDE_MERGE_BASE_ANCESTORS=^${MERGE_BASE}^@
+            exclude_merge_base_ancestors=("^${MERGE_BASE}^@")
           fi
-          echo "TEST_BASE=$(git rev-list -n$((${{ env.MAX_COUNT }} + 1)) --reverse HEAD $EXCLUDE_MERGE_BASE_ANCESTORS | head -1)" >> "$GITHUB_ENV"
+          echo "TEST_BASE=$(git rev-list -n$((${{ env.MAX_COUNT }} + 1)) --reverse HEAD "${exclude_merge_base_ancestors[@]}" | head -1)" >> "$GITHUB_ENV"
       - run: |
           git fetch origin "${GITHUB_BASE_REF}"
           git config user.email "ci@example.com"
@@ -211,7 +211,7 @@ jobs:
   macos-native-arm64:
     name: ${{ matrix.job-name }}
     runs-on: macos-14
-    if: false # Disabled: no macOS runner available
+    if: ${{ vars.QBIT_ENABLE_MACOS_NATIVE_ARM64 == 'true' }} # Disabled by default: no macOS runner available
 
     timeout-minutes: 120
 
@@ -234,7 +234,7 @@ jobs:
     steps:
       - &CHECKOUT
         name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           # Ensure PR re-runs use merged state.
           ref: &CHECKOUT_REF_TMPL ${{ github.event_name == 'pull_request' && github.ref || '' }}
@@ -266,7 +266,7 @@ jobs:
 
       - name: Restore Ccache cache
         id: ccache-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ github.job }}-${{ matrix.job-type }}-ccache-${{ github.run_id }}
@@ -278,7 +278,7 @@ jobs:
           FILE_ENV: ${{ matrix.file-env }}
 
       - name: Save Ccache cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: github.event_name != 'pull_request' && steps.ccache-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ env.CCACHE_DIR }}
@@ -313,7 +313,7 @@ jobs:
 
       - name: Configure Developer Command Prompt for Microsoft Visual C++
         # Using microsoft/setup-msbuild is not enough.
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
         with:
           arch: x64
 
@@ -343,13 +343,13 @@ jobs:
           sed -i '1s/^/set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)\n/' "${VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake"
 
       - name: vcpkg tools cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: C:/vcpkg/downloads/tools
           key: ${{ github.job }}-vcpkg-tools
 
       - name: Restore vcpkg binary cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: vcpkg-binary-cache
         with:
           path: ~/AppData/Local/vcpkg/archives
@@ -360,7 +360,7 @@ jobs:
           cmake -B build -Werror=dev --preset vs2022 -DCMAKE_TOOLCHAIN_FILE="${VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake" ${{ matrix.generate-options }}
 
       - name: Save vcpkg binary cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: github.event_name != 'pull_request' && steps.vcpkg-binary-cache.outputs.cache-hit != 'true' && matrix.job-type == 'standard'
         with:
           path: ~/AppData/Local/vcpkg/archives
@@ -369,7 +369,7 @@ jobs:
       - name: Build
         working-directory: build
         run: |
-          cmake --build . -j $NUMBER_OF_PROCESSORS --config Release
+          cmake --build . -j "$NUMBER_OF_PROCESSORS" --config Release
 
       - name: Get qbitd manifest
         if: matrix.job-type == 'standard'
@@ -509,7 +509,7 @@ jobs:
 
       - name: Upload Windows crash diagnostics
         if: matrix.job-type == 'standard' && steps.qt_test.outcome != 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: windows-qt-crash-diagnostics-${{ github.run_id }}
           if-no-files-found: ignore
@@ -551,7 +551,22 @@ jobs:
           BITCOINWALLET: '${{ github.workspace }}\build\bin\Release\qbit-wallet.exe'
           TEST_RUNNER_FAILFAST: ${{ github.event_name == 'pull_request' && '--failfast' || '' }}
           TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
-        run: py -3 test/functional/test_runner.py --jobs $NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix="${RUNNER_TEMP}" --combinedlogslen=2000 --timeout-factor=${TEST_RUNNER_TIMEOUT_FACTOR} ${TEST_RUNNER_FAILFAST} ${TEST_RUNNER_EXTRA}
+        run: |
+          test_runner_args=(
+            --jobs "$NUMBER_OF_PROCESSORS"
+            --ci
+            --quiet
+            --tmpdirprefix="${RUNNER_TEMP}"
+            --combinedlogslen=2000
+            --timeout-factor="${TEST_RUNNER_TIMEOUT_FACTOR}"
+          )
+          if [[ -n "${TEST_RUNNER_FAILFAST}" ]]; then
+            test_runner_args+=("${TEST_RUNNER_FAILFAST}")
+          fi
+          if [[ -n "${TEST_RUNNER_EXTRA}" ]]; then
+            test_runner_args+=("${TEST_RUNNER_EXTRA}")
+          fi
+          py -3 test/functional/test_runner.py "${test_runner_args[@]}"
 
       - name: Clone corpora
         if: matrix.job-type == 'fuzz'
@@ -568,7 +583,7 @@ jobs:
           BITCOINFUZZ: '${{ github.workspace }}\build\bin\Release\fuzz.exe'
         run: |
           # TODO: Fix the Windows fail-fast in ephemeral_package_eval and re-enable it.
-          py -3 test/fuzz/test_runner.py --par $NUMBER_OF_PROCESSORS --loglevel DEBUG --exclude ephemeral_package_eval "${RUNNER_TEMP}/qa-assets/fuzz_corpora"
+          py -3 test/fuzz/test_runner.py --par "$NUMBER_OF_PROCESSORS" --loglevel DEBUG --exclude ephemeral_package_eval "${RUNNER_TEMP}/qa-assets/fuzz_corpora"
 
   windows-cross:
     name: 'Linux->Windows cross, no tests'
@@ -605,7 +620,7 @@ jobs:
         uses: ./.github/actions/save-caches
 
       - name: Upload built executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: x86_64-w64-mingw32-executables-${{ github.run_id }}
           path: |
@@ -635,7 +650,7 @@ jobs:
       - *CHECKOUT
 
       - name: Download built executables
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: x86_64-w64-mingw32-executables-${{ github.run_id }}
 
@@ -681,16 +696,31 @@ jobs:
 
       - name: Get previous releases
         working-directory: test
-        run: ./get_previous_releases.py --target-dir $PREVIOUS_RELEASES_DIR
+        run: ./get_previous_releases.py --target-dir "$PREVIOUS_RELEASES_DIR"
 
       - name: Run functional tests
         env:
           # TODO: Fix the excluded test and re-enable it.
           # feature_unsupported_utxo_db.py fails on windows because of emojis in the test data directory
-          EXCLUDE: '--exclude wallet_multiwallet.py,feature_unsupported_utxo_db.py'
           TEST_RUNNER_FAILFAST: ${{ github.event_name == 'pull_request' && '--failfast' || '' }}
           TEST_RUNNER_EXTRA: ${{ github.event_name != 'pull_request' && '--extended' || '' }}
-        run: py -3 test/functional/test_runner.py --jobs $NUMBER_OF_PROCESSORS --ci --quiet --tmpdirprefix="$RUNNER_TEMP" --combinedlogslen=2000 --timeout-factor=$TEST_RUNNER_TIMEOUT_FACTOR $EXCLUDE $TEST_RUNNER_FAILFAST $TEST_RUNNER_EXTRA
+        run: |
+          test_runner_args=(
+            --jobs "$NUMBER_OF_PROCESSORS"
+            --ci
+            --quiet
+            --tmpdirprefix="$RUNNER_TEMP"
+            --combinedlogslen=2000
+            --timeout-factor="$TEST_RUNNER_TIMEOUT_FACTOR"
+            --exclude "wallet_multiwallet.py,feature_unsupported_utxo_db.py"
+          )
+          if [[ -n "${TEST_RUNNER_FAILFAST}" ]]; then
+            test_runner_args+=("${TEST_RUNNER_FAILFAST}")
+          fi
+          if [[ -n "${TEST_RUNNER_EXTRA}" ]]; then
+            test_runner_args+=("${TEST_RUNNER_EXTRA}")
+          fi
+          py -3 test/functional/test_runner.py "${test_runner_args[@]}"
 
   ci-matrix:
     name: ${{ matrix.name }}
@@ -722,42 +752,84 @@ jobs:
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_asan.sh'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
           - name: 'macOS-cross, gui, no tests'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_mac_cross.sh'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
           - name: 'No wallet, libbitcoinkernel'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-sm'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_nowallet_libbitcoinkernel.sh'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
           - name: 'no IPC, i686, DEBUG'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_i686_no_ipc.sh'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
           - name: 'CentOS, depends, gui'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_centos.sh'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
           - name: 'tidy'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_tidy.sh'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
           - name: 'TSan, depends, no gui'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-md'
             fallback-runner: 'ubuntu-24.04'
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_tsan.sh'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
           - name: 'MSan, depends, unit tests'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
@@ -765,6 +837,12 @@ jobs:
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_msan.sh'
             msan-ci-part: 'unit'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
           - name: 'MSan, depends, functional tests'
             cirrus-runner: 'ghcr.io/cirruslabs/ubuntu-runner-amd64:24.04-lg'
@@ -772,6 +850,12 @@ jobs:
             timeout-minutes: 200
             file-env: './ci/test/00_setup_env_native_msan.sh'
             msan-ci-part: 'functional'
+            makejobs: '-j6'
+            test-runner-jobs: '6'
+            ctest-jobs: '6'
+            container-cpus: '8'
+            container-memory: '48g'
+            provider: ''
 
     steps:
       - *CHECKOUT
@@ -832,7 +916,7 @@ jobs:
       CONTAINER_NAME: "bitcoin-linter"
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: *CHECKOUT_REF_TMPL
           fetch-depth: 0
@@ -849,14 +933,15 @@ jobs:
           set -o xtrace
           source ./ci/test/00_setup_env_base_image.sh
           ci_set_base_image_name_tag "ubuntu:24.04"
-          docker buildx build -t "$CONTAINER_NAME" $DOCKER_BUILD_CACHE_ARG --build-arg "CI_IMAGE_NAME_TAG=${CI_IMAGE_NAME_TAG}" --file "./ci/lint_imagefile" .
-          CIRRUS_PR_FLAG=""
+          read -r -a docker_build_cache_args <<< "${DOCKER_BUILD_CACHE_ARG:-}"
+          docker buildx build -t "$CONTAINER_NAME" "${docker_build_cache_args[@]}" --build-arg "CI_IMAGE_NAME_TAG=${CI_IMAGE_NAME_TAG}" --file "./ci/lint_imagefile" .
+          cirrus_pr_flags=()
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            CIRRUS_PR_FLAG="-e CIRRUS_PR=1"
+            cirrus_pr_flags=(-e CIRRUS_PR=1)
           fi
           # Use docker cp instead of bind mount to avoid DinD path mapping issues
           # when runners share the host Docker socket.
-          LINT_CID=$(docker create $CIRRUS_PR_FLAG "$CONTAINER_NAME")
+          LINT_CID=$(docker create "${cirrus_pr_flags[@]}" "$CONTAINER_NAME")
           docker cp "$(pwd)/." "$LINT_CID":/bitcoin
           docker start -a "$LINT_CID"; rc=$?
           docker rm "$LINT_CID" || true
@@ -870,7 +955,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: *CHECKOUT_REF_TMPL
           fetch-depth: 0
@@ -887,7 +972,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: *CHECKOUT_REF_TMPL
 
@@ -955,7 +1040,7 @@ jobs:
           test -f "${RUNNER_TEMP}/rpcdocs-install/share/doc/qbit/rpc/data/rpc-docs-build-meta.json"
 
       - name: Upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rpc-docs-site
           if-no-files-found: error
@@ -963,7 +1048,7 @@ jobs:
             build/doc/rpc-site/**
 
       - name: Upload data artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rpc-docs-data
           if-no-files-found: error

--- a/.github/workflows/core-checks.yml
+++ b/.github/workflows/core-checks.yml
@@ -45,7 +45,7 @@ jobs:
       source_validation_required: ${{ steps.classify.outputs.source_validation_required }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install build dependencies
         run: |
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install build dependencies
         run: |
@@ -217,7 +217,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Install build dependencies
         run: |
@@ -276,7 +276,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ibd-perf-manual.yml
+++ b/.github/workflows/ibd-perf-manual.yml
@@ -135,13 +135,13 @@ jobs:
       NETWORK_IBD_EXIT_TIMEOUT: ${{ github.event_name != 'schedule' && inputs.NETWORK_IBD_EXIT_TIMEOUT || '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
 
@@ -518,7 +518,7 @@ jobs:
         id: upload_perf_summary_artifact
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ibd-perf-${{ github.run_id }}-summary
           path: |
@@ -537,7 +537,7 @@ jobs:
         id: upload_perf_benchmark_artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ibd-perf-${{ github.run_id }}-bench
           path: |
@@ -556,7 +556,7 @@ jobs:
         id: upload_perf_replay_artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ibd-perf-${{ github.run_id }}-replay
           path: |
@@ -575,7 +575,7 @@ jobs:
         id: retry_perf_replay_artifacts
         if: always() && steps.upload_perf_replay_artifacts.outcome != 'success'
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ibd-perf-${{ github.run_id }}-replay
           path: |
@@ -594,7 +594,7 @@ jobs:
         id: upload_perf_network_artifacts
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ibd-perf-${{ github.run_id }}-network
           path: |

--- a/.github/workflows/lint-image-prewarm.yml
+++ b/.github/workflows/lint-image-prewarm.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: Validate tag exists and is GitHub-verified
         id: tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -163,13 +163,13 @@ jobs:
           fi
 
       - name: Checkout tagged source
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: refs/tags/${{ steps.tag.outputs.tag }}
           fetch-depth: 0
 
       - name: Checkout trusted release validation policy
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.trusted_release_ref }}
           path: .trusted-release
@@ -419,7 +419,7 @@ jobs:
       - name: Create or update GitHub Release with notes file
         id: release_with_notes
         if: steps.notes.outputs.has_notes == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           target_commitish: ${{ steps.tag.outputs.target_commitish }}
@@ -435,7 +435,7 @@ jobs:
       - name: Create or update GitHub Release with generated notes
         id: release_generated
         if: steps.notes.outputs.has_notes != 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           target_commitish: ${{ steps.tag.outputs.target_commitish }}

--- a/.github/workflows/required-merge-gate.yml
+++ b/.github/workflows/required-merge-gate.yml
@@ -56,7 +56,7 @@ jobs:
       source_validation_required: ${{ steps.classify.outputs.source_validation_required }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -122,7 +122,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -334,7 +334,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -417,7 +417,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/rpc-docs-pages.yml
+++ b/.github/workflows/rpc-docs-pages.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ inputs.ref || github.ref_name }}
 
@@ -106,7 +106,7 @@ jobs:
           test -f "${RUNNER_TEMP}/rpcdocs-install/share/doc/qbit/rpc/data/rpc-docs-build-meta.json"
 
       - name: Upload site artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rpc-docs-site
           if-no-files-found: error
@@ -114,7 +114,7 @@ jobs:
             build/doc/rpc-site/**
 
       - name: Upload data artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rpc-docs-data
           if-no-files-found: error
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: ${{ inputs.publish }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: build/doc/rpc-site
 
@@ -152,4 +152,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/rpc-perf-manual.yml
+++ b/.github/workflows/rpc-perf-manual.yml
@@ -58,13 +58,13 @@ jobs:
       REFERENCE_REF: ${{ github.event_name == 'schedule' && 'v30.2' || inputs.reference_ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
 
@@ -217,7 +217,7 @@ jobs:
 
       - name: Upload RPC perf artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rpc-perf-${{ github.run_id }}
           path: ${{ env.PERF_ARTIFACT_ROOT }}

--- a/ci/release/validate_builder_attestations.py
+++ b/ci/release/validate_builder_attestations.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import os
 import re
 import shutil
 import subprocess
@@ -574,7 +573,7 @@ def main() -> int:
 
         with tempfile.TemporaryDirectory(prefix="qbit-operator-gnupg-") as gnupg_home:
             gnupg_home_path = Path(gnupg_home)
-            os.chmod(gnupg_home_path, 0o700)
+            gnupg_home_path.chmod(0o700)
             import_operator_keys(args.gpg, gnupg_home_path, operator_keys_dir, policy)
             counts: dict[str, list[str]] = {}
             for artifact in artifacts:

--- a/ci/release/validate_release_artifacts.py
+++ b/ci/release/validate_release_artifacts.py
@@ -578,7 +578,7 @@ def main() -> int:
 
         with tempfile.TemporaryDirectory(prefix="qbit-release-gnupg-") as gnupg_home:
             gnupg_home_path = Path(gnupg_home)
-            os.chmod(gnupg_home_path, 0o700)
+            gnupg_home_path.chmod(0o700)
             import_release_keys(args.gpg, gnupg_home_path, keys_dir, policy)
             counted_aliases = verify_manifest_signatures(
                 args.gpg, gnupg_home_path, artifacts_dir, policy

--- a/ci/scanners/run-scanners.py
+++ b/ci/scanners/run-scanners.py
@@ -129,6 +129,13 @@ LIBBITCOINPQC_UPSTREAM_TAG = "v0.3.0"
 LIBBITCOINPQC_UPSTREAM_REF = f"refs/tags/{LIBBITCOINPQC_UPSTREAM_TAG}"
 LIBBITCOINPQC_UPSTREAM_PEELED_REF = f"{LIBBITCOINPQC_UPSTREAM_REF}^{{}}"
 LIBBITCOINPQC_VERIFY_COMMAND = ["test/lint/libbitcoinpqc-subtree-check.sh"]
+LIBBITCOINPQC_RUSTSEC_CROSSBEAM_PATCH_ID = "RUSTSEC-2026-0204-crossbeam-epoch-0.9.20"
+LIBBITCOINPQC_RUSTSEC_CROSSBEAM_PATCH_LINES = [
+    '-version = "0.9.18"',
+    '+version = "0.9.20"',
+    '-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"',
+    '+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"',
+]
 
 
 def utcnow() -> str:
@@ -1124,6 +1131,63 @@ def git_commit_tree(source: Path, commit: str) -> str:
     return stdout.strip() if exit_code == 0 else ""
 
 
+def git_diff_name_only(source: Path, left: str, right: str) -> list[str]:
+    exit_code, stdout, _stderr = git_command(source, "diff", "--name-only", left, right)
+    if exit_code != 0:
+        return []
+    return [line.strip() for line in stdout.splitlines() if line.strip()]
+
+
+def git_diff_changed_lines(source: Path, left: str, right: str, path: str) -> list[str]:
+    exit_code, stdout, _stderr = git_command(
+        source,
+        "diff",
+        "--unified=0",
+        "--no-ext-diff",
+        left,
+        right,
+        "--",
+        path,
+    )
+    if exit_code != 0:
+        return []
+    return [
+        line
+        for line in stdout.splitlines()
+        if (line.startswith("+") or line.startswith("-"))
+        and not line.startswith("+++")
+        and not line.startswith("---")
+    ]
+
+
+def libbitcoinpqc_approved_downstream_patch_ids(
+    changed_paths: list[str],
+    cargo_lock_changed_lines: list[str],
+) -> list[str]:
+    if (
+        changed_paths == ["Cargo.lock"]
+        and cargo_lock_changed_lines == LIBBITCOINPQC_RUSTSEC_CROSSBEAM_PATCH_LINES
+    ):
+        return [LIBBITCOINPQC_RUSTSEC_CROSSBEAM_PATCH_ID]
+    return []
+
+
+def libbitcoinpqc_approved_downstream_patch_ids_for_trees(
+    source: Path,
+    base_tree: str,
+    current_tree: str,
+) -> list[str]:
+    if not base_tree or not current_tree or base_tree == current_tree:
+        return []
+    changed_paths = git_diff_name_only(source, base_tree, current_tree)
+    cargo_lock_changed_lines = (
+        git_diff_changed_lines(source, base_tree, current_tree, "Cargo.lock")
+        if changed_paths == ["Cargo.lock"]
+        else []
+    )
+    return libbitcoinpqc_approved_downstream_patch_ids(changed_paths, cargo_lock_changed_lines)
+
+
 def git_peel_commit(source: Path, object_name: str) -> str:
     if not object_name:
         return ""
@@ -1252,15 +1316,24 @@ def libbitcoinpqc_provenance(source: Path) -> tuple[dict[str, Any], list[str]]:
     provenance["qbit_subtree_tree"] = current_tree
     provenance["qbit_import_tree"] = import_tree
     provenance["upstream_tag_tree"] = upstream_tree
+    approved_import_patches = libbitcoinpqc_approved_downstream_patch_ids_for_trees(
+        source, import_tree, current_tree
+    )
+    approved_upstream_patches = libbitcoinpqc_approved_downstream_patch_ids_for_trees(
+        source, upstream_tree, current_tree
+    )
+    approved_patches = sorted(set(approved_import_patches + approved_upstream_patches))
+    if approved_patches:
+        provenance["approved_downstream_patches"] = approved_patches
     if not current_tree:
         gaps.append("libbitcoinpqc subtree tree hash unavailable from HEAD.")
     if import_commit and not import_tree:
         gaps.append(f"libbitcoinpqc qbit import commit tree unavailable: {import_commit}")
-    if current_tree and import_tree and current_tree != import_tree:
+    if current_tree and import_tree and current_tree != import_tree and not approved_import_patches:
         gaps.append("libbitcoinpqc subtree tree does not match the recorded qbit import commit tree.")
     if upstream_ref_commit and not upstream_tree:
         gaps.append(f"libbitcoinpqc upstream tag commit tree unavailable: {upstream_ref_commit}")
-    if current_tree and upstream_tree and current_tree != upstream_tree:
+    if current_tree and upstream_tree and current_tree != upstream_tree and not approved_upstream_patches:
         gaps.append("libbitcoinpqc subtree tree does not match the upstream tag tree.")
 
     verify_script = source / LIBBITCOINPQC_VERIFY_COMMAND[0]

--- a/ci/scanners/test_run_scanners.py
+++ b/ci/scanners/test_run_scanners.py
@@ -258,6 +258,36 @@ class RunScannersTest(unittest.TestCase):
             gaps,
         )
 
+    def test_libbitcoinpqc_approves_crossbeam_rustsec_lockfile_patch(self) -> None:
+        self.assertEqual(
+            [run_scanners.LIBBITCOINPQC_RUSTSEC_CROSSBEAM_PATCH_ID],
+            run_scanners.libbitcoinpqc_approved_downstream_patch_ids(
+                ["Cargo.lock"],
+                run_scanners.LIBBITCOINPQC_RUSTSEC_CROSSBEAM_PATCH_LINES,
+            ),
+        )
+
+    def test_libbitcoinpqc_rejects_other_lockfile_patch(self) -> None:
+        changed_lines = list(run_scanners.LIBBITCOINPQC_RUSTSEC_CROSSBEAM_PATCH_LINES)
+        changed_lines[-1] = '+checksum = "unexpected"'
+
+        self.assertEqual(
+            [],
+            run_scanners.libbitcoinpqc_approved_downstream_patch_ids(
+                ["Cargo.lock"],
+                changed_lines,
+            ),
+        )
+
+    def test_libbitcoinpqc_rejects_extra_downstream_path(self) -> None:
+        self.assertEqual(
+            [],
+            run_scanners.libbitcoinpqc_approved_downstream_patch_ids(
+                ["Cargo.lock", "README.md"],
+                run_scanners.LIBBITCOINPQC_RUSTSEC_CROSSBEAM_PATCH_LINES,
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/contrib/photon/src/vendor/WirehairCodec.cpp
+++ b/contrib/photon/src/vendor/WirehairCodec.cpp
@@ -1462,7 +1462,7 @@ void Codec::InitializeColumnValues()
     const uint16_t first_heavy_row = _defer_count + _dense_count;
     const uint16_t column_count = _defer_count + _mix_count;
 
-    uint16_t pivot_i;
+    unsigned pivot_i;
 
     // For each pivot:
     for (pivot_i = 0; pivot_i < column_count; ++pivot_i)
@@ -2534,7 +2534,7 @@ void Codec::BackSubstituteAboveDiagonal()
             if (first_word == last_word)
             {
                 // For each pivot row:
-                for (uint16_t above_pivot_i = 0; above_pivot_i < backsub_i; ++above_pivot_i)
+                for (unsigned above_pivot_i = 0; above_pivot_i < backsub_i; ++above_pivot_i)
                 {
                     const unsigned ge_row_k = *pivot_row++;
 
@@ -2567,7 +2567,7 @@ void Codec::BackSubstituteAboveDiagonal()
                 const unsigned shift1 = 64 - shift0;
 
                 // For each pivot row,
-                for (uint16_t above_pivot_i = 0; above_pivot_i < backsub_i; ++above_pivot_i)
+                for (unsigned above_pivot_i = 0; above_pivot_i < backsub_i; ++above_pivot_i)
                 {
                     const unsigned ge_row_k = *pivot_row++;
 
@@ -3099,7 +3099,7 @@ WirehairResult Codec::ResumeSolveMatrix(
     uint64_t ge_mask = 1;
 
     // For each pivot-found column up to the start of the heavy columns:
-    for (uint16_t pivot_j = 0; pivot_j < _next_pivot && pivot_j < _first_heavy_column; ++pivot_j)
+    for (unsigned pivot_j = 0; pivot_j < _next_pivot && pivot_j < _first_heavy_column; ++pivot_j)
     {
         const unsigned word_offset = pivot_j >> 6;
         uint64_t * GF256_RESTRICT rem_row = &ge_new_row[word_offset];
@@ -3721,7 +3721,7 @@ bool Codec::AllocateMatrix()
     // received in excess of N for when the decoder fails and has to resume
     // again.
     // When these extra rows are added we clear the row memory at that point.
-    memset(_ge_matrix, 0, ge_cols * ge_pitch * sizeof(uint64_t));
+    memset(_ge_matrix, 0, (size_t)ge_cols * ge_pitch * sizeof(uint64_t));
 
     return true;
 }

--- a/doc/subtrees/libbitcoinpqc.md
+++ b/doc/subtrees/libbitcoinpqc.md
@@ -57,6 +57,13 @@ The check fetches the pinned tag if needed, should report `GOOD`, and should
 show the subtree split commit as `ac72d1ffa0ef486f08d37334a43f5db1adb731db`
 for the current pin.
 
+The current qbit tree carries one approved downstream security delta on top of
+the pinned upstream tag: `RUSTSEC-2026-0204-crossbeam-epoch-0.9.20`, which
+updates only `src/libbitcoinpqc/Cargo.lock` from `crossbeam-epoch 0.9.18` to
+`0.9.20`. The subtree check accepts exactly that lockfile hunk and no other
+subtree drift. Drop the exception after `Qbit-Org/qbit-libbitcoinpqc` publishes
+an immutable tag containing the same advisory fix and qbit imports it.
+
 ## PR Checklist For Subtree Updates
 
 When a PR touches `src/libbitcoinpqc`, confirm:
@@ -67,6 +74,8 @@ When a PR touches `src/libbitcoinpqc`, confirm:
 - [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
 - [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh`
   is intentional and matches this runbook.
+- [ ] Any downstream security delta is listed above, is limited to the exact
+  lint allowlist, and is removed once a fixed upstream release tag is imported.
 
 ## Common Failures
 

--- a/src/crypto/muhash.cpp
+++ b/src/crypto/muhash.cpp
@@ -60,7 +60,7 @@ inline void mulnadd3(limb_t& c0, limb_t& c1, limb_t& c2, limb_t& d0, limb_t& d1,
     t += (double_limb_t)d1 * n + c1;
     c1 = t;
     t >>= LIMB_SIZE;
-    c2 = t + d2 * n;
+    c2 = t + double_limb_t{d2} * n;
 }
 
 /* [c0,c1] *= n */

--- a/src/libbitcoinpqc/Cargo.lock
+++ b/src/libbitcoinpqc/Cargo.lock
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/univalue/lib/univalue_write.cpp
+++ b/src/univalue/lib/univalue_write.cpp
@@ -64,7 +64,7 @@ std::string UniValue::write(unsigned int prettyIndent,
 
 static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, std::string& s)
 {
-    s.append(prettyIndent * indentLevel, ' ');
+    s.append(static_cast<std::string::size_type>(prettyIndent) * indentLevel, ' ');
 }
 
 // NOLINTNEXTLINE(misc-no-recursion)

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -126,6 +126,10 @@ verifies that both `HEAD:src/libbitcoinpqc` and the recorded
 subtree workflow, see
 [`doc/subtrees/libbitcoinpqc.md`](../../doc/subtrees/libbitcoinpqc.md).
 
+The check accepts the exact documented downstream lockfile patch for
+`RUSTSEC-2026-0204-crossbeam-epoch-0.9.20`. Any other subtree drift remains a
+failure.
+
 lint-libbitcoinpqc-vectors.py
 =============================
 Run this script from the root of the repository to verify bounded30 SPHINCS+

--- a/test/lint/libbitcoinpqc-subtree-check.sh
+++ b/test/lint/libbitcoinpqc-subtree-check.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 PREFIX="${LIBBITCOINPQC_PATH:-src/libbitcoinpqc}"
 REMOTE_URL="${LIBBITCOINPQC_REMOTE_URL:-https://github.com/Qbit-Org/qbit-libbitcoinpqc.git}"
 REMOTE_REF="${LIBBITCOINPQC_REMOTE_REF:-v0.3.0}"
+APPROVED_RUSTSEC_CROSSBEAM_PATCH="RUSTSEC-2026-0204-crossbeam-epoch-0.9.20"
+APPROVED_RUSTSEC_CROSSBEAM_DIFF_LINES=$'-version = "0.9.18"\n+version = "0.9.20"\n-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"\n+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"'
 
 usage() {
   cat <<EOF
@@ -37,6 +39,43 @@ resolve_remote_commit() {
   if ls_remote_output="$(git ls-remote --exit-code "${remote_url}" "${remote_ref}" 2>/dev/null)"; then
     printf '%s\n' "${ls_remote_output}" | awk 'NR==1 {print $1}'
   fi
+}
+
+approved_downstream_patch() {
+  local base_tree="$1"
+  local current_tree="$2"
+  local changed_paths
+  local changed_lines
+
+  changed_paths="$(git diff --name-only "${base_tree}" "${current_tree}")"
+  if [[ "${changed_paths}" != "Cargo.lock" ]]; then
+    return 1
+  fi
+
+  changed_lines="$(
+    git diff --unified=0 --no-ext-diff "${base_tree}" "${current_tree}" -- Cargo.lock |
+    awk '/^[-+]/ && $0 !~ /^(---|\+\+\+)/ {print}'
+  )"
+  [[ "${changed_lines}" == "${APPROVED_RUSTSEC_CROSSBEAM_DIFF_LINES}" ]]
+}
+
+verify_tree_match_or_approved_patch() {
+  local base_tree="$1"
+  local current_tree="$2"
+  local failure_message="$3"
+
+  if [[ "${current_tree}" == "${base_tree}" ]]; then
+    return 0
+  fi
+
+  if approved_downstream_patch "${base_tree}" "${current_tree}"; then
+    echo "GOOD: approved downstream libbitcoinpqc patch ${APPROVED_RUSTSEC_CROSSBEAM_PATCH}"
+    return 0
+  fi
+
+  git diff --stat "${base_tree}" "${current_tree}" >&2 || true
+  echo "FAIL: ${failure_message}" >&2
+  exit 1
 }
 
 if [[ "${1-}" == "--help" || "${1-}" == "-h" ]]; then
@@ -119,16 +158,14 @@ if [[ "${metadata_split}" != "${upstream_commit}" ]]; then
   exit 1
 fi
 
-if [[ "${current_tree}" != "${metadata_tree}" ]]; then
-  git diff --stat "${metadata_tree}" "${current_tree}" >&2 || true
-  echo "FAIL: ${PREFIX} tree differs from latest subtree import commit ${metadata_commit}" >&2
-  exit 1
-fi
+verify_tree_match_or_approved_patch \
+  "${metadata_tree}" \
+  "${current_tree}" \
+  "${PREFIX} tree differs from latest subtree import commit ${metadata_commit}"
 
-if [[ "${current_tree}" != "${upstream_tree}" ]]; then
-  git diff --stat "${upstream_tree}" "${current_tree}" >&2 || true
-  echo "FAIL: ${PREFIX} tree differs from upstream tag ${REMOTE_REF}" >&2
-  exit 1
-fi
+verify_tree_match_or_approved_patch \
+  "${upstream_tree}" \
+  "${current_tree}" \
+  "${PREFIX} tree differs from upstream tag ${REMOTE_REF}"
 
 echo "GOOD"


### PR DESCRIPTION
## Summary

Resolve scanner-reported medium findings from artifact `8175655824`:

- pin Qbit-owned GitHub Actions to full commit SHAs while preserving tag comments;
- fix actionlint shell quoting, disabled-job gates, and matrix defaults;
- address CodeQL integer-width findings in muhash, UniValue, and vendored Wirehair;
- update `src/libbitcoinpqc/Cargo.lock` for `RUSTSEC-2026-0204` with an exact downstream provenance exception until upstream publishes a fixed tag;
- triage LevelDB benchmark HTTP links as vendored subtree content instead of editing the subtree directly.

Residual triage:

- vendored upstream workflow files under `src/...` retain mutable action tags to preserve subtree/vendor snapshots;
- `src/leveldb/doc/benchmark.html` HTTP links remain unchanged because LevelDB is a pure subtree; updating them should happen through the upstream/subtree flow;
- artifact-only Semgrep ID `semgrep:dd25528218737b71` did not reproduce locally.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Checks run:

- `git diff --check`
- `python3 -m py_compile ci/scanners/run-scanners.py ci/scanners/test_run_scanners.py ci/release/validate_builder_attestations.py ci/release/validate_release_artifacts.py`
- `python3 ci/scanners/test_run_scanners.py`
- `actionlint -format '{{json .}}'`
- `semgrep scan --config=auto --json --output .context/scanner-other-verification/semgrep-1.0.0.json .`
- `cmake --build build_scanner_verify --target bitcoin_crypto univalue unitester object -j 8`
- `ctest --test-dir build_scanner_verify -R 'univalue' --output-on-failure`
- `cmake --build build_photon_scanner_verify --target photon_vendor_fec -j 8`
- `cargo audit --deny warnings` from `src/libbitcoinpqc`
- `osv-scanner scan source --lockfile src/libbitcoinpqc/Cargo.lock --format json --output-file .context/scanner-other-verification/osv-libbitcoinpqc-1.0.0.json .`
- `cargo test --locked` from `src/libbitcoinpqc`
- Docker-based `test/lint/lint-shell.py` via the `bitcoin-linter` image
- Docker-based `ruff check` for changed Python files via the `bitcoin-linter` image
- Docker-based `test/lint/git-subtree-check.sh src/leveldb` via the `bitcoin-linter` image
- `test/lint/libbitcoinpqc-subtree-check.sh`

Results:

- actionlint returned `[]`.
- Cargo Audit and OSV reported no Rust advisories after the lockfile update.
- Semgrep completed with only triaged residuals from this scope plus pre-existing high/error findings outside this PR scope.
- LevelDB subtree lint passed after removing the direct subtree edit.
- C++ build/test targets, Photon vendor FEC build, Rust tests, Docker lint, and subtree provenance check passed.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

Touches CI/release scanner policy, crypto arithmetic hardening, vendored Wirehair arithmetic, and libbitcoinpqc dependency provenance. No consensus rule or wallet behavior changes intended.

## Docs / Process Impact

Choose exactly one:

- [x] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [ ] No public docs update needed. Reason:

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [x] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

Note: The current upstream tag `v0.3.0` and upstream `main` still lock `crossbeam-epoch 0.9.18`; this PR carries only the documented downstream Cargo.lock security delta for `RUSTSEC-2026-0204`, and the subtree check allows exactly that hunk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/release workflows, crypto arithmetic, and dependency provenance policy; changes are hardening and supply-chain focused with no intended consensus behavior change.
> 
> **Overview**
> Addresses scanner-reported supply-chain and static-analysis items by **pinning Qbit-owned GitHub Actions** (workflows and composite actions) to **full commit SHAs** with version comments, and tightening **CI shell usage** (quoted variables, bash arrays for test runners, safer `docker buildx` / `docker create` argument expansion).
> 
> **CI behavior** changes opt-in gates: `test-each-commit` and **macOS native** jobs run only when repo vars (`QBIT_ENABLE_TEST_EACH_COMMIT`, `QBIT_ENABLE_MACOS_NATIVE_ARM64`) are set, with trusted-fork checks preserved. The main **ci-matrix** entries now declare explicit **make/test job counts and container resource** defaults.
> 
> **Security / deps:** bumps `crossbeam-epoch` in `src/libbitcoinpqc/Cargo.lock` for **RUSTSEC-2026-0204**, with a **single exact Cargo.lock hunk** allowed in `libbitcoinpqc-subtree-check.sh`, `ci/scanners/run-scanners.py`, and docs until upstream ships a fixed tag.
> 
> **CodeQL integer-width fixes** in `muhash.cpp`, UniValue JSON writing, and vendored **Wirehair** loops/`memset` sizing. Release validator scripts use **`Path.chmod`** instead of `os.chmod`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b6840c211ea8e0d0edc3d240f83f629a8636ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786128083&installation_id=141183937&pr_number=74&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F74&signature=ec928f0e2c091705721d4cb824a59b6ff864f810b31538cf55449652cd3eb67d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
