### PR TITLE
Bind Qt P2MR proof verification to an expected signer

### DIFF
--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -316,6 +316,38 @@
           <number>0</number>
          </property>
          <item>
+          <widget class="QLabel" name="expectedSignerLabel_VM">
+           <property name="visible">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>&amp;Expected signer (optional):</string>
+           </property>
+           <property name="textFormat">
+            <enum>Qt::PlainText</enum>
+           </property>
+           <property name="buddy">
+            <cstring>addressIn_VM</cstring>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="expectedSignerSpacer_VM">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>8</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
           <widget class="QValidatedLineEdit" name="addressIn_VM">
            <property name="toolTip">
             <string>The qbit address the message was signed with</string>

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -196,6 +196,28 @@ bool ParseP2MRProofJson(const QString& proof_json, common::P2MRDataSignatureProo
     return true;
 }
 
+bool ParseExpectedP2MRSigner(const QString& address_text, std::optional<WitnessV2P2MR>& expected_signer, QString& error)
+{
+    expected_signer.reset();
+    const QString trimmed_address{address_text.trimmed()};
+    if (trimmed_address.isEmpty()) return true;
+
+    const CTxDestination destination{DecodeDestination(trimmed_address.toStdString())};
+    if (!IsValidDestination(destination)) {
+        error = SignVerifyMessageDialog::tr("The expected signer address is invalid for the active network.");
+        return false;
+    }
+
+    const auto* output{std::get_if<WitnessV2P2MR>(&destination)};
+    if (!output) {
+        error = SignVerifyMessageDialog::tr("The expected signer address is not a P2MR address.");
+        return false;
+    }
+
+    expected_signer = *output;
+    return true;
+}
+
 void AppendPQCUsageJson(UniValue& object, const wallet::PQCUsageReport& report)
 {
     if (report.key_states.empty()) return;
@@ -377,11 +399,15 @@ void SignVerifyMessageDialog::updateP2MRDataModeUi()
         ui->p2mrMessageHashLabel_SM->setVisible(true);
         ui->p2mrMessageHash_SM->setVisible(true);
 
-        ui->infoLabel_VM->setText(tr("Verify a P2MR/PQC data-signature proof JSON object. When original text or a 32-byte "
-                                     "hash is entered, it must match the proof's message_hash before the P2MR commitment "
-                                     "and PQC signature are verified."));
-        ui->addressIn_VM->setVisible(false);
-        ui->addressBookButton_VM->setVisible(false);
+        ui->infoLabel_VM->setText(tr("Enter an expected signer address from a trusted source to authenticate a P2MR/PQC "
+                                     "proof. Entered text or a 32-byte hash must also match the proof's message_hash. "
+                                     "Without an expected signer, or in proof-only mode, verification reports only "
+                                     "cryptographic validity with a neutral result."));
+        ui->expectedSignerLabel_VM->setVisible(true);
+        ui->addressIn_VM->setVisible(true);
+        ui->addressIn_VM->setToolTip(tr("The expected P2MR signer address from a trusted source; leave blank for neutral proof validation"));
+        ui->addressBookButton_VM->setVisible(true);
+        ui->addressBookButton_VM->setToolTip(tr("Choose an expected signer address"));
         ui->signatureIn_VM->setVisible(false);
         ui->messageIn_VM->setToolTip(tr("Paste proof JSON to verify"));
         ui->messageIn_VM->setPlaceholderText(tr("Paste proof JSON to verify"));
@@ -421,8 +447,11 @@ void SignVerifyMessageDialog::updateP2MRDataModeUi()
                                      "the signature than what is in the signed message itself, to avoid being tricked by a "
                                      "man-in-the-middle attack. Note that this only proves the signing party receives with "
                                      "the address, it cannot prove sendership of any transaction!"));
+        ui->expectedSignerLabel_VM->setVisible(false);
         ui->addressIn_VM->setVisible(true);
+        ui->addressIn_VM->setToolTip(tr("The qbit address the message was signed with"));
         ui->addressBookButton_VM->setVisible(true);
+        ui->addressBookButton_VM->setToolTip(tr("Choose previously used address"));
         ui->signatureIn_VM->setVisible(true);
         ui->messageIn_VM->setToolTip(tr("The signed message to verify"));
         ui->messageIn_VM->setPlaceholderText(tr("The signed message to verify"));
