### PR TITLE
qt: avoid wallet shutdown deadlock during model adoption

### DIFF
--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -32,6 +32,7 @@ if(ENABLE_WALLET)
   target_sources(test_bitcoin-qt
     PRIVATE
       addressbooktests.cpp
+      walletcontrollertests.cpp
       wallettests.cpp
       ../../wallet/test/wallet_test_fixture.cpp
   )

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -19,6 +19,7 @@
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
+#include <qt/test/walletcontrollertests.h>
 #include <qt/test/wallettests.h>
 #endif // ENABLE_WALLET
 
@@ -101,6 +102,9 @@ int main(int argc, char* argv[])
 #ifdef ENABLE_WALLET
         WalletTests test5(app.node());
         num_test_failures += QTest::qExec(&test5);
+
+        WalletControllerTests wallet_controller_tests(app.node());
+        num_test_failures += QTest::qExec(&wallet_controller_tests);
 
         AddressBookTests test6(app.node());
         num_test_failures += QTest::qExec(&test6);

--- a/src/qt/test/walletcontrollertests.cpp
+++ b/src/qt/test/walletcontrollertests.cpp
@@ -1,0 +1,197 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/walletcontrollertests.h>
+
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <qt/clientmodel.h>
+#include <qt/optionsmodel.h>
+#include <qt/platformstyle.h>
+#include <qt/walletcontroller.h>
+#include <qt/walletmodel.h>
+#include <util/chaintype.h>
+#include <wallet/test/wallet_test_fixture.h>
+#include <wallet/wallet.h>
+
+#include <chrono>
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <QApplication>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QTest>
+#include <QThread>
+
+using namespace std::chrono_literals;
+using wallet::WALLET_FLAG_DESCRIPTORS;
+
+namespace {
+template <typename Predicate>
+bool WaitUntil(Predicate&& predicate, int timeout_ms = 5000)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < timeout_ms) {
+        if (predicate()) return true;
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        QTest::qWait(10);
+    }
+    return predicate();
+}
+
+bool WaitForNotificationWithoutEvents(std::future<void>& notification)
+{
+    const bool completed_without_events{notification.wait_for(5s) == std::future_status::ready};
+    if (!completed_without_events) {
+        // Let the vulnerable implementation service its blocking GUI call so a
+        // failed regression assertion does not strand the test process.
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+    }
+    notification.wait();
+    return completed_without_events;
+}
+
+util::Result<std::unique_ptr<interfaces::Wallet>> CreateTestWallet(interfaces::WalletLoader& loader, const std::string& name)
+{
+    std::vector<bilingual_str> warnings;
+    return loader.createWallet(name, SecureString{}, WALLET_FLAG_DESCRIPTORS, warnings);
+}
+} // namespace
+
+void WalletControllerTests::notificationDoesNotBlockGuiThread()
+{
+    wallet::WalletTestingSetup setup{ChainType::REGTEST};
+    setup.m_node.wallet_loader = setup.m_wallet_loader.get();
+    m_node.setContext(&setup.m_node);
+
+    auto wallet_result{CreateTestWallet(m_node.walletLoader(), "wallet-controller-notification")};
+    QVERIFY(wallet_result.has_value());
+    wallet::WalletContext& context{*m_node.walletLoader().context()};
+    const auto core_wallet{wallet::GetWallet(context, "wallet-controller-notification")};
+    QVERIFY(core_wallet);
+
+    OptionsModel options_model{m_node};
+    bilingual_str error;
+    QVERIFY(options_model.Init(error));
+    ClientModel client_model{m_node, &options_model};
+    const std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    auto controller{std::make_unique<WalletController>(client_model, platform_style.get(), nullptr)};
+
+    int added_count{0};
+    WalletModel* added_model{nullptr};
+    connect(controller.get(), &WalletController::walletAdded, controller.get(), [&](WalletModel* model) {
+        ++added_count;
+        added_model = model;
+    });
+
+    auto notification{std::async(std::launch::async, [&] {
+        wallet::NotifyWalletLoaded(context, core_wallet);
+    })};
+    const bool completed_without_events{WaitForNotificationWithoutEvents(notification)};
+    QVERIFY2(completed_without_events, "Wallet notification synchronously waited for the GUI thread");
+
+    QVERIFY(WaitUntil([&] { return added_count == 1; }));
+    QCOMPARE(added_count, 1);
+    QVERIFY(added_model);
+    QCOMPARE(added_model->thread(), qApp->thread());
+    QCOMPARE(added_model->parent(), controller.get());
+
+    auto duplicate_notification{std::async(std::launch::async, [&] {
+        wallet::NotifyWalletLoaded(context, core_wallet);
+    })};
+    QVERIFY(WaitForNotificationWithoutEvents(duplicate_notification));
+    QCoreApplication::processEvents();
+    QCOMPARE(added_count, 1);
+
+    controller.reset();
+    (*wallet_result)->remove();
+}
+
+void WalletControllerTests::shutdownDropsPendingAdoption()
+{
+    wallet::WalletTestingSetup setup{ChainType::REGTEST};
+    setup.m_node.wallet_loader = setup.m_wallet_loader.get();
+    m_node.setContext(&setup.m_node);
+
+    auto wallet_result{CreateTestWallet(m_node.walletLoader(), "wallet-controller-shutdown")};
+    QVERIFY(wallet_result.has_value());
+    wallet::WalletContext& context{*m_node.walletLoader().context()};
+    const auto core_wallet{wallet::GetWallet(context, "wallet-controller-shutdown")};
+    QVERIFY(core_wallet);
+
+    OptionsModel options_model{m_node};
+    bilingual_str error;
+    QVERIFY(options_model.Init(error));
+    ClientModel client_model{m_node, &options_model};
+    const std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    auto controller{std::make_unique<WalletController>(client_model, platform_style.get(), nullptr)};
+
+    int added_count{0};
+    connect(controller.get(), &WalletController::walletAdded, controller.get(), [&](WalletModel*) {
+        ++added_count;
+    });
+
+    auto notification{std::async(std::launch::async, [&] {
+        wallet::NotifyWalletLoaded(context, core_wallet);
+    })};
+    const bool completed_without_events{WaitForNotificationWithoutEvents(notification)};
+    QVERIFY2(completed_without_events, "Wallet notification synchronously waited for the GUI thread");
+
+    QElapsedTimer timer;
+    timer.start();
+    controller.reset();
+    QVERIFY2(timer.elapsed() < 5000, "WalletController destruction exceeded the shutdown bound");
+
+    QCoreApplication::processEvents();
+    QCOMPARE(added_count, 0);
+
+    (*wallet_result)->remove();
+}
+
+void WalletControllerTests::startupLoadFinishesAfterAdoption()
+{
+    wallet::WalletTestingSetup setup{ChainType::REGTEST};
+    setup.m_node.wallet_loader = setup.m_wallet_loader.get();
+    m_node.setContext(&setup.m_node);
+
+    auto first_wallet{CreateTestWallet(m_node.walletLoader(), "wallet-controller-startup-one")};
+    auto second_wallet{CreateTestWallet(m_node.walletLoader(), "wallet-controller-startup-two")};
+    QVERIFY(first_wallet.has_value());
+    QVERIFY(second_wallet.has_value());
+
+    OptionsModel options_model{m_node};
+    bilingual_str error;
+    QVERIFY(options_model.Init(error));
+    ClientModel client_model{m_node, &options_model};
+    const std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    auto controller{std::make_unique<WalletController>(client_model, platform_style.get(), nullptr)};
+
+    int added_count{0};
+    int finished_count{0};
+    int models_at_finish{-1};
+    connect(controller.get(), &WalletController::walletAdded, controller.get(), [&](WalletModel*) {
+        ++added_count;
+    });
+
+    auto activity = new LoadWalletsActivity(controller.get(), nullptr);
+    connect(activity, &LoadWalletsActivity::finished, controller.get(), [&] {
+        ++finished_count;
+        models_at_finish = added_count;
+    });
+    activity->load(/*show_loading_minimized=*/false);
+
+    QVERIFY(WaitUntil([&] { return finished_count == 1; }));
+    QCOMPARE(finished_count, 1);
+    QCOMPARE(added_count, 2);
+    QCOMPARE(models_at_finish, 2);
+
+    controller.reset();
+    (*first_wallet)->remove();
+    (*second_wallet)->remove();
+}

