### PR TITLE
Reject malformed P2MR leaf versions in qbit-qt

### DIFF
--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -187,12 +187,12 @@ bool ParseP2MRProofJson(const QString& proof_json, common::P2MRDataSignatureProo
         error = SignVerifyMessageDialog::tr("Proof field \"leaf_version\" must be a number.");
         return false;
     }
-    const int leaf_version_int{leaf_version.getInt<int>()};
-    if (leaf_version_int < 0 || leaf_version_int > 0xff) {
-        error = SignVerifyMessageDialog::tr("Proof field \"leaf_version\" is out of range.");
+    const auto leaf_version_int{ToIntegral<uint8_t>(leaf_version.getValStr())};
+    if (!leaf_version_int.has_value()) {
+        error = SignVerifyMessageDialog::tr("Proof field \"leaf_version\" must be an integer from 0 to 255.");
         return false;
     }
-    proof.leaf_version = static_cast<uint8_t>(leaf_version_int);
+    proof.leaf_version = *leaf_version_int;
     return true;
 }
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -6,6 +6,8 @@
 #include <qt/test/util.h>
 
 #include <wallet/coincontrol.h>
+#include <common/p2mr_data_signature.h>
+#include <crypto/pqc.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
@@ -53,6 +55,7 @@
 #include <QComboBox>
 #include <QElapsedTimer>
 #include <QEvent>
+#include <QLabel>
 #include <QLineEdit>
 #include <QObject>
 #include <QPointer>
@@ -64,6 +67,8 @@
 #include <QTextEdit>
 #include <QListView>
 #include <QDialogButtonBox>
+
+#include <univalue.h>
 
 using wallet::AddWallet;
 using wallet::CWallet;
@@ -81,6 +86,67 @@ constexpr int QT_WALLET_FUNDING_TXS{5};
 constexpr CAmount QT_WALLET_FUNDING_AMOUNT{210 * COIN - 1000};
 constexpr std::array QT_WALLET_BECH32_DESCRIPTOR_OUTPUT_TYPES{OutputType::BECH32};
 constexpr std::array QT_WALLET_P2MR_DESCRIPTOR_OUTPUT_TYPES{OutputType::P2MR};
+
+QString MakeP2MRProofJson(std::string leaf_version)
+{
+    UniValue proof{UniValue::VOBJ};
+    proof.pushKV("proof_mode", common::P2MR_DATA_SIGNATURE_PROOF_MODE);
+    proof.pushKV("address", EncodeDestination(WitnessV2P2MR{}));
+    proof.pushKV("message_hash", std::string(uint256::size() * 2, '0'));
+    proof.pushKV("pubkey", std::string(PQC_PUBKEY_SIZE * 2, '0'));
+    proof.pushKV("signature", std::string(PQC_SIG_SIZE * 2, '0'));
+    proof.pushKV("leaf_script", "00");
+    proof.pushKV("control_block", "c1");
+
+    UniValue leaf_version_value;
+    leaf_version_value.setNumStr(std::move(leaf_version));
+    proof.pushKV("leaf_version", std::move(leaf_version_value));
+    return QString::fromStdString(proof.write());
+}
+
+void TestP2MRProofLeafVersionValidation(SignVerifyMessageDialog& dialog)
+{
+    QPlainTextEdit* proof_input = dialog.findChild<QPlainTextEdit*>("messageIn_VM");
+    QVERIFY(proof_input);
+    QComboBox* verify_input_mode = dialog.findChild<QComboBox*>("p2mrVerifyInputMode_VM");
+    QVERIFY(verify_input_mode);
+    QLabel* status_label = dialog.findChild<QLabel*>("statusLabel_VM");
+    QVERIFY(status_label);
+    QPushButton* verify_button = dialog.findChild<QPushButton*>("verifyMessageButton_VM");
+    QVERIFY(verify_button);
+
+    dialog.showTab_VM(/*fShow=*/false);
+    verify_input_mode->setCurrentIndex(2);
+
+    const QString stale_success{"P2MR/PQC proof verified for a previous proof."};
+    const QString leaf_version_error{"Proof field \"leaf_version\" must be an integer from 0 to 255."};
+    const std::array invalid_leaf_versions{
+        "192.0",
+        "1e2",
+        "-1",
+        "256",
+        "2147483648",
+        "1e1000000",
+    };
+    for (const char* leaf_version : invalid_leaf_versions) {
+        status_label->setStyleSheet("QLabel { color: green; }");
+        status_label->setText(stale_success);
+        proof_input->setPlainText(MakeP2MRProofJson(leaf_version));
+
+        verify_button->click();
+
+        QCOMPARE(status_label->text(), leaf_version_error);
+        QVERIFY(status_label->styleSheet().contains("red"));
+        QVERIFY(status_label->text() != stale_success);
+        QVERIFY(verify_button->isEnabled());
+        QVERIFY(QApplication::instance() != nullptr);
+    }
+
+    proof_input->setPlainText(MakeP2MRProofJson("192"));
+    verify_button->click();
+    QVERIFY(status_label->text().startsWith("P2MR/PQC proof verification failed:"));
+    QVERIFY(status_label->styleSheet().contains("red"));
+}
 
 template <typename Predicate>
 bool WaitUntil(Predicate&& predicate, int timeout_ms)