@@ -724,11 +753,41 @@ void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
 void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
 {
     if (isP2MRDataMode()) {
+        const auto set_error = [this](const QString& text) {
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
+            ui->statusLabel_VM->setText(text);
+        };
+        const auto set_neutral = [this](const QString& text) {
+            ui->statusLabel_VM->setStyleSheet("");
+            ui->statusLabel_VM->setText(text);
+        };
+        const auto set_authenticated = [this](const QString& text) {
+            ui->statusLabel_VM->setStyleSheet("QLabel { color: green; }");
+            ui->statusLabel_VM->setText(text);
+        };
+
         common::P2MRDataSignatureProof proof;
         QString parse_error;
         if (!ParseP2MRProofJson(ui->messageIn_VM->document()->toPlainText(), proof, parse_error)) {
-            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
-            ui->statusLabel_VM->setText(parse_error);
+            set_error(parse_error);
+            return;
+        }
+
+        const QString embedded_signer{QString::fromStdString(EncodeDestination(CTxDestination{proof.output}))};
+        const QString signed_message_hash{QString::fromStdString(HashToHexString(proof.message_hash))};
+        const auto proof_context = [&] {
+            return QStringList{
+                tr("Proof-supplied signer: %1.").arg(embedded_signer),
+                tr("Signed message hash: %1.").arg(signed_message_hash),
+            };
+        };
+
+        std::optional<WitnessV2P2MR> expected_signer;
+        if (!ParseExpectedP2MRSigner(ui->addressIn_VM->text(), expected_signer, parse_error)) {
+            ui->addressIn_VM->setValid(false);
+            QStringList status{parse_error};
+            status.append(proof_context());
+            set_error(status.join("\n"));
             return;
         }
 
@@ -737,8 +796,9 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
         if (verify_mode == P2MR_VERIFY_INPUT_HASH) {
             uint256 parsed_hash;
             if (!ParseDataHash(ui->p2mrDataIn_VM->document()->toPlainText(), parsed_hash, parse_error)) {
-                ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
-                ui->statusLabel_VM->setText(parse_error);
+                QStringList status{parse_error};
+                status.append(proof_context());
+                set_error(status.join("\n"));
                 return;
             }
             expected_message_hash = parsed_hash;
@@ -746,30 +806,58 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
             expected_message_hash = HashP2MRUtf8Text(ui->p2mrDataIn_VM->document()->toPlainText());
         }
 
+        if (expected_signer.has_value() && *expected_signer != proof.output) {
+            const QString expected_address{QString::fromStdString(EncodeDestination(CTxDestination{*expected_signer}))};
+            QStringList status{
+                tr("The proof contains signer %1, but the expected signer is %2.").arg(embedded_signer, expected_address),
+                tr("Signed message hash: %1.").arg(signed_message_hash),
+            };
+            set_error(status.join("\n"));
+            return;
+        }
+
         if (expected_message_hash.has_value() && *expected_message_hash != proof.message_hash) {
-            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
-            ui->statusLabel_VM->setText(
-                tr("Entered data hashes to %1, but the proof signed %2.")
-                    .arg(QString::fromStdString(HashToHexString(*expected_message_hash)))
-                    .arg(QString::fromStdString(HashToHexString(proof.message_hash)))
-            );
+            QStringList status{
+                tr("Entered data hashes to %1, but the proof contains message hash %2.")
+                    .arg(QString::fromStdString(HashToHexString(*expected_message_hash)), signed_message_hash),
+                tr("Proof-supplied signer: %1.").arg(embedded_signer),
+            };
+            set_error(status.join("\n"));
             return;
         }
 
         const common::P2MRDataSignatureVerification result{common::VerifyP2MRDataSignatureProof(proof)};
         if (result.valid) {
-            ui->statusLabel_VM->setStyleSheet("QLabel { color: green; }");
-            QString status{tr("P2MR/PQC proof verified for %1.")
-                .arg(QString::fromStdString(EncodeDestination(CTxDestination{proof.output})))};
-            if (expected_message_hash.has_value()) {
-                status.append("\n");
-                status.append(tr("Entered data matches message hash %1.")
-                    .arg(QString::fromStdString(HashToHexString(*expected_message_hash))));
+            const bool identity_bound{expected_signer.has_value()};
+            const bool data_bound{expected_message_hash.has_value()};
+            QStringList status{
+                identity_bound && data_bound ?
+                    tr("P2MR/PQC proof authenticated for the expected signer.") :
+                    tr("P2MR/PQC proof is cryptographically valid."),
+                tr("Embedded signer: %1.").arg(embedded_signer),
+                tr("Signed message hash: %1.").arg(signed_message_hash),
+            };
+            if (identity_bound) {
+                status.append(tr("Expected signer matches the embedded signer."));
+            } else {
+                status.append(tr("No expected signer was provided; signer identity was not independently authenticated."));
             }
-            ui->statusLabel_VM->setText(status);
+            if (expected_message_hash.has_value()) {
+                status.append(tr("Entered data matches the signed message hash."));
+            } else {
+                status.append(tr("Proof-only mode did not independently bind the signed data."));
+            }
+            if (identity_bound && data_bound) {
+                set_authenticated(status.join("\n"));
+            } else {
+                set_neutral(status.join("\n"));
+            }
         } else {
-            ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
-            ui->statusLabel_VM->setText(tr("P2MR/PQC proof verification failed: %1").arg(ToQString(result.error)));
+            QStringList status{
+                tr("P2MR/PQC proof verification failed: %1").arg(ToQString(result.error)),
+            };
+            status.append(proof_context());
+            set_error(status.join("\n"));
         }
         return;
     }
@@ -831,12 +919,9 @@ void SignVerifyMessageDialog::on_clearButton_VM_clicked()
     ui->messageIn_VM->clear();
     ui->p2mrDataIn_VM->clear();
     ui->statusLabel_VM->clear();
+    ui->statusLabel_VM->setStyleSheet("");
 
-    if (isP2MRDataMode()) {
-        ui->messageIn_VM->setFocus();
-    } else {
-        ui->addressIn_VM->setFocus();
-    }
+    ui->addressIn_VM->setFocus();
 }
 
 bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
@@ -859,6 +944,7 @@ bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
         {
             /* Clear status message on focus change */
             ui->statusLabel_VM->clear();
+            ui->statusLabel_VM->setStyleSheet("");
         }
     }
     return QDialog::eventFilter(object, event);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -662,6 +662,15 @@ void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
     SendCoinsDialog& sendCoinsDialog = mini_gui.sendCoinsDialog;
     TransactionView& transactionView = mini_gui.transactionView;
 