--- a/src/qt/test/walletcontrollertests.h
+++ b/src/qt/test/walletcontrollertests.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef QBIT_QT_TEST_WALLETCONTROLLERTESTS_H
+#define QBIT_QT_TEST_WALLETCONTROLLERTESTS_H
+
+#include <QObject>
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+class WalletControllerTests : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit WalletControllerTests(interfaces::Node& node) : m_node(node) {}
+
+private Q_SLOTS:
+    void notificationDoesNotBlockGuiThread();
+    void shutdownDropsPendingAdoption();
+    void startupLoadFinishesAfterAdoption();
+
+private:
+    interfaces::Node& m_node;
+};
+
+#endif // QBIT_QT_TEST_WALLETCONTROLLERTESTS_H

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -21,11 +21,13 @@
 
 #include <algorithm>
 #include <chrono>
+#include <functional>
+#include <memory>
+#include <utility>
 
 #include <QApplication>
 #include <QMessageBox>
 #include <QMetaObject>
-#include <QMutexLocker>
 #include <QThread>
 #include <QTimer>
 #include <QWindow>
@@ -35,6 +37,14 @@ using wallet::WALLET_FLAG_BLANK_WALLET;
 using wallet::WALLET_FLAG_DESCRIPTORS;
 using wallet::WALLET_FLAG_DISABLE_PRIVATE_KEYS;
 using wallet::WALLET_FLAG_EXTERNAL_SIGNER;
