### PR TITLE
Bind builder attestations to signed-tag source

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -348,9 +348,7 @@ jobs:
           ARTIFACTS_DIR_INPUT: ${{ inputs.artifacts_dir }}
           RELEASE_LINE: ${{ inputs.release_line }}
           REQUIRE_PHOTON: ${{ inputs.require_photon }}
-          SOURCE_ROOT: ${{ github.workspace }}
           TAG_NAME: ${{ steps.tag.outputs.tag }}
-          TARGET_COMMITISH: ${{ steps.tag.outputs.target_commitish }}
           TRUSTED_OPERATOR_KEYS_DIR: ${{ steps.trusted.outputs.operator_keys_dir }}
           TRUSTED_OPERATOR_POLICY: ${{ steps.trusted.outputs.operator_policy }}
           TRUSTED_ROOT: ${{ steps.trusted.outputs.root }}
@@ -391,7 +389,9 @@ jobs:
           PHOTON_ARTIFACT_COUNT: ${{ steps.artifacts.outputs.photon_artifact_count }}
           RELEASE_LINE: ${{ inputs.release_line }}
           REQUIRE_PHOTON: ${{ inputs.require_photon }}
+          SOURCE_ROOT: ${{ github.workspace }}
           TAG_NAME: ${{ steps.tag.outputs.tag }}
+          TARGET_COMMITISH: ${{ steps.tag.outputs.target_commitish }}
           TRUSTED_OPERATOR_KEYS_DIR: ${{ steps.trusted.outputs.operator_keys_dir }}
           TRUSTED_OPERATOR_POLICY: ${{ steps.trusted.outputs.operator_policy }}
           TRUSTED_ROOT: ${{ steps.trusted.outputs.root }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -172,6 +172,28 @@ jobs:
           ref: refs/tags/${{ steps.tag.outputs.tag }}
           fetch-depth: 0
 
+      - name: Restore verified annotated release tag
+        env:
+          TAG_NAME: ${{ steps.tag.outputs.tag }}
+          TAG_SHA: ${{ steps.tag.outputs.tag_sha }}
+          TARGET_COMMITISH: ${{ steps.tag.outputs.target_commitish }}
+        run: |
+          set -euo pipefail
+
+          git fetch --force --no-tags origin \
+            "refs/tags/${TAG_NAME}:refs/tags/${TAG_NAME}"
+
+          local_tag_sha="$(git rev-parse "refs/tags/${TAG_NAME}^{tag}")"
+          local_target="$(git rev-parse "refs/tags/${TAG_NAME}^{commit}")"
+          if [[ "${local_tag_sha,,}" != "${TAG_SHA,,}" ]]; then
+            echo "Local tag object ${local_tag_sha} does not match verified tag object ${TAG_SHA}" >&2
+            exit 1
+          fi
+          if [[ "${local_target,,}" != "${TARGET_COMMITISH,,}" ]]; then
+            echo "Local tag target ${local_target} does not match verified target ${TARGET_COMMITISH}" >&2
+            exit 1
+          fi
+
       - name: Checkout trusted release validation policy
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -129,6 +129,10 @@ jobs:
               core.setFailed(`Tag ${tag} is not a verified signed tag (reason: ${verification.reason || 'unknown'})`);
               return;
             }
+            if (tagObject.data.object.type !== 'commit') {
+              core.setFailed(`Tag ${tag} must target a commit, got ${tagObject.data.object.type || 'unknown'}`);
+              return;
+            }
 
             core.setOutput('tag', tag);
             core.setOutput('tag_sha', ref.data.object.sha);
@@ -344,7 +348,9 @@ jobs:
           ARTIFACTS_DIR_INPUT: ${{ inputs.artifacts_dir }}
           RELEASE_LINE: ${{ inputs.release_line }}
           REQUIRE_PHOTON: ${{ inputs.require_photon }}
+          SOURCE_ROOT: ${{ github.workspace }}
           TAG_NAME: ${{ steps.tag.outputs.tag }}
+          TARGET_COMMITISH: ${{ steps.tag.outputs.target_commitish }}
           TRUSTED_OPERATOR_KEYS_DIR: ${{ steps.trusted.outputs.operator_keys_dir }}
           TRUSTED_OPERATOR_POLICY: ${{ steps.trusted.outputs.operator_policy }}
           TRUSTED_ROOT: ${{ steps.trusted.outputs.root }}