+    SignVerifyMessageDialog legacy_sign_verify_dialog(platformStyle.get(), nullptr);
+    legacy_sign_verify_dialog.setModel(&walletModel);
+    QLabel* expected_signer_label = legacy_sign_verify_dialog.findChild<QLabel*>("expectedSignerLabel_VM");
+    QVERIFY(expected_signer_label);
+    QVERIFY(expected_signer_label->isHidden());
+    QValidatedLineEdit* legacy_verify_address = legacy_sign_verify_dialog.findChild<QValidatedLineEdit*>("addressIn_VM");
+    QVERIFY(legacy_verify_address);
+    QVERIFY(!legacy_verify_address->isHidden());
+
     // Update walletModel cached balance which will trigger an update for the 'labelBalance' QLabel.
     walletModel.pollBalanceChanged();
     // Check balance in send dialog
@@ -789,6 +798,7 @@ void TestGUIWatchOnly(interfaces::Node& node, TestChain100Setup& test)
     std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
     MiniGUI mini_gui(node, platformStyle.get());
     mini_gui.initModelForWallet(node, wallet, platformStyle.get());
+
     WalletModel& walletModel = *mini_gui.walletModel;
     SendCoinsDialog& sendCoinsDialog = mini_gui.sendCoinsDialog;
 
@@ -828,6 +838,13 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     MiniGUI mini_gui(node, platformStyle.get());
     mini_gui.initModelForWallet(node, wallet, platformStyle.get());
 
+    QVERIFY(wallet->TopUpKeyPool(2));
+    const CTxDestination expected_signer_dest{*Assert(wallet->GetNewDestination(OutputType::P2MR, ""))};
+    const CTxDestination proof_signer_dest{*Assert(wallet->GetNewDestination(OutputType::P2MR, ""))};
+    QVERIFY(expected_signer_dest != proof_signer_dest);
+    const QString expected_signer_address{QString::fromStdString(EncodeDestination(expected_signer_dest))};
+    const QString proof_signer_address{QString::fromStdString(EncodeDestination(proof_signer_dest))};
+
     ReceiveCoinsDialog receiveCoinsDialog(platformStyle.get());
     receiveCoinsDialog.setModel(mini_gui.walletModel.get());
     QComboBox* address_type = receiveCoinsDialog.findChild<QComboBox*>("addressType");
@@ -857,6 +874,9 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     QPlainTextEdit* sign_input = sign_verify_dialog.findChild<QPlainTextEdit*>("messageIn_SM");
     QVERIFY(sign_input);
     QVERIFY(sign_input->placeholderText().contains("UTF-8 text"));