@@ -845,6 +911,8 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     QPushButton* verify_button = sign_verify_dialog.findChild<QPushButton*>("verifyMessageButton_VM");
     QVERIFY(verify_button);
     QCOMPARE(verify_button->text(), QString("Verify &Proof"));
+
+    TestP2MRProofLeafVersionValidation(sign_verify_dialog);
 }
 
 void TestSendPQCReportPropagation(interfaces::Node& node)


### PR DESCRIPTION
## Summary

Fixes #75.

Replace the throwing `UniValue::getInt<int>()` conversion in the qbit-qt P2MR proof parser with non-throwing `ToIntegral<uint8_t>()` validation. Fractional, exponent, negative, and overflowing `leaf_version` values now produce a normal red proof error instead of escaping the Verify dialog and terminating the GUI session.

Add Verify-button regression coverage for malformed numeric representations, stale-success replacement, application liveness, and the canonical `192` control case.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Checks run:

- `git diff --check`
- `cmake -S . -B build -G Ninja -DBUILD_GUI=ON -DBUILD_TESTS=ON -DBUILD_GUI_TESTS=ON -DENABLE_WALLET=ON`
- `cmake --build build --target test_qbit-qt qbit-qt -j8`
- `ulimit -n 1024; QT_QPA_PLATFORM=offscreen build/bin/test_qbit-qt`
- Docker lint image from `ci/lint_imagefile`, running the default lint entrypoint with the worktree and shared Git metadata mounted.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

This fix targets the maintained `1.0.0` branch.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- The change is limited to qbit-qt proof JSON validation and its Qt regression test.
- Consensus, RPC, shared proof verification, and cryptographic behavior are unchanged.
- Well-formed byte values still reach the shared verifier, which remains responsible for rejecting unsupported P2MR leaf versions.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this corrects malformed-input handling, and the dialog now reports the validation requirement directly.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786296235&installation_id=141183937&pr_number=82&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F82&signature=b51bfd8a8657d3f45ffe6ea1d8f93197aa86d4b0cd1f5bafa061243d86f4b77e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to qbit-qt proof JSON parsing and GUI tests; consensus, RPC, and shared verification are unchanged.
> 
> **Overview**
> Fixes **qbit-qt** crashing when **Verify Proof** parses a P2MR JSON proof with a malformed **`leaf_version`**.
> 
> **`ParseP2MRProofJson`** no longer uses throwing **`UniValue::getInt<int>()`**. It parses **`leaf_version`** with **`ToIntegral<uint8_t>(getValStr())`** so fractional, scientific, negative, and out-of-range values fail validation and show a red status message (**"must be an integer from 0 to 255"**) instead of terminating the GUI.
> 
> **`test_qbit-qt`** adds **`TestP2MRProofLeafVersionValidation`**, which drives the Verify button with invalid **`leaf_version`** strings (and a valid **`192`** case that still fails crypto verification) to assert error text, stale-success replacement, and app liveness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 177ede0047fb45426081932dac385f665f270c5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->