@@ -403,6 +409,8 @@ jobs:
           args=(
             --artifacts-dir "${ARTIFACTS_DIR}"
             --tag "${TAG_NAME}"
+            --source-root "${SOURCE_ROOT}"
+            --expected-tag-target "${TARGET_COMMITISH}"
             --release-line "${RELEASE_LINE}"
             --guix-sigs-repo "${GUIX_SIGS_REPO_INPUT}"
             --operator-key-policy "${TRUSTED_OPERATOR_POLICY}"
@@ -455,6 +463,9 @@ jobs:
           BUILDER_ATTESTATION_CORE_COUNT: ${{ steps.builders.outputs.builder_attestation_core_count }}
           BUILDER_ATTESTATION_PHOTON_COUNT: ${{ steps.builders.outputs.builder_attestation_photon_count || 'n/a' }}
           BUILDER_ATTESTATION_QUORUM: ${{ steps.builders.outputs.builder_attestation_quorum }}
+          BUILDER_ATTESTATION_SOURCE_ARCHIVE: ${{ steps.builders.outputs.builder_attestation_source_archive }}
+          BUILDER_ATTESTATION_SOURCE_SHA256: ${{ steps.builders.outputs.builder_attestation_source_sha256 }}
+          BUILDER_ATTESTATION_TAG_TARGET: ${{ steps.builders.outputs.builder_attestation_tag_target }}
           CORE_ARTIFACT_COUNT: ${{ steps.artifacts.outputs.core_artifact_count }}
           DRAFT: ${{ inputs.draft }}
           FILE_COUNT: ${{ steps.artifacts.outputs.file_count }}
@@ -496,6 +507,9 @@ jobs:
             echo "- Counted release signer aliases: \`${RELEASE_SIGNATURE_ALIASES}\`"
             echo "- Builder attestations (core): \`${BUILDER_ATTESTATION_CORE_COUNT}/${BUILDER_ATTESTATION_QUORUM}\`"
             echo "- Builder attestations (PHOTON): \`${BUILDER_ATTESTATION_PHOTON_COUNT}/${BUILDER_ATTESTATION_QUORUM}\`"
+            echo "- Builder source archive: \`${BUILDER_ATTESTATION_SOURCE_ARCHIVE}\`"
+            echo "- Builder source archive SHA256: \`${BUILDER_ATTESTATION_SOURCE_SHA256}\`"
+            echo "- Builder source tag target: \`${BUILDER_ATTESTATION_TAG_TARGET}\`"
             echo "- Draft: \`${DRAFT}\`"
             echo "- Prerelease: \`${PRERELEASE}\`"
             echo "- Make latest: \`${MAKE_LATEST}\`"

--- a/ci/release/test_validate_builder_attestations.py
+++ b/ci/release/test_validate_builder_attestations.py
@@ -19,9 +19,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BUILDER_VALIDATOR = REPO_ROOT / "ci" / "release" / "validate_builder_attestations.py"
 GPG = shutil.which("gpg")
+GIT = shutil.which("git")
 
 
-@unittest.skipUnless(GPG, "gpg is required for builder attestation tests")
+@unittest.skipUnless(GPG and GIT, "gpg and git are required for builder attestation tests")
 class ValidateBuilderAttestationsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -105,6 +106,18 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
         self.mirror_policy = self.mirror_keys_dir / "keys.json"
         self.tag = "v1.0.0-testnet1"
         self.version = self.tag[1:]
+        self.source_root = self.root / "source"
+        self.source_root.mkdir()
+        self.git("init", "--quiet")
+        self.git("config", "user.name", "qbit release fixture")
+        self.git("config", "user.email", "release-fixture@example.invalid")
+        (self.source_root / "README.md").write_text("qbit release fixture\n", encoding="utf8")
+        self.git("add", "README.md")
+        self.git("commit", "--quiet", "-m", "initial release source")
+        self.git("tag", "-a", self.tag, "-m", "release fixture")
+        self.tag_target = self.git("rev-parse", f"{self.tag}^{{commit}}").stdout.strip()
+        self.source_archive = f"qbit-{self.version}.tar.gz"
+        self.source_sha256 = self.archive_sha256(self.tag_target, self.source_archive)
         self.core_artifact = f"qbit-{self.version}-x86_64-linux-gnu.tar.gz"
         self.photon_artifact = f"qbit-photon-{self.version}-x86_64-linux-gnu.tar.gz"
         self.write_operator_policy(self.builders[:3])
@@ -113,6 +126,39 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.tmp.cleanup()
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        result = subprocess.run(
+            [
+                GIT,
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "tag.gpgsign=false",
+                *args,
+            ],
+            cwd=self.source_root,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"git failed: {' '.join(args)}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+        return result
+
+    def archive_sha256(self, target: str, name: str) -> str:
+        archive = self.root / f"{hashlib.sha256(target.encode()).hexdigest()}-{name}"
+        self.git(
+            "archive",
+            f"--prefix=qbit-{self.version}/",
+            f"--output={archive}",
+            target,
+        )
+        digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+        archive.unlink()
+        return digest
 
     def public_key_file(self, alias: str) -> str:
         return f"public-keys/{alias}-release.asc"
@@ -254,8 +300,13 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
         names: list[str],
         *,
         tamper: bool = False,
+        omit_source: bool = False,
+        source_name: str | None = None,
+        source_digest: str | None = None,
+        manifest_type: str = "noncodesigned",
     ) -> None:
-        manifest_name = "noncodesigned.SHA256SUMS" if artifact == "core" else f"{artifact}-noncodesigned.SHA256SUMS"
+        prefix = "" if artifact == "core" else f"{artifact}-"
+        manifest_name = f"{prefix}{manifest_type}.SHA256SUMS"
         for builder in builders:
             builder_dir = self.guix_sigs_repo / self.version / builder["alias"]
             builder_dir.mkdir(parents=True, exist_ok=True)
@@ -263,6 +314,11 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
             lines = [self.manifest_line(name) for name in names]
             if tamper:
                 lines[0] = "0" * 64 + f"  {names[0]}\n"
+            if not omit_source:
+                lines.append(
+                    f"{source_digest or self.source_sha256}  "
+                    f"{source_name or self.source_archive}\n"
+                )
             manifest.write_text("".join(lines), encoding="utf8")
             self.gpg(
                 [
@@ -279,8 +335,14 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
                 home=self.secret_home,
             )
 
-    def attestation_signature(self, builder: dict[str, str], artifact: str) -> Path:
-        manifest_name = "noncodesigned.SHA256SUMS" if artifact == "core" else f"{artifact}-noncodesigned.SHA256SUMS"
+    def attestation_signature(
+        self,
+        builder: dict[str, str],
+        artifact: str,
+        manifest_type: str = "noncodesigned",
+    ) -> Path:
+        prefix = "" if artifact == "core" else f"{artifact}-"
+        manifest_name = f"{prefix}{manifest_type}.SHA256SUMS"
         manifest = self.guix_sigs_repo / self.version / builder["alias"] / manifest_name
         return Path(f"{manifest}.asc")
 
@@ -293,6 +355,10 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
                 str(self.artifacts_dir),
                 "--tag",
                 self.tag,
+                "--source-root",
+                str(self.source_root),
+                "--expected-tag-target",
+                self.tag_target,
                 "--release-line",
                 "testnet",
                 "--guix-sigs-repo",
@@ -307,6 +373,8 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
                 str(self.mirror_keys_dir),
                 "--gpg",
                 GPG,
+                "--git",
+                GIT,
                 *extra_args,
             ],
             check=False,
@@ -319,6 +387,173 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("core:2/2", result.stdout)
+        self.assertIn(
+            f"source={self.source_archive}:{self.source_sha256}",
+            result.stdout,
+        )
+        self.assertIn(f"tag_target={self.tag_target}", result.stdout)
+
+    def test_source_archive_evidence_is_written_to_github_output(self) -> None:
+        github_output = self.root / "github-output.txt"
+
+        result = self.run_builder_validator("--github-output", str(github_output))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        output = github_output.read_text(encoding="utf8")
+        self.assertIn(f"builder_attestation_source_archive={self.source_archive}\n", output)
+        self.assertIn(f"builder_attestation_source_sha256={self.source_sha256}\n", output)
+        self.assertIn(f"builder_attestation_tag_target={self.tag_target}\n", output)
+
+    def test_missing_source_archive_fails_quorum(self) -> None:
+        self.write_attestations(
+            [self.builders[1]],
+            "core",
+            [self.core_artifact],
+            omit_source=True,
+        )
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("core builder attestation quorum not met: got 1, need 2", result.stderr)
+        self.assertIn(
+            f"operator-02: manifest is missing canonical source archive {self.source_archive}",
+            result.stderr,
+        )
+
+    def test_renamed_source_archive_fails_quorum(self) -> None:
+        self.write_attestations(
+            self.builders[:2],
+            "core",
+            [self.core_artifact],
+            source_name=f"renamed-{self.source_archive}",
+        )
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(f"missing canonical source archive {self.source_archive}", result.stderr)
+
+    def test_wrong_source_archive_digest_fails_quorum(self) -> None:
+        self.write_attestations(
+            self.builders[:2],
+            "core",
+            [self.core_artifact],
+            source_digest="0" * 64,
+        )
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            f"expected {self.source_sha256} from signed tag target",
+            result.stderr,
+        )
+
+    def test_source_archive_from_different_commit_fails_quorum(self) -> None:
+        (self.source_root / "README.md").write_text(
+            "different release source\n",
+            encoding="utf8",
+        )
+        self.git("add", "README.md")
+        self.git("commit", "--quiet", "-m", "different release source")
+        other_target = self.git("rev-parse", "HEAD").stdout.strip()
+        other_source_sha256 = self.archive_sha256(other_target, self.source_archive)
+        self.write_attestations(
+            self.builders[:2],
+            "core",
+            [self.core_artifact],
+            source_digest=other_source_sha256,
+        )
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(
+            f"expected {self.source_sha256} from signed tag target",
+            result.stderr,
+        )
+
+    def test_invalid_source_manifest_does_not_block_met_quorum(self) -> None:
+        self.write_attestations(
+            self.builders[2:3],
+            "core",
+            [self.core_artifact],
+            omit_source=True,
+        )
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("core:2/2", result.stdout)
+
+    def test_all_manifest_cannot_bypass_source_binding(self) -> None:
+        self.write_attestations(
+            self.builders[:2],
+            "core",
+            [self.core_artifact],
+            omit_source=True,
+            manifest_type="all",
+        )
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(f"missing canonical source archive {self.source_archive}", result.stderr)
+
+    def test_expected_tag_target_must_match_local_annotated_tag(self) -> None:
+        (self.source_root / "README.md").write_text("new target\n", encoding="utf8")
+        self.git("add", "README.md")
+        self.git("commit", "--quiet", "-m", "new target")
+        other_target = self.git("rev-parse", "HEAD").stdout.strip()
+
+        result = self.run_builder_validator("--expected-tag-target", other_target)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not verified target", result.stderr)
+
+    def test_lightweight_release_tag_is_rejected(self) -> None:
+        self.git("tag", "-d", self.tag)
+        self.git("tag", self.tag, self.tag_target)
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("must be an annotated tag object", result.stderr)
+
+    def test_release_tag_must_directly_target_commit(self) -> None:
+        inner_tag = "v1.0.0-testnet1-inner"
+        self.git("tag", "-a", inner_tag, self.tag_target, "-m", "inner release tag")
+        self.git("tag", "-d", self.tag)
+        self.git("tag", "-a", self.tag, inner_tag, "-m", "outer release tag")
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("must directly target a commit", result.stderr)
+
+    def test_missing_release_tag_is_rejected(self) -> None:
+        self.git("tag", "-d", self.tag)
+
+        result = self.run_builder_validator()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn(f"Failed to resolve annotated release tag {self.tag}", result.stderr)
+
+    def test_invalid_expected_tag_target_is_rejected(self) -> None:
+        result = self.run_builder_validator("--expected-tag-target", "abcd")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("must be a full 40-character commit SHA", result.stderr)
+
+    def test_missing_source_root_is_rejected(self) -> None:
+        result = self.run_builder_validator(
+            "--source-root",
+            str(self.root / "missing-source"),
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Source root is not a directory", result.stderr)
 
     def test_under_quorum_fails(self) -> None:
         shutil.rmtree(self.guix_sigs_repo / self.version / "operator-02")
@@ -561,6 +796,22 @@ class ValidateBuilderAttestationsTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("core:2/2", result.stdout)
         self.assertIn("photon:2/2", result.stdout)
+
+    def test_photon_manifest_without_source_archive_fails_photon_quorum(self) -> None:
+        self.write_release_sha256sums([self.core_artifact, self.photon_artifact])
+        self.write_attestations(self.builders[:2], "photon", [self.photon_artifact])
+        self.write_attestations(
+            [self.builders[1]],
+            "photon",
+            [self.photon_artifact],
+            omit_source=True,
+        )
+
+        result = self.run_builder_validator("--artifact", "core", "--artifact", "photon")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("photon builder attestation quorum not met: got 1, need 2", result.stderr)
+        self.assertIn(f"missing canonical source archive {self.source_archive}", result.stderr)
 
     def test_staged_photon_artifact_requires_photon_attestation_by_default(self) -> None:
         self.write_release_sha256sums([self.core_artifact, self.photon_artifact])

--- a/ci/release/test_validate_release_artifacts.py
+++ b/ci/release/test_validate_release_artifacts.py
@@ -667,9 +667,22 @@ class ReleaseWorkflowBoundaryTest(unittest.TestCase):
             workflow,
             r"Checkout trusted release validation policy[\s\S]*fetch-depth: 0",
         )