+
+    QValidatedLineEdit* sign_address = sign_verify_dialog.findChild<QValidatedLineEdit*>("addressIn_SM");
+    QVERIFY(sign_address);
 
     QLineEdit* sign_hash_preview = sign_verify_dialog.findChild<QLineEdit*>("p2mrMessageHash_SM");
     QVERIFY(sign_hash_preview);
@@ -900,9 +920,17 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     QVERIFY(verify_data_input->isHidden());
     QVERIFY(verify_hash_preview->isHidden());
 
+    QLabel* expected_signer_label = sign_verify_dialog.findChild<QLabel*>("expectedSignerLabel_VM");
+    QVERIFY(expected_signer_label);
+    QVERIFY(!expected_signer_label->isHidden());
+
     QValidatedLineEdit* verify_address = sign_verify_dialog.findChild<QValidatedLineEdit*>("addressIn_VM");
     QVERIFY(verify_address);
-    QVERIFY(verify_address->isHidden());
+    QVERIFY(!verify_address->isHidden());
+
+    QPushButton* verify_address_book = sign_verify_dialog.findChild<QPushButton*>("addressBookButton_VM");
+    QVERIFY(verify_address_book);
+    QVERIFY(!verify_address_book->isHidden());
 
     QValidatedLineEdit* verify_signature = sign_verify_dialog.findChild<QValidatedLineEdit*>("signatureIn_VM");
     QVERIFY(verify_signature);
@@ -913,6 +941,84 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     QCOMPARE(verify_button->text(), QString("Verify &Proof"));
 
     TestP2MRProofLeafVersionValidation(sign_verify_dialog);
+
+    QLabel* verify_status = sign_verify_dialog.findChild<QLabel*>("statusLabel_VM");
+    QVERIFY(verify_status);
+
+    sign_input_mode->setCurrentIndex(0);
+    sign_address->setText(proof_signer_address);
+    const QString signed_text{"expected signer binding test"};
+    sign_input->setPlainText(signed_text);
+    const QString signed_message_hash{sign_hash_preview->text()};
+    sign_button->click();
+    const QString proof_json{proof_output->toPlainText()};
+    QVERIFY(!proof_json.isEmpty());
+
+    sign_verify_dialog.showTab_VM(/*fShow=*/false);
+    proof_input->setPlainText(proof_json);
+
+    const auto verify = [&](const QString& expected_address, int input_mode, const QString& data) {
+        verify_address->setText(expected_address);
+        verify_input_mode->setCurrentIndex(input_mode);
+        verify_data_input->setPlainText(data);
+        proof_input->setPlainText(proof_json);
+        verify_button->click();
+    };
+
+    verify(proof_signer_address, /*input_mode=*/0, signed_text);
+    QVERIFY(verify_status->styleSheet().contains("green"));
+    QVERIFY(verify_status->text().contains("authenticated for the expected signer"));
+    QVERIFY(verify_status->text().contains(proof_signer_address));
+    QVERIFY(verify_status->text().contains(signed_message_hash));
+
+    verify(expected_signer_address, /*input_mode=*/0, signed_text);
+    QVERIFY(verify_status->styleSheet().contains("red"));
+    QVERIFY(verify_status->text().contains(expected_signer_address));
+    QVERIFY(verify_status->text().contains(proof_signer_address));
+    QVERIFY(verify_address->isValid());
+
+    const QString wrong_text{"different text"};
+    verify(proof_signer_address, /*input_mode=*/0, wrong_text);
+    const QString wrong_message_hash{verify_hash_preview->text()};
+    QVERIFY(verify_status->styleSheet().contains("red"));
+    QVERIFY(verify_status->text().contains(wrong_message_hash));
+    QVERIFY(verify_status->text().contains(signed_message_hash));
+
+    const QString wrong_network_address{"qb1zt39mp8jjcqd7pyh7qgz93gmhh2qlqppq8c3j4qy02chzfzp8c7sqkcq5ga"};
+    verify(wrong_network_address, /*input_mode=*/0, signed_text);
+    QVERIFY(verify_status->styleSheet().contains("red"));
+    QVERIFY(verify_status->text().contains("invalid for the active network"));
+    QVERIFY(!verify_address->isValid());
+    QVERIFY(verify_status->text().contains(proof_signer_address));
+    QVERIFY(verify_status->text().contains(signed_message_hash));
+
+    verify(/*expected_address=*/{}, /*input_mode=*/0, signed_text);
+    QVERIFY(verify_status->styleSheet().isEmpty());
+    QVERIFY(verify_status->text().contains("cryptographically valid"));
+    QVERIFY(verify_status->text().contains("No expected signer was provided"));
+    QVERIFY(verify_status->text().contains(proof_signer_address));
+    QVERIFY(verify_status->text().contains(signed_message_hash));
+
+    verify(/*expected_address=*/{}, /*input_mode=*/2, /*data=*/{});
+    QVERIFY(verify_status->styleSheet().isEmpty());
+    QVERIFY(verify_status->text().contains("No expected signer was provided"));
+    QVERIFY(verify_status->text().contains("Proof-only mode"));
+    QVERIFY(verify_status->text().contains(proof_signer_address));
+    QVERIFY(verify_status->text().contains(signed_message_hash));
+
+    verify(proof_signer_address, /*input_mode=*/2, /*data=*/{});
+    QVERIFY(verify_status->styleSheet().isEmpty());
+    QVERIFY(verify_status->text().contains("Expected signer matches"));
+    QVERIFY(verify_status->text().contains("Proof-only mode"));
+
+    QPushButton* verify_clear = sign_verify_dialog.findChild<QPushButton*>("clearButton_VM");
+    QVERIFY(verify_clear);
+    verify_clear->click();
+    QVERIFY(verify_address->text().isEmpty());
+    QVERIFY(proof_input->toPlainText().isEmpty());
+    QVERIFY(verify_data_input->toPlainText().isEmpty());
+    QVERIFY(verify_status->text().isEmpty());
+    QVERIFY(verify_status->styleSheet().isEmpty());
 }
 
 void TestSendPQCReportPropagation(interfaces::Node& node)


