### PR TITLE
Use aggregate work rate for assumevalid burial

### DIFF
--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -64,7 +64,12 @@ static bool HasAssumeutxoData()
     return !Params().GetAvailableSnapshotHeights().empty();
 }
 
-static CBlockIndex& InsertTestBlockIndex(ChainstateManager& chainman, const uint256& hash, CBlockIndex* prev, int height, uint32_t n_bits, const arith_uint256& chain_work) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
+static uint256 TestBlockHash(uint64_t value)
+{
+    return ArithToUint256(arith_uint256{value});
+}
+
+static CBlockIndex& InsertTestBlockIndex(ChainstateManager& chainman, const uint256& hash, CBlockIndex* prev, int height, uint32_t n_bits, const arith_uint256& chain_work, uint32_t block_time = 0, bool auxpow = false) EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
     AssertLockHeld(::cs_main);
     auto [it, inserted] = chainman.m_blockman.m_block_index.try_emplace(hash);
@@ -76,6 +81,11 @@ static CBlockIndex& InsertTestBlockIndex(ChainstateManager& chainman, const uint
     index.nHeight = height;
     index.nBits = n_bits;
     index.nChainWork = chain_work;
+    index.nTime = block_time;
+    if (auxpow) {
+        index.nVersion = MakeVersion(static_cast<uint16_t>(chainman.GetConsensus().nAuxpowChainId),
+                                     /*auxpow=*/true, /*version_bits=*/0);
+    }
     index.nTx = 1;
     index.m_chain_tx_count = prev ? prev->m_chain_tx_count + 1 : 1;
     index.nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
@@ -226,9 +236,9 @@ BOOST_FIXTURE_TEST_CASE(needs_witness_for_validation_gate, TestingSetup)
         auto& mutable_opts = const_cast<ChainstateManager::Options&>(chainman.m_options);
         mutable_opts.minimum_chain_work = proof;
 
-        auto& base = InsertTestBlockIndex(chainman, uint256{1}, nullptr, 0, n_bits, proof);
-        auto& candidate = InsertTestBlockIndex(chainman, uint256{2}, &base, 1, n_bits, proof * 2);
-        auto& assumed = InsertTestBlockIndex(chainman, uint256{3}, &candidate, 2, n_bits, proof * 3);
+        auto& base = InsertTestBlockIndex(chainman, uint256{1}, nullptr, 0, n_bits, proof, 1'000);
+        auto& candidate = InsertTestBlockIndex(chainman, uint256{2}, &base, 1, n_bits, proof * 2, 1'060);
+        auto& assumed = InsertTestBlockIndex(chainman, uint256{3}, &candidate, 2, n_bits, proof * 3, 1'120);
 
         mutable_opts.assumed_valid_block = uint256::ZERO;
         chainman.m_best_header = &assumed;
@@ -238,19 +248,205 @@ BOOST_FIXTURE_TEST_CASE(needs_witness_for_validation_gate, TestingSetup)
         BOOST_CHECK(!chainman.NeedsWitnessForValidation(candidate));
         BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(candidate, /*witness_unavailable=*/false));
 
-        auto& best = InsertTestBlockIndex(chainman, uint256{4}, &assumed, 3, n_bits, assumed.nChainWork + proof * 2);
+        auto& best = InsertTestBlockIndex(chainman, uint256{4}, &assumed, 3, n_bits, assumed.nChainWork + proof * 2, 1'180);
         chainman.m_best_header = &best;
         BOOST_CHECK(!chainman.NeedsWitnessForValidation(candidate));
         BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(candidate, /*witness_unavailable=*/false));
 
         const int64_t burial_seconds{60 * 60 * 24 * 7 * 2};
         const int64_t burial_blocks{burial_seconds / chainman.GetConsensus().nPowTargetSpacing + 1};
-        auto& buried = InsertTestBlockIndex(chainman, uint256{6}, &best, 4, n_bits, best.nChainWork + proof * burial_blocks);
-        chainman.m_best_header = &buried;
+        auto* buried = &InsertTestBlockIndex(chainman, uint256{6}, &best, 4, n_bits, best.nChainWork + proof * burial_blocks, 1'240);
+        // Include enough history before the sampled window for both endpoint
+        // median-times-past to use a full 11-block sample.
+        for (int i = 0; i < 126; ++i) {
+            buried = &InsertTestBlockIndex(chainman, uint256{static_cast<uint8_t>(100 + i)}, buried,
+                                           buried->nHeight + 1, n_bits, buried->nChainWork + proof,
+                                           buried->nTime + chainman.GetConsensus().nPowTargetSpacing);
+        }
+        chainman.m_best_header = buried;
         BOOST_CHECK(test_chainman.CanSkipScriptChecksForTest(candidate, /*witness_unavailable=*/false));
 
         auto& alternate = InsertTestBlockIndex(chainman, uint256{5}, &base, 1, n_bits, proof * 2);
         BOOST_CHECK(chainman.NeedsWitnessForValidation(alternate));
+    });
+}
+
+BOOST_FIXTURE_TEST_CASE(assumevalid_burial_uses_mixed_lane_work_rate, TestingSetup)
+{
+    auto& chainman{*Assert(m_node.chainman)};
+    auto& test_chainman{static_cast<TestChainstateManager&>(chainman)};
+
+    WITH_LOCK(::cs_main, {
+        const uint32_t permissionless_bits{chainman.ActiveChain()[0]->nBits};
+        CBlockIndex proof_index;
+        proof_index.nBits = permissionless_bits;
+        const arith_uint256 permissionless_proof{GetBlockProof(proof_index)};
+        BOOST_REQUIRE(permissionless_proof != 0);
+
+        arith_uint256 auxpow_target;
+        auxpow_target.SetCompact(permissionless_bits);
+        auxpow_target /= arith_uint256{1'000};
+        const uint32_t auxpow_bits{auxpow_target.GetCompact()};
+        proof_index.nBits = auxpow_bits;
+        const arith_uint256 auxpow_proof{GetBlockProof(proof_index)};
+        BOOST_REQUIRE(auxpow_proof > permissionless_proof * 900);
+
+        auto& mutable_opts = const_cast<ChainstateManager::Options&>(chainman.m_options);
+        mutable_opts.minimum_chain_work = permissionless_proof;
+
+        auto* candidate = &InsertTestBlockIndex(chainman, uint256{1}, nullptr, 0,
+                                                permissionless_bits, permissionless_proof, 1'000);
+        mutable_opts.assumed_valid_block = candidate->GetBlockHash();
+
+        // Give the recent-work window enough preceding history for stable MTP
+        // endpoints, then compress the older burial work into one test index.
+        CBlockIndex* tip{candidate};
+        for (int i = 0; i < 10; ++i) {
+            tip = &InsertTestBlockIndex(chainman, uint256{static_cast<uint8_t>(2 + i)}, tip,
+                                        tip->nHeight + 1, permissionless_bits,
+                                        tip->nChainWork + permissionless_proof, tip->nTime + 60);
+        }
+
+        const arith_uint256 window_work{auxpow_proof * 24 + permissionless_proof * 96};
+        const arith_uint256 target_burial_work{window_work * 167 + (window_work * 9) / arith_uint256{10}};
+        const arith_uint256 work_before_window{target_burial_work - window_work};
+        BOOST_REQUIRE(candidate->nChainWork + work_before_window > tip->nChainWork);
+        tip = &InsertTestBlockIndex(chainman, uint256{12}, tip, tip->nHeight + 1,
+                                    permissionless_bits, candidate->nChainWork + work_before_window,
+                                    tip->nTime + 60);
+
+        for (int i = 0; i < 120; ++i) {
+            const bool auxpow{i % 5 == 0};
+            const arith_uint256 block_proof{auxpow ? auxpow_proof : permissionless_proof};
+            tip = &InsertTestBlockIndex(chainman, uint256{static_cast<uint8_t>(20 + i)}, tip,
+                                        tip->nHeight + 1, auxpow ? auxpow_bits : permissionless_bits,
+                                        tip->nChainWork + block_proof, tip->nTime + 60, auxpow);
+        }
+
+        BOOST_REQUIRE(tip->IsPermissionless());
+        BOOST_CHECK_EQUAL(tip->nChainWork - candidate->nChainWork, target_burial_work);
+        chainman.m_best_header = tip;
+        BOOST_CHECK_GT(GetBlockProofEquivalentTime(*tip, *candidate, *tip, chainman.GetConsensus()),
+                       60 * 60 * 24 * 7 * 2);
+        BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(*candidate, /*witness_unavailable=*/false));
+
+        tip = &InsertTestBlockIndex(chainman, uint256{200}, tip, tip->nHeight + 1, auxpow_bits,
+                                    tip->nChainWork + auxpow_proof, tip->nTime + 60, /*auxpow=*/true);
+        BOOST_REQUIRE(tip->SignalsAuxpow());
+        chainman.m_best_header = tip;
+        BOOST_CHECK_LT(GetBlockProofEquivalentTime(*tip, *candidate, *tip, chainman.GetConsensus()),
+                       60 * 60 * 24 * 7 * 2);
+        BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(*candidate, /*witness_unavailable=*/false));
+    });
+}
+
+BOOST_FIXTURE_TEST_CASE(assumevalid_burial_rejects_unusable_work_rate_samples, TestingSetup)
+{
+    auto& chainman{*Assert(m_node.chainman)};
+    auto& test_chainman{static_cast<TestChainstateManager&>(chainman)};
+
+    WITH_LOCK(::cs_main, {
+        const uint32_t n_bits{chainman.ActiveChain()[0]->nBits};
+        CBlockIndex proof_index;
+        proof_index.nBits = n_bits;
+        const arith_uint256 proof{GetBlockProof(proof_index)};
+        BOOST_REQUIRE(proof != 0);
+
+        auto& mutable_opts = const_cast<ChainstateManager::Options&>(chainman.m_options);
+        mutable_opts.minimum_chain_work = 0;
+
+        auto* stale_candidate = &InsertTestBlockIndex(chainman, TestBlockHash(1'000), nullptr, 0,
+                                                      n_bits, proof, 1'000);
+        auto* stale_tip = &InsertTestBlockIndex(chainman, TestBlockHash(1'001), stale_candidate, 1,
+                                                n_bits, proof * 2, 1'060);
+        for (int i = 0; i < 120; ++i) {
+            stale_tip = &InsertTestBlockIndex(chainman, TestBlockHash(1'002 + i), stale_tip,
+                                              stale_tip->nHeight + 1, n_bits, stale_tip->nChainWork,
+                                              stale_tip->nTime + 60);
+        }
+        mutable_opts.assumed_valid_block = stale_candidate->GetBlockHash();
+        chainman.m_best_header = stale_tip;
+        BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(*stale_candidate, /*witness_unavailable=*/false));
+
+        auto* zero_time_candidate = &InsertTestBlockIndex(chainman, TestBlockHash(2'000), nullptr, 0,
+                                                          n_bits, proof, 1'000);
+        CBlockIndex* zero_time_tip{zero_time_candidate};
+        for (int i = 0; i < 119; ++i) {
+            zero_time_tip = &InsertTestBlockIndex(chainman, TestBlockHash(2'001 + i), zero_time_tip,
+                                                  zero_time_tip->nHeight + 1, n_bits,
+                                                  zero_time_tip->nChainWork + proof, 1'000);
+        }
+        mutable_opts.assumed_valid_block = zero_time_candidate->GetBlockHash();
+        chainman.m_best_header = zero_time_tip;
+        BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(*zero_time_candidate, /*witness_unavailable=*/false));
+
+        zero_time_tip = &InsertTestBlockIndex(chainman, TestBlockHash(2'120), zero_time_tip,
+                                              zero_time_tip->nHeight + 1, n_bits,
+                                              zero_time_tip->nChainWork + proof, 1'000);
+        chainman.m_best_header = zero_time_tip;
+        BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(*zero_time_candidate, /*witness_unavailable=*/false));
+
+        auto* high_work_candidate = &InsertTestBlockIndex(chainman, TestBlockHash(3'000), nullptr, 0,
+                                                          n_bits, proof * 1'000, 1'000);
+        auto* low_work_tip = &InsertTestBlockIndex(chainman, TestBlockHash(3'001), high_work_candidate, 1,
+                                                   n_bits, proof, 1'060);
+        for (int i = 0; i < 120; ++i) {
+            low_work_tip = &InsertTestBlockIndex(chainman, TestBlockHash(3'002 + i), low_work_tip,
+                                                 low_work_tip->nHeight + 1, n_bits,
+                                                 low_work_tip->nChainWork + proof, low_work_tip->nTime + 60);
+        }
+        mutable_opts.assumed_valid_block = high_work_candidate->GetBlockHash();
+        chainman.m_best_header = low_work_tip;
+        BOOST_REQUIRE(low_work_tip->nChainWork < high_work_candidate->nChainWork);
+        BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(*high_work_candidate, /*witness_unavailable=*/false));
+    });
+}
+
+BOOST_FIXTURE_TEST_CASE(assumevalid_burial_boundary_is_strict_and_overflow_safe, TestingSetup)
+{
+    auto& chainman{*Assert(m_node.chainman)};
+    auto& test_chainman{static_cast<TestChainstateManager&>(chainman)};
+
+    WITH_LOCK(::cs_main, {
+        const uint32_t n_bits{chainman.ActiveChain()[0]->nBits};
+        constexpr uint32_t BURIAL_SECONDS{60 * 60 * 24 * 7 * 2};
+        constexpr uint32_t WINDOW_BLOCKS{120};
+        constexpr uint32_t EXACT_BLOCK_SPACING{BURIAL_SECONDS / WINDOW_BLOCKS};
+        const arith_uint256 max_work{~arith_uint256{0}};
+
+        auto& mutable_opts = const_cast<ChainstateManager::Options&>(chainman.m_options);
+        mutable_opts.minimum_chain_work = 0;
+
+        auto* candidate = &InsertTestBlockIndex(chainman, TestBlockHash(4'000), nullptr, 0,
+                                                n_bits, 0, 1'000);
+        CBlockIndex* window_start{candidate};
+        for (int i = 0; i < 11; ++i) {
+            window_start = &InsertTestBlockIndex(chainman, TestBlockHash(4'001 + i), window_start,
+                                                 window_start->nHeight + 1, n_bits, 0,
+                                                 window_start->nTime + EXACT_BLOCK_SPACING);
+        }
+
+        std::vector<CBlockIndex*> window;
+        window.reserve(WINDOW_BLOCKS);
+        CBlockIndex* tip{window_start};
+        for (uint32_t i = 1; i <= WINDOW_BLOCKS; ++i) {
+            const arith_uint256 chain_work{i == WINDOW_BLOCKS ? max_work : arith_uint256{i}};
+            tip = &InsertTestBlockIndex(chainman, TestBlockHash(4'100 + i), tip,
+                                        tip->nHeight + 1, n_bits, chain_work,
+                                        window_start->nTime + i * EXACT_BLOCK_SPACING);
+            window.push_back(tip);
+        }
+
+        mutable_opts.assumed_valid_block = candidate->GetBlockHash();
+        chainman.m_best_header = tip;
+        BOOST_REQUIRE_EQUAL(tip->GetMedianTimePast() - window_start->GetMedianTimePast(), BURIAL_SECONDS);
+        BOOST_CHECK(!test_chainman.CanSkipScriptChecksForTest(*candidate, /*witness_unavailable=*/false));
+
+        for (uint32_t i = 1; i <= WINDOW_BLOCKS; ++i) {
+            window[i - 1]->nTime = window_start->nTime + i * (EXACT_BLOCK_SPACING + 1);
+        }
+        BOOST_REQUIRE_GT(tip->GetMedianTimePast() - window_start->GetMedianTimePast(), BURIAL_SECONDS);
+        BOOST_CHECK(test_chainman.CanSkipScriptChecksForTest(*candidate, /*witness_unavailable=*/false));
     });
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -71,6 +71,7 @@
 #include <cassert>
 #include <chrono>
 #include <deque>
+#include <limits>
 #include <numeric>
 #include <optional>
 #include <ranges>
@@ -2407,6 +2408,65 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex& block_index, const Ch
 // Full blocks keep the existing two-week assumevalid burial check, while
 // witness-pruned blocks fall back to the assumed-valid ancestry/work gate
 // because witness script execution is unavailable once history is compacted.
+static constexpr int ASSUMEVALID_WORK_RATE_WINDOW{120};
+static constexpr uint32_t ASSUMEVALID_BURIAL_SECONDS{60 * 60 * 24 * 7 * 2};
+
+/**
+ * Return whether work / reference_work exceeds seconds / elapsed_seconds.
+ *
+ * Dividing both ratios into integer and remainder parts avoids overflowing
+ * arith_uint256 when comparing the cross-products.
+ */
+static bool WorkDurationExceeds(const arith_uint256& work, const arith_uint256& reference_work,
+                                uint32_t elapsed_seconds, uint32_t seconds)
+{
+    if (work == 0 || reference_work == 0 || elapsed_seconds == 0) return false;
+
+    const arith_uint256 work_quotient{work / reference_work};
+    const arith_uint256 seconds_quotient{seconds / elapsed_seconds};
+    if (work_quotient != seconds_quotient) return work_quotient > seconds_quotient;
+
+    const arith_uint256 work_remainder{work - work_quotient * reference_work};
+    const uint32_t seconds_remainder{seconds % elapsed_seconds};
+
+    // Compare work_remainder / reference_work with
+    // seconds_remainder / elapsed_seconds. Computing the floor of the
+    // right-hand cross-product this way keeps every intermediate value in
+    // range. The first product is strictly less than reference_work and the
+    // second product fits in uint64_t.
+    const arith_uint256 elapsed{elapsed_seconds};
+    const arith_uint256 reference_quotient{reference_work / elapsed};
+    const arith_uint256 reference_remainder{reference_work - reference_quotient * elapsed};
+    arith_uint256 remainder_threshold{reference_quotient * seconds_remainder};
+    remainder_threshold += reference_remainder.GetLow64() * seconds_remainder / elapsed_seconds;
+
+    return work_remainder > remainder_threshold;
+}
+
+/**
+ * Check the assumevalid burial interval against aggregate recent chainwork.
+ * A multi-block work-rate sample prevents either cadence lane at the tip from
+ * controlling the estimate. Missing history, non-monotonic work, and invalid
+ * timestamp windows all fail closed.
+ */
+static bool HasAssumeValidBurial(const CBlockIndex& tip, const CBlockIndex& block_index)
+{
+    const CBlockIndex* window_start{&tip};
+    for (int i = 0; i < ASSUMEVALID_WORK_RATE_WINDOW; ++i) {
+        window_start = window_start->pprev;
+        if (!window_start) return false;
+    }
+
+    if (tip.nChainWork <= window_start->nChainWork || tip.nChainWork <= block_index.nChainWork) return false;
+
+    const int64_t elapsed{tip.GetMedianTimePast() - window_start->GetMedianTimePast()};
+    if (elapsed <= 0 || elapsed > std::numeric_limits<uint32_t>::max()) return false;
+
+    return WorkDurationExceeds(tip.nChainWork - block_index.nChainWork,
+                               tip.nChainWork - window_start->nChainWork,
+                               static_cast<uint32_t>(elapsed), ASSUMEVALID_BURIAL_SECONDS);
+}
+
 static bool IsAssumedValidAncestor(const ChainstateManager& chainman, const CBlockIndex& block_index)
     EXCLUSIVE_LOCKS_REQUIRED(::cs_main)
 {
@@ -2436,7 +2496,7 @@ bool ChainstateManager::CanSkipScriptChecks(const CBlockIndex& block_index, bool
     if (!IsAssumedValidAncestor(*this, block_index)) return false;
     if (witness_unavailable) return true;
 
-    return GetBlockProofEquivalentTime(*m_best_header, block_index, *m_best_header, GetConsensus()) > 60 * 60 * 24 * 7 * 2;
+    return HasAssumeValidBurial(*m_best_header, block_index);
 }
 
 util::Result<void> ChainstateManager::CheckAssumeValidCoversWitnessPrunedHistory() const


### PR DESCRIPTION
## Summary

- replace assumevalid's single-tip-proof burial estimate with aggregate chainwork over a 120-block MTP window
- compare work duration with exact quotient/remainder arithmetic so large chainwork values cannot overflow
- fail closed for incomplete, stale, malformed, or non-increasing samples while preserving witness-pruned behavior
- add mixed-lane proof-skew, strict-boundary, overflow-scale, and unusable-sample regression coverage

Closes #83

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands/checks:

- `cmake --build build --target test_bitcoin qbitd qbit-cli`
- `build/bin/test_qbit --run_test=validation_chainstatemanager_tests`
- `build/bin/test_qbit --run_test=pow_tests`
- `build/bin/test_qbit --run_test=validation_tests`
- `build/test/functional/test_runner.py feature_assumevalid.py --jobs=1`
- repository lint suite in the documented Docker image
- `git diff --check`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

This changes the policy that decides when assumevalid may skip historical script checks. It does not change block validity, chainwork accumulation, fork choice, difficulty adjustment, serialization, or the generic equivalent-time helper. Invalid recent-work samples retain script verification.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this is a correctness fix for an existing internal validation-policy calculation with no interface or configuration changes.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786297242&installation_id=141183937&pr_number=88&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F88&signature=a6329fb6914aa0e552e43014c4537fe858ed86526b0c4551de6291ff2e461b15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This changes when assumevalid may skip historical script verification—a validation-policy path tied to consensus-adjacent security; behavior shifts even though block validity rules themselves are unchanged.
> 
> **Overview**
> **Assumevalid burial** no longer uses `GetBlockProofEquivalentTime` on the best header alone. `ChainstateManager::CanSkipScriptChecks` now calls **`HasAssumeValidBurial`**, which samples **120 blocks** of chainwork and median-time-past, compares cumulative work since the assumed-valid ancestor against recent work over that window, and requires the ratio to exceed the existing **two-week** threshold.
> 
> The comparison goes through **`WorkDurationExceeds`**, which uses quotient/remainder arithmetic so large `arith_uint256` chainwork values do not overflow. **Incomplete history, flat or decreasing work, and bad MTP windows fail closed** (no script skip).
> 
> Unit tests extend **`InsertTestBlockIndex`** with times and auxpow, lengthen the existing burial gate scenario for MTP sampling, and add cases for **mixed permissionless/auxpow lanes**, **unusable samples**, and **strict boundary / max-work overflow** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05bed48da6968fe8f84cadbe6eb4d59a9ae6f21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->