-        self.assertIn("SOURCE_ROOT: ${{ github.workspace }}", workflow)
-        self.assertIn("--source-root \"${SOURCE_ROOT}\"", workflow)
-        self.assertIn("--expected-tag-target \"${TARGET_COMMITISH}\"", workflow)
+        builder_step_start = workflow.index("- name: Validate builder attestations")
+        builder_step_end = workflow.index(
+            "- name: Create or update GitHub Release",
+            builder_step_start,
+        )
+        builder_step = workflow[builder_step_start:builder_step_end]
+        self.assertIn("SOURCE_ROOT: ${{ github.workspace }}", builder_step)
+        self.assertIn(
+            "TARGET_COMMITISH: ${{ steps.tag.outputs.target_commitish }}",
+            builder_step,
+        )
+        self.assertIn("--source-root \"${SOURCE_ROOT}\"", builder_step)
+        self.assertIn(
+            "--expected-tag-target \"${TARGET_COMMITISH}\"",
+            builder_step,
+        )
         self.assertIn(
             "BUILDER_ATTESTATION_SOURCE_SHA256: "
             "${{ steps.builders.outputs.builder_attestation_source_sha256 }}",

--- a/ci/release/test_validate_release_artifacts.py
+++ b/ci/release/test_validate_release_artifacts.py
@@ -667,6 +667,30 @@ class ReleaseWorkflowBoundaryTest(unittest.TestCase):
             workflow,
             r"Checkout trusted release validation policy[\s\S]*fetch-depth: 0",
         )