### PR DESCRIPTION
## Summary

- show an optional expected-signer address in qbit-qt P2MR proof verification
- validate the expected signer for the active network and require its P2MR output to match the proof before showing authenticated success
- reserve green success for proofs with both independent signer and text/hash binding, while rendering missing-signer and proof-only validation neutrally
- add wallet-backed Qt coverage for correct, substituted, wrong-network, wrong-text, missing-signer, and proof-only flows

Fixes #77.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Checks run:

- `cmake --preset dev-mode -DWITH_USDT=OFF -DENABLE_IPC=OFF`
- `cmake --build build_dev_mode --target bitcoin-qt test_bitcoin-qt test_bitcoin -j 8`
- `ulimit -n 1024; QT_QPA_PLATFORM=offscreen QTEST_FUNCTION_TIMEOUT=600000 build_dev_mode/bin/test_qbit-qt`
- `build_dev_mode/bin/test_qbit --run_test=p2mr_datapqchash_tests --catch_system_errors=no --log_level=test_suite`
- Docker lint image from `ci/lint_imagefile`, running its default lint entrypoint
- `git diff --check`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- This changes security-sensitive Qt presentation and expected-identity binding only.
- The shared P2MR proof verifier, proof JSON schema, wallet signing interface, RPC behavior, and consensus behavior are unchanged.
- Legacy P2PKH message signing and verification remain unchanged.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: the expected-signer field, explanatory copy, and result messages describe the Qt behavior directly; no RPC or integration contract changes.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786296748&installation_id=141183937&pr_number=85&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F85&signature=3058c023b0fb07b62f84f538b881e286fa21de5be5b5d247836b9c487a14944c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-sensitive Qt UX for identity binding around P2MR proofs; core verification logic is unchanged but users may misread neutral vs authenticated results if copy is misunderstood.
> 
> **Overview**
> P2MR **Verify Proof** in qbit-qt now exposes an optional **expected signer** P2MR address (with label and address book) instead of hiding the verify address field. **`ParseExpectedP2MRSigner`** validates that address for the active network before verification compares it to the signer embedded in the proof.
> 
> Verification flow distinguishes **authenticated** success (green) when both an expected signer and entered text/hash match the proof from **neutral** outcomes when only cryptographic validity is checked (no expected signer and/or proof-only mode). Errors and successes include clearer context (embedded signer, message hash, mismatch reasons). Legacy P2PKH verify UI is unchanged; P2MR copy and clear/status styling were updated accordingly.
> 
> Wallet Qt tests cover matching signer, signer substitution, wrong data hash, wrong network, missing signer, and proof-only paths, plus a legacy-mode check that the expected-signer label stays hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cebbf4061f85f40d0b5bacc5bab420a1cbfccf9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->