+
+namespace {
+struct PendingWalletModel
+{
+    std::unique_ptr<interfaces::Wallet> wallet;
+    std::function<void(WalletModel*)> callback;
+};
+} // namespace
 
 WalletController::WalletController(ClientModel& client_model, const PlatformStyle* platform_style, QObject* parent)
     : QObject(parent)
@@ -46,7 +56,7 @@ WalletController::WalletController(ClientModel& client_model, const PlatformStyl
     , m_options_model(client_model.getOptionsModel())
 {
     m_handler_load_wallet = m_node.walletLoader().handleLoadWallet([this](std::unique_ptr<interfaces::Wallet> wallet) {
-        getOrCreateWallet(std::move(wallet));
+        scheduleWalletModel(std::move(wallet));
     });
 
     m_activity_worker->moveToThread(m_activity_thread);
@@ -60,6 +70,9 @@ WalletController::WalletController(ClientModel& client_model, const PlatformStyl
 // available in the header, just forward declared.
 WalletController::~WalletController()
 {
+    assert(QThread::currentThread() == thread());
+    m_stopping.store(true, std::memory_order_release);
+    m_handler_load_wallet.reset();
     m_activity_thread->quit();
     m_activity_thread->wait();
     delete m_activity_worker;
@@ -67,7 +80,7 @@ WalletController::~WalletController()
 
 std::map<std::string, std::pair<bool, std::string>> WalletController::listWalletDir() const
 {
-    QMutexLocker locker(&m_mutex);
+    assert(QThread::currentThread() == thread());
     std::map<std::string, std::pair<bool, std::string>> wallets;
     for (const auto& [name, format] : m_node.walletLoader().listWalletDir()) {
         wallets[name] = std::make_pair(false, format);
@@ -81,14 +94,16 @@ std::map<std::string, std::pair<bool, std::string>> WalletController::listWallet
 
 void WalletController::removeWallet(WalletModel* wallet_model)
 {
+    assert(QThread::currentThread() == thread());
     // Once the wallet is successfully removed from the node, the model will emit the 'WalletModel::unload' signal.
     // This signal is already connected and will complete the removal of the view from the GUI.
-    // Look at 'WalletController::getOrCreateWallet' for the signal connection.
+    // Look at 'WalletController::getOrCreateWalletOnGuiThread' for the signal connection.
     wallet_model->wallet().remove();
 }
 
 void WalletController::closeWallet(WalletModel* wallet_model, QWidget* parent)
 {
+    assert(QThread::currentThread() == thread());
     QMessageBox box(parent);
     box.setWindowTitle(tr("Close wallet"));
     box.setText(tr("Are you sure you wish to close the wallet <i>%1</i>?").arg(GUIUtil::HtmlEscape(wallet_model->getDisplayName())));
@@ -102,21 +117,38 @@ void WalletController::closeWallet(WalletModel* wallet_model, QWidget* parent)
 
 void WalletController::closeAllWallets(QWidget* parent)
 {
+    assert(QThread::currentThread() == thread());
     QMessageBox::StandardButton button = QMessageBox::question(parent, tr("Close all wallets"),
         tr("Are you sure you wish to close all wallets?"),
         QMessageBox::Yes|QMessageBox::Cancel,
         QMessageBox::Yes);
     if (button != QMessageBox::Yes) return;
 
-    QMutexLocker locker(&m_mutex);
     for (WalletModel* wallet_model : m_wallets) {
         removeWallet(wallet_model);
     }
 }
 
-WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wallet> wallet)
+void WalletController::scheduleWalletModel(std::unique_ptr<interfaces::Wallet> wallet, WalletModelCallback callback)
 {
-    QMutexLocker locker(&m_mutex);
+    if (m_stopping.load(std::memory_order_acquire)) return;
+
+    auto pending = std::make_shared<PendingWalletModel>(PendingWalletModel{
+        .wallet = std::move(wallet),
+        .callback = std::move(callback),
+    });
+    const bool called = QMetaObject::invokeMethod(this, [this, pending] {
+        if (m_stopping.load(std::memory_order_acquire)) return;
+
+        WalletModel* wallet_model = getOrCreateWalletOnGuiThread(std::move(pending->wallet));
+        if (pending->callback) pending->callback(wallet_model);
+    }, Qt::QueuedConnection);
+    assert(called);
+}
+
+WalletModel* WalletController::getOrCreateWalletOnGuiThread(std::unique_ptr<interfaces::Wallet> wallet)
+{
+    assert(QThread::currentThread() == thread());
 
     // Return model instance if exists.
     if (!m_wallets.empty()) {
@@ -129,27 +161,11 @@ WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wal
     }
 
     // Instantiate model and register it.
-    WalletModel* wallet_model = new WalletModel(std::move(wallet), m_client_model, m_platform_style,
-                                                nullptr /* required for the following moveToThread() call */);
-
-    // Move WalletModel object to the thread that created the WalletController
-    // object (GUI main thread), instead of the current thread, which could be
-    // an outside wallet thread or RPC thread sending a LoadWallet notification.
-    // This ensures queued signals sent to the WalletModel object will be
-    // handled on the GUI event loop.
-    wallet_model->moveToThread(thread());
-    // setParent(parent) must be called in the thread which created the parent object. More details in #18948.
-    QMetaObject::invokeMethod(this, [wallet_model, this] {
-        wallet_model->setParent(this);
-    }, GUIUtil::blockingGUIThreadConnection());
+    WalletModel* wallet_model = new WalletModel(std::move(wallet), m_client_model, m_platform_style, this);
 
     m_wallets.push_back(wallet_model);
 
-    // WalletModel::startPollBalance needs to be called in a thread managed by
-    // Qt because of startTimer. Considering the current thread can be a RPC
-    // thread, better delegate the calling to Qt with Qt::AutoConnection.
-    const bool called = QMetaObject::invokeMethod(wallet_model, "startPollBalance");
-    assert(called);
+    wallet_model->startPollBalance();
 
     connect(wallet_model, &WalletModel::unload, this, [this, wallet_model] {
         // Defer removeAndDeleteWallet when no modal widget is actively waiting for an action.
@@ -176,11 +192,9 @@ WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wal
 
 void WalletController::removeAndDeleteWallet(WalletModel* wallet_model)
 {
+    assert(QThread::currentThread() == thread());
     // Unregister wallet model.
-    {
-        QMutexLocker locker(&m_mutex);
-        m_wallets.erase(std::remove(m_wallets.begin(), m_wallets.end(), wallet_model));
-    }
+    m_wallets.erase(std::remove(m_wallets.begin(), m_wallets.end(), wallet_model));
     Q_EMIT walletRemoved(wallet_model);
     // Currently this can trigger the unload since the model can hold the last
     // CWallet shared pointer.
@@ -193,6 +207,11 @@ WalletControllerActivity::WalletControllerActivity(WalletController* wallet_cont
     , m_parent_widget(parent_widget)
 {
     connect(this, &WalletControllerActivity::finished, this, &QObject::deleteLater);
+}
+
+void WalletControllerActivity::scheduleWalletModel(std::unique_ptr<interfaces::Wallet> wallet, std::function<void(WalletModel*)> callback)
+{
+    m_wallet_controller->scheduleWalletModel(std::move(wallet), std::move(callback));
 }
 
 void WalletControllerActivity::showProgressDialog(const QString& title_text, const QString& label_text, bool show_minimized)
@@ -270,12 +289,14 @@ void CreateWalletActivity::createWallet()
         auto wallet{node().walletLoader().createWallet(name, m_passphrase, flags, m_warning_message)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            scheduleWalletModel(std::move(*wallet), [this](WalletModel* wallet_model) {
+                m_wallet_model = wallet_model;
+                finish();
+            });
         } else {
             m_error_message = util::ErrorString(wallet);
+            QTimer::singleShot(0ms, this, &CreateWalletActivity::finish);
         }
-
-        QTimer::singleShot(0ms, this, &CreateWalletActivity::finish);
     });
 }
 
@@ -359,12 +380,14 @@ void OpenWalletActivity::open(const std::string& path)
         auto wallet{node().walletLoader().loadWallet(path, m_warning_message)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            scheduleWalletModel(std::move(*wallet), [this](WalletModel* wallet_model) {
+                m_wallet_model = wallet_model;
+                finish();
+            });
         } else {
             m_error_message = util::ErrorString(wallet);
+            QTimer::singleShot(0, this, &OpenWalletActivity::finish);
         }
-
-        QTimer::singleShot(0, this, &OpenWalletActivity::finish);
     });
 }
 
@@ -384,11 +407,18 @@ void LoadWalletsActivity::load(bool show_loading_minimized)
         /*show_minimized=*/show_loading_minimized);
 
     QTimer::singleShot(0, worker(), [this] {
-        for (auto& wallet : node().walletLoader().getWallets()) {
-            m_wallet_controller->getOrCreateWallet(std::move(wallet));
+        auto wallets = node().walletLoader().getWallets();
+        if (wallets.empty()) {
+            QTimer::singleShot(0, this, [this] { Q_EMIT finished(); });
+            return;
         }
 
-        QTimer::singleShot(0, this, [this] { Q_EMIT finished(); });
+        auto remaining = std::make_shared<size_t>(wallets.size());
+        for (auto& wallet : wallets) {
+            scheduleWalletModel(std::move(wallet), [this, remaining](WalletModel*) {
+                if (--*remaining == 0) Q_EMIT finished();
+            });
+        }
     });
 }
 
@@ -412,12 +442,14 @@ void RestoreWalletActivity::restore(const fs::path& backup_file, const std::stri
         auto wallet{node().walletLoader().restoreWallet(backup_file, wallet_name, m_warning_message)};
 
         if (wallet) {
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(*wallet));
+            scheduleWalletModel(std::move(*wallet), [this](WalletModel* wallet_model) {
+                m_wallet_model = wallet_model;
+                finish();
+            });
         } else {
             m_error_message = util::ErrorString(wallet);
+            QTimer::singleShot(0, this, &RestoreWalletActivity::finish);
         }
-
-        QTimer::singleShot(0, this, &RestoreWalletActivity::finish);
     });
 }
 
@@ -475,12 +507,14 @@ void MigrateWalletActivity::migrate(const std::string& name)
             if (res->solvables_wallet_name) {
                 m_success_message += QChar(' ') + tr("Solvable but not watched scripts have been migrated to a new wallet named '%1'.").arg(GUIUtil::HtmlEscape(GUIUtil::WalletDisplayName(res->solvables_wallet_name.value())));
             }
-            m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(res->wallet));
+            scheduleWalletModel(std::move(res->wallet), [this](WalletModel* wallet_model) {
+                m_wallet_model = wallet_model;
+                finish();
+            });
         } else {
             m_error_message = util::ErrorString(res);
+            QTimer::singleShot(0, this, &MigrateWalletActivity::finish);
         }