+        restore_step_start = workflow.index(
+            "- name: Restore verified annotated release tag"
+        )
+        restore_step_end = workflow.index(
+            "- name: Checkout trusted release validation policy",
+            restore_step_start,
+        )
+        restore_step = workflow[restore_step_start:restore_step_end]
+        self.assertLess(verified_step, restore_step_start)
+        self.assertLess(restore_step_start, local_validator_step)
+        self.assertIn(
+            '"refs/tags/${TAG_NAME}:refs/tags/${TAG_NAME}"',
+            restore_step,
+        )
+        self.assertIn('git rev-parse "refs/tags/${TAG_NAME}^{tag}"', restore_step)
+        self.assertIn(
+            'git rev-parse "refs/tags/${TAG_NAME}^{commit}"',
+            restore_step,
+        )
+        self.assertIn('"${local_tag_sha,,}" != "${TAG_SHA,,}"', restore_step)
+        self.assertIn(
+            '"${local_target,,}" != "${TARGET_COMMITISH,,}"',
+            restore_step,
+        )
         builder_step_start = workflow.index("- name: Validate builder attestations")
         builder_step_end = workflow.index(
             "- name: Create or update GitHub Release",

--- a/ci/release/test_validate_release_artifacts.py
+++ b/ci/release/test_validate_release_artifacts.py
@@ -647,6 +647,7 @@ class ReleaseWorkflowBoundaryTest(unittest.TestCase):
 
         self.assertLess(verified_step, local_validator_step)
         self.assertIn("verification.verified", workflow)
+        self.assertIn("tagObject.data.object.type !== 'commit'", workflow)
         self.assertIn("validate_release_artifacts.py", workflow)
         self.assertIn("ci/release/verify_testnet_release_posture.py", workflow)
         self.assertNotIn(OLD_TESTNET_POSTURE_VERIFIER, workflow)
@@ -666,6 +667,15 @@ class ReleaseWorkflowBoundaryTest(unittest.TestCase):
             workflow,
             r"Checkout trusted release validation policy[\s\S]*fetch-depth: 0",
         )
+        self.assertIn("SOURCE_ROOT: ${{ github.workspace }}", workflow)
+        self.assertIn("--source-root \"${SOURCE_ROOT}\"", workflow)
+        self.assertIn("--expected-tag-target \"${TARGET_COMMITISH}\"", workflow)
+        self.assertIn(
+            "BUILDER_ATTESTATION_SOURCE_SHA256: "
+            "${{ steps.builders.outputs.builder_attestation_source_sha256 }}",
+            workflow,
+        )
+        self.assertIn("Builder source archive SHA256", workflow)
 
         validator_source = VALIDATOR.read_text(encoding="utf8")
         self.assertNotIn("github.rest", validator_source)

--- a/ci/release/validate_builder_attestations.py
+++ b/ci/release/validate_builder_attestations.py
@@ -27,6 +27,7 @@ CHECKSUMS_FILE = "SHA256SUMS"
 FINGERPRINT_RE = re.compile(r"^[0-9A-F]{40}$")
 APPROVAL_ALIAS_RE = re.compile(r"^[a-z0-9][a-z0-9-]{2,31}$")
 SHA256SUMS_LINE_RE = re.compile(r"^([0-9A-Fa-f]{64}) [ *](.+)$")
+COMMIT_SHA_RE = re.compile(r"^[0-9A-Fa-f]{40}$")
 ALLOWED_ARTIFACT_SETS = {"core", "photon"}
 
 
@@ -51,6 +52,13 @@ class BuilderPolicy:
     active_signer_set_size: int
     signer_public_key_files: frozenset[str]
     active_builders: dict[str, BuilderOperator]
+
+
+@dataclass(frozen=True)
+class CanonicalSourceArchive:
+    name: str
+    sha256: str
+    tag_target: str
 
 
 def normalize_fingerprint(value: str) -> str:
@@ -316,7 +324,7 @@ def parse_sha256sums(path: Path) -> dict[str, str]:
 
 
 def expected_release_entries(artifacts_dir: Path, tag: str, artifact: str) -> dict[str, str]:
-    version = tag.removeprefix("v")
+    version = release_version(tag)
     all_entries = parse_sha256sums(artifacts_dir / CHECKSUMS_FILE)
     if artifact == "core":
         prefix = f"qbit-{version}-"
@@ -335,7 +343,7 @@ def expected_release_entries(artifacts_dir: Path, tag: str, artifact: str) -> di
 
 
 def detected_artifacts(artifacts_dir: Path, tag: str) -> list[str]:
-    version = tag.removeprefix("v")
+    version = release_version(tag)
     all_entries = parse_sha256sums(artifacts_dir / CHECKSUMS_FILE)
     artifacts: list[str] = []
     if any(name.startswith(f"qbit-{version}-") for name in all_entries):
@@ -406,6 +414,135 @@ def run_command(
     )
 
 
+def release_version(tag: str) -> str:
+    if not tag.startswith("v") or len(tag) == 1:
+        raise BuilderValidationError(f"Release tag must start with v: {tag!r}")
+    version = tag[1:]
+    if Path(version).name != version or "\\" in version or version in {".", ".."}:
+        raise BuilderValidationError(f"Release tag has an unsafe version component: {tag!r}")
+    return version
+
+
+def git_stdout(git: str, source_root: Path, args: list[str], *, action: str) -> str:
+    try:
+        result = run_command([git, "-C", str(source_root), *args])
+    except OSError as exc:
+        raise BuilderValidationError(f"Failed to run git while {action}: {exc}") from exc
+    if result.returncode != 0:
+        detail = one_line_error(Exception(result.stderr or result.stdout))
+        suffix = f": {detail}" if detail else ""
+        raise BuilderValidationError(f"Failed to {action}{suffix}")
+    return result.stdout.strip()
+
+
+def reconstruct_canonical_source_archive(
+    *,
+    git: str,
+    source_root: Path,
+    tag: str,
+    expected_tag_target: str,
+) -> CanonicalSourceArchive:
+    version = release_version(tag)
+    if not source_root.is_dir():
+        raise BuilderValidationError(f"Source root is not a directory: {source_root}")
+    if not COMMIT_SHA_RE.fullmatch(expected_tag_target):
+        raise BuilderValidationError(
+            "--expected-tag-target must be a full 40-character commit SHA"
+        )
+    expected_target = expected_tag_target.lower()
+    tag_ref = f"refs/tags/{tag}"
+
+    object_type = git_stdout(
+        git,
+        source_root,
+        ["cat-file", "-t", tag_ref],
+        action=f"resolve annotated release tag {tag}",
+    )
+    if object_type != "tag":
+        raise BuilderValidationError(
+            f"Release tag {tag} must be an annotated tag object, got {object_type!r}"
+        )
+
+    tag_payload = git_stdout(
+        git,
+        source_root,
+        ["cat-file", "-p", tag_ref],
+        action=f"inspect annotated release tag {tag}",
+    )
+    tag_headers = tag_payload.split("\n\n", 1)[0].splitlines()
+    if (
+        len(tag_headers) < 2
+        or not tag_headers[0].startswith("object ")
+        or not tag_headers[1].startswith("type ")
+    ):
+        raise BuilderValidationError(f"Release tag {tag} has malformed object headers")
+    direct_target = tag_headers[0].removeprefix("object ").lower()
+    direct_target_type = tag_headers[1].removeprefix("type ")
+    if direct_target_type != "commit":
+        raise BuilderValidationError(
+            f"Release tag {tag} must directly target a commit, got {direct_target_type!r}"
+        )
+    if direct_target != expected_target:
+        raise BuilderValidationError(
+            f"Release tag {tag} directly targets {direct_target}, not verified target "
+            f"{expected_target}"
+        )
+
+    resolved_target = git_stdout(
+        git,
+        source_root,
+        ["rev-parse", "--verify", f"{tag_ref}^{{commit}}"],
+        action=f"resolve release tag target for {tag}",
+    ).lower()
+    if not COMMIT_SHA_RE.fullmatch(resolved_target):
+        raise BuilderValidationError(
+            f"Release tag {tag} resolved to an invalid commit SHA: {resolved_target!r}"
+        )
+    if resolved_target != expected_target:
+        raise BuilderValidationError(
+            f"Release tag {tag} target {resolved_target} does not match "
+            f"verified target {expected_target}"
+        )
+
+    target_type = git_stdout(
+        git,
+        source_root,
+        ["cat-file", "-t", expected_target],
+        action=f"verify release tag target {expected_target}",
+    )
+    if target_type != "commit":
+        raise BuilderValidationError(
+            f"Release tag {tag} target must be a commit, got {target_type!r}"
+        )
+
+    archive_name = f"qbit-{version}.tar.gz"
+    with tempfile.TemporaryDirectory(prefix="qbit-source-archive-") as temp_dir:
+        archive_path = Path(temp_dir) / archive_name
+        git_stdout(
+            git,
+            source_root,
+            [
+                "archive",
+                f"--prefix=qbit-{version}/",
+                f"--output={archive_path}",
+                expected_target,
+            ],
+            action=f"reconstruct canonical source archive for {tag}",
+        )
+        try:
+            archive_sha256 = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+        except OSError as exc:
+            raise BuilderValidationError(
+                f"Failed to hash canonical source archive {archive_name}: {exc}"
+            ) from exc
+
+    return CanonicalSourceArchive(
+        name=archive_name,
+        sha256=archive_sha256,
+        tag_target=expected_target,
+    )
+
+
 def status_fingerprints(status_output: str) -> list[str]:
     fingerprints: list[str] = []
     for line in status_output.splitlines():
@@ -465,12 +602,29 @@ def find_builder_manifest(builder_dir: Path, artifact: str) -> Path | None:
     return None
 
 
-def manifest_covers_release_entries(manifest: Path, expected_entries: dict[str, str]) -> bool:
+def require_manifest_coverage(
+    manifest: Path,
+    release_entries: dict[str, str],
+    source_archive: CanonicalSourceArchive,
+) -> None:
     manifest_entries = parse_sha256sums(manifest)
-    for name, digest in expected_entries.items():
-        if manifest_entries.get(name) != digest:
-            return False
-    return True
+    source_digest = manifest_entries.get(source_archive.name)
+    if source_digest is None:
+        raise BuilderValidationError(
+            f"manifest is missing canonical source archive {source_archive.name}"
+        )
+    if source_digest != source_archive.sha256:
+        raise BuilderValidationError(
+            f"manifest source archive {source_archive.name} has digest {source_digest}, "
+            f"expected {source_archive.sha256} from signed tag target"
+        )
+    for name, digest in release_entries.items():
+        actual = manifest_entries.get(name)
+        if actual != digest:
+            raise BuilderValidationError(
+                f"manifest does not cover staged artifact {name}: "
+                f"got {actual or 'missing'}, expected {digest}"
+            )
 
 
 def one_line_error(error: Exception) -> str:
@@ -485,6 +639,7 @@ def validate_artifact_attestations(
     version: str,
     artifact: str,
     release_entries: dict[str, str],
+    source_archive: CanonicalSourceArchive,
     builders: dict[str, BuilderOperator],
     quorum: int,
 ) -> list[str]:
@@ -505,9 +660,7 @@ def validate_artifact_attestations(
             continue
         try:
             verify_manifest_signature(gpg, gnupg_home, manifest, builder.fingerprint)
-            if not manifest_covers_release_entries(manifest, release_entries):
-                rejected.append(f"{alias}: manifest does not cover staged {artifact} artifacts")
-                continue
+            require_manifest_coverage(manifest, release_entries, source_archive)
             counted.append(alias)
         except BuilderValidationError as exc:
             rejected.append(f"{alias}: {one_line_error(exc)}")
@@ -528,6 +681,8 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--artifacts-dir", required=True, type=Path)
     parser.add_argument("--tag", required=True)
+    parser.add_argument("--source-root", required=True, type=Path)
+    parser.add_argument("--expected-tag-target", required=True)
     parser.add_argument("--release-line", required=True, choices=("testnet", "mainnet"))
     parser.add_argument("--guix-sigs-repo", required=True, type=Path)
     parser.add_argument("--operator-key-policy", default=DEFAULT_OPERATOR_POLICY, type=Path)
@@ -535,6 +690,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--guix-operator-key-policy", type=Path)
     parser.add_argument("--guix-operator-keys-dir", type=Path)
     parser.add_argument("--gpg", default=shutil.which("gpg") or "gpg")
+    parser.add_argument("--git", default=shutil.which("git") or "git")
     parser.add_argument("--artifact", choices=("core", "photon"), action="append")
     parser.add_argument("--github-output", type=Path)
     return parser.parse_args()
@@ -554,6 +710,12 @@ def main() -> int:
         artifacts_dir = args.artifacts_dir.resolve()
         guix_sigs_repo = args.guix_sigs_repo.resolve()
         operator_keys_dir = args.operator_keys_dir.resolve()
+        source_archive = reconstruct_canonical_source_archive(
+            git=args.git,
+            source_root=args.source_root.resolve(),
+            tag=args.tag,
+            expected_tag_target=args.expected_tag_target,
+        )
         policy = load_builder_policy(
             args.operator_key_policy.resolve(),
             operator_keys_dir,
@@ -568,7 +730,7 @@ def main() -> int:
             args.release_line,
         )
         quorum = policy.builder_attestation_quorum
-        version = args.tag.removeprefix("v")
+        version = release_version(args.tag)
         artifacts = args.artifact or detected_artifacts(artifacts_dir, args.tag)
 
         with tempfile.TemporaryDirectory(prefix="qbit-operator-gnupg-") as gnupg_home:
@@ -584,6 +746,7 @@ def main() -> int:
                     version=version,
                     artifact=artifact,
                     release_entries=expected_release_entries(artifacts_dir, args.tag, artifact),
+                    source_archive=source_archive,
                     builders=builders,
                     quorum=quorum,
                 )
@@ -592,12 +755,19 @@ def main() -> int:
         if args.github_output:
             with args.github_output.open("a", encoding="utf8") as output:
                 output.write(f"builder_attestation_quorum={quorum}\n")
+                output.write(f"builder_attestation_source_archive={source_archive.name}\n")
+                output.write(f"builder_attestation_source_sha256={source_archive.sha256}\n")
+                output.write(f"builder_attestation_tag_target={source_archive.tag_target}\n")
                 for artifact, counted in sorted(counts.items()):
                     output.write(f"builder_attestation_{artifact}_count={len(counted)}\n")
                     output.write(f"builder_attestation_{artifact}_aliases={','.join(counted)}\n")
 
         summary = ", ".join(f"{artifact}:{len(counted)}/{quorum}" for artifact, counted in sorted(counts.items()))
-        print(f"Validated builder attestations: {summary}")
+        print(
+            f"Validated builder attestations: {summary}; "
+            f"source={source_archive.name}:{source_archive.sha256}; "
+            f"tag_target={source_archive.tag_target}"
+        )
         return 0
     except BuilderValidationError as exc:
         print(f"ERR: {exc}", file=sys.stderr)

--- a/contrib/guix/repo-templates/qbit-guix.sigs/README.md
+++ b/contrib/guix/repo-templates/qbit-guix.sigs/README.md
@@ -42,7 +42,15 @@ the corresponding Guix helper is run with `ARTIFACT=...`.
    before release publication.
 5. The release coordinator runs
    `ci/release/validate_builder_attestations.py` from the qbit source checkout
-   before publishing GitHub Release assets.
+   before publishing GitHub Release assets, passing the public release checkout
+   as `--source-root` and the verified annotated-tag target as
+   `--expected-tag-target`.
+
+Every counted core and PHOTON manifest must contain the common
+`qbit-<version>.tar.gz` entry. The validator reconstructs that archive from the
+signed-tag target with the same Guix `git archive` prefix and requires its exact
+basename and SHA256 before counting the manifest toward quorum. The source
+archive remains attestation evidence and is not a staged GitHub Release asset.
 
 The release signer key that signs `SHA256SUMS.operator-XX.asc` for GitHub
 release artifacts can also sign that operator's Guix attestations when the

--- a/doc/release/guix.md
+++ b/doc/release/guix.md
@@ -5,3 +5,36 @@ builds and checked against builder attestations before publication.
 
 Public release evidence pins the exact `qbit-guix.sigs` commit used for
 attestation validation.
+
+## Source archive binding
+
+Core and PHOTON Guix builds both create `qbit-<version>.tar.gz` from the build
+checkout with:
+
+```sh
+git archive --prefix="qbit-<version>/" --output="qbit-<version>.tar.gz" HEAD
+```
+
+The archive is included in every generated builder manifest even though it is
+not uploaded as a public release artifact. Before counting a signed manifest,
+`ci/release/validate_builder_attestations.py` independently reconstructs the
+archive from the verified annotated-tag target and requires the exact basename
+and SHA256 in that manifest.
+
+Release coordinators must provide both the source repository and the verified
+tag target:
+
+```sh
+python3 ci/release/validate_builder_attestations.py \
+  --artifacts-dir /path/to/staged-release \
+  --tag "${TAG}" \
+  --source-root /path/to/public-qbit-checkout \
+  --expected-tag-target "${VERIFIED_TAG_TARGET}" \
+  --release-line "${RELEASE_LINE}" \
+  --guix-sigs-repo /path/to/qbit-guix.sigs
+```
+
+The validator requires an annotated local tag, confirms that it resolves to
+the supplied commit, reconstructs the archive from that commit rather than the
+worktree or `trusted_release_ref`, and reports the canonical source digest for
+release evidence.