-
-        QTimer::singleShot(0, this, &MigrateWalletActivity::finish);
     });
 }
 

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -7,16 +7,16 @@
 
 #include <qt/sendcoinsrecipient.h>
 #include <support/allocators/secure.h>
-#include <sync.h>
 #include <util/translation.h>
 
+#include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <QMessageBox>
-#include <QMutex>
 #include <QProgressDialog>
 #include <QThread>
 #include <QTimer>
@@ -51,13 +51,9 @@ class WalletController : public QObject
 {
     Q_OBJECT
 
-    void removeAndDeleteWallet(WalletModel* wallet_model);
-
 public:
     WalletController(ClientModel& client_model, const PlatformStyle* platform_style, QObject* parent);
-    ~WalletController();
-
-    WalletModel* getOrCreateWallet(std::unique_ptr<interfaces::Wallet> wallet);
+    ~WalletController() override;
 
     //! Returns all wallet names in the wallet dir mapped to whether the wallet
     //! is loaded.
@@ -73,18 +69,23 @@ Q_SIGNALS:
     void coinsSent(WalletModel* wallet_model, SendCoinsRecipient recipient, QByteArray transaction);
 
 private:
+    using WalletModelCallback = std::function<void(WalletModel*)>;
+
+    void scheduleWalletModel(std::unique_ptr<interfaces::Wallet> wallet, WalletModelCallback callback = {});
+    WalletModel* getOrCreateWalletOnGuiThread(std::unique_ptr<interfaces::Wallet> wallet);
+    void removeAndDeleteWallet(WalletModel* wallet_model);
+
     QThread* const m_activity_thread;
     QObject* const m_activity_worker;
     ClientModel& m_client_model;
     interfaces::Node& m_node;
     const PlatformStyle* const m_platform_style;
     OptionsModel* const m_options_model;
-    mutable QMutex m_mutex;
     std::vector<WalletModel*> m_wallets;
     std::unique_ptr<interfaces::Handler> m_handler_load_wallet;
+    std::atomic_bool m_stopping{false};
 
     friend class WalletControllerActivity;
-    friend class MigrateWalletActivity;
 
     //! Starts the wallet closure procedure
     void removeWallet(WalletModel* wallet_model);
@@ -105,6 +106,7 @@ protected:
     interfaces::Node& node() const { return m_wallet_controller->m_node; }
     QObject* worker() const { return m_wallet_controller->m_activity_worker; }
 
+    void scheduleWalletModel(std::unique_ptr<interfaces::Wallet> wallet, std::function<void(WalletModel*)> callback = {});
     void showProgressDialog(const QString& title_text, const QString& label_text, bool show_minimized=false);
 
     WalletController* const m_wallet_controller;


### PR DESCRIPTION
## Summary

Fixes #79.

Queue wallet-model adoption onto the GUI thread instead of synchronously blocking wallet workers while the GUI parents a new model. Wallet creation, opening, startup loading, restore, migration, and backend load notifications now share the same nonblocking adoption path.

Shutdown marks the controller as stopping and disconnects load-wallet notifications before joining the activity worker. Pending adoption requests retain ownership of their wallet interface and are safely discarded if controller teardown wins the race.

Add deterministic Qt regressions covering nonblocking notifications, GUI-thread model ownership, duplicate notification deduplication, bounded teardown with adoption pending, and startup completion after every model is adopted.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands and results:

- `cmake --build build --target test_bitcoin-qt -j 8` — passed.
- `QT_QPA_PLATFORM=minimal build/bin/test_qbit-qt -v1` with a finite file-descriptor limit — all tests passed, including the new `WalletControllerTests` cases.
- Docker lint using `ci/lint_imagefile` — passed.
- `cmake --build build-asan --target test_bitcoin-qt -j 8` — ASAN build and link passed. Runtime leak detection is unsupported on macOS, and the instrumented test binary exceeded the local host execution watchdog before Qt startup.
- Cocoa application initialization and shutdown passed. The existing Cocoa `WalletTests` modal flow stalled later in the suite and was stopped; the complete minimal-platform suite passed.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target requested: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- The change is limited to Qt wallet-model lifetime and thread ownership; consensus, wallet persistence, and transaction behavior are unchanged.
- All `WalletModel` construction, parenting, registration, polling startup, and `walletAdded` emission now run on the GUI thread.
- Workers never wait for GUI adoption. Teardown does not pump the GUI event loop.
- Name-based model deduplication preserves the existing behavior when both the core notification and the initiating activity submit wrappers for the same wallet.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this is an internal Qt lifetime and shutdown correctness fix with no interface or workflow change.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; `src/libbitcoinpqc` is unchanged.

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786297238&installation_id=141183937&pr_number=87&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F87&signature=4cd22d8d528d663de19033140c555f70ef47beb15258a1ae9681af8edbb5133c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Qt wallet GUI lifetime and threading at shutdown; consensus and wallet persistence are unchanged, but incorrect adoption ordering could still affect GUI wallet state.
> 
> **Overview**
> Fixes Qt wallet shutdown deadlock (#79) by **replacing synchronous GUI-thread blocking** during wallet load with **queued adoption** on the GUI thread.
> 
> `WalletController` now routes load notifications and activity results through **`scheduleWalletModel`**, which posts work with `Qt::QueuedConnection` instead of `getOrCreateWallet` blocking workers via `blockingGUIThreadConnection` / cross-thread `moveToThread`. **`WalletModel` construction, parenting, polling, and `walletAdded`** run only on the GUI thread; **`QMutex` protection is removed** in favor of GUI-thread asserts. **Shutdown** sets **`m_stopping`**, drops the load-wallet handler, and ignores pending adoptions so teardown does not pump the event loop or hang.
> 
> Create/open/load/restore/migrate activities **finish after adoption callbacks**; **`LoadWalletsActivity`** emits **`finished`** only after every wallet is adopted (or immediately if none).
> 
> Adds **`WalletControllerTests`** (nonblocking notifications, shutdown with pending adoption, startup load ordering) wired into **`test_qbit-qt`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5db6bf224f3af738e18cdd0fc621f9da50a7a498. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->