--- a/doc/release/release-process.md
+++ b/doc/release/release-process.md
@@ -27,6 +27,12 @@ The tag target commit is the source commit used for release builds. Do not use a
 private source commit, a sanitizer mapping, a branch name, a short SHA, or a tag
 object SHA as the release source.
 
+The release validator recreates `qbit-<version>.tar.gz` directly from that tag
+target with the same `git archive --prefix="qbit-<version>/"` semantics used by
+the Guix build. Every counted core and PHOTON builder manifest must contain the
+resulting basename and SHA256. The source archive is builder evidence and is not
+part of the staged GitHub Release upload set.
+
 ## Trusted Validation Ref
 
 `trusted_release_ref` is the reviewed public commit used for release validation
@@ -58,12 +64,19 @@ The workflow validates:
   tag target commit
 - staged artifacts match `SHA256SUMS`
 - `SHA256SUMS.asc` meets release-signature quorum
-- `qbit-guix.sigs` builder attestations meet builder quorum
+- `qbit-guix.sigs` builder attestations meet builder quorum and every counted
+  manifest is bound to the source archive reconstructed from the signed tag
+  target
 - testnet posture evidence passes when `release_line=testnet`
 
 Testnet posture evidence is mandatory for `release_line=testnet`: both the
 publish workflow and the local publish fallback require the
 `TESTNET_RELEASE_POSTURE_EVIDENCE` input and fail closed when it is missing.
+
+Any local publication path must run the builder validator with the public
+release checkout as `--source-root` and the commit target obtained from the
+verified annotated tag as `--expected-tag-target`. These inputs are required;
+an older local caller that omits them fails before builder quorum is evaluated.
 
 Public validators live under `ci/release/`. Release key metadata lives under
 `contrib/keys/operator-keys/`.
@@ -79,6 +92,7 @@ Normal public release evidence should pin public data:
 - exact-byte `keys.json` SHA256, `policy_id`, and `policy_sequence`
 - exact public `qbit-guix.sigs` commit used for final validation
 - counted builder aliases/fingerprints and artifact sets
+- canonical source archive basename, SHA256, and signed-tag target commit
 - counted release signer aliases/fingerprints
 - artifact manifest digest, combined signature digest, individual operator
   signature digests, and artifact count


### PR DESCRIPTION
## Summary

- reconstruct the canonical `qbit-<version>.tar.gz` archive from the verified annotated-tag target before evaluating builder quorum
- require that exact source basename and SHA256 in every counted core and PHOTON manifest
- pass the verified tag target and public source checkout through the release workflow and record the source binding in release evidence
- add fail-closed coverage for missing, renamed, wrong-digest, wrong-source, lightweight, indirect, and mismatched tag cases
- document the workflow and local-publication requirements

Fixes #76.

## Testing

- [ ] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [x] Not run. Reason: A qbit binary build was not run because this changes Python release validation, workflow configuration, tests, and documentation only.

Commands and checks:

- `python3 -m unittest ci.release.test_validate_builder_attestations ci.release.test_validate_key_metadata ci.release.test_validate_release_artifacts ci.release.test_verify_testnet_release_posture` — 131 tests passed, with one expected skip for the absent public local-publish helper
- `python3 contrib/guix/test_build_config.py`
- full lint suite using `ci/lint_imagefile` in Docker
- targeted Docker `py_lint`
- Python bytecode compilation, workflow YAML parsing, and `git diff --check`
- no-publish validation against `v0.1.2-testnet4` and `qbit-guix.sigs@0ee0190073bedf4cf6d3ef60b7531a3551966f26`: core 2/2, PHOTON 2/2, source SHA256 `a0a596f778f1add8175f40931d274e50857928d4bff09b9ee4f69ef2231b19da`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- This deliberately makes `--source-root` and `--expected-tag-target` required. Existing local publication callers fail closed until they provide the same verified source context as the workflow.
- Validator code still comes from `trusted_release_ref`; archive bytes come only from the verified release-tag target.
- The source archive remains builder-attestation evidence and is not added to the staged GitHub Release upload set.
- Invalid manifests are rejected individually, preserving existing quorum behavior when enough other valid builders remain.

## Docs / Process Impact

Choose exactly one:

- [x] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [ ] No public docs update needed. Reason:

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; the subtree was not changed.

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786296679&installation_id=141183937&pr_number=84&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F84&signature=4064609d8c97032141cabf9b982b4c9384bb4fdbab5e0b287bbeb5d815816b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes release publication trust: builder quorum and workflow tag verification are security-critical; missing `--source-root`/`--expected-tag-target` fails closed for local callers.
> 
> **Overview**
> Builder attestation quorum now depends on **canonical source binding**, not only staged binary manifests.
> 
> `validate_builder_attestations.py` requires `--source-root` and `--expected-tag-target`, reconstructs `qbit-<version>.tar.gz` from the verified annotated tag’s commit (Guix-style `git archive`), and rejects manifests that omit, rename, or mismatch that archive’s SHA256. Tag handling is stricter: annotated tags must point **directly** at a commit (no lightweight or chained tags).
> 
> The **release-publish** workflow adds a post-checkout step to restore and locally verify the GitHub-verified tag object and target, passes the workspace and `target_commitish` into the builder validator, and records source archive name, digest, and tag target in the job summary.
> 
> Tests cover quorum behavior, GitHub outputs, and fail-closed tag/source edge cases; release and Guix docs describe the new required inputs and evidence fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2398638f017a44582c093d90efa2bd5b848f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->