### PR TITLE
p2p: make near-tip work thresholds lane-independent

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -138,6 +138,17 @@ arith_uint256 GetBlockProof(const CBlockIndex& block)
     return (~bnTarget / (bnTarget + 1)) + 1;
 }
 
+arith_uint256 GetRecentChainWork(const CBlockIndex& tip, const int block_count)
+{
+    assert(block_count > 0);
+    if (tip.nHeight < block_count) return tip.nChainWork;
+
+    const CBlockIndex* ancestor{tip.GetAncestor(tip.nHeight - block_count)};
+    assert(ancestor != nullptr);
+    assert(ancestor->nChainWork <= tip.nChainWork);
+    return tip.nChainWork - ancestor->nChainWork;
+}
+
 int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params& params)
 {
     arith_uint256 r;

--- a/src/chain.h
+++ b/src/chain.h
@@ -366,6 +366,8 @@ protected:
 };
 
 arith_uint256 GetBlockProof(const CBlockIndex& block);
+/** Return the cumulative work contributed by up to the most recent block_count blocks ending at tip. */
+arith_uint256 GetRecentChainWork(const CBlockIndex& tip, int block_count);
 /** Return the time it would take to redo the work difference between from and to, assuming the current hashrate corresponds to the difficulty at tip, in seconds. */
 int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params&);
 /** Find the forking point between two chain tips. */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -155,6 +155,8 @@ static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 16;
 static const unsigned int NODE_NETWORK_LIMITED_MIN_BLOCKS = 288;
 /** Window, in blocks, for connecting to NODE_NETWORK_LIMITED peers */
 static const unsigned int NODE_NETWORK_LIMITED_ALLOW_CONN_BLOCKS = 144;
+/** Recent-work window used to admit near-tip headers and blocks. */
+static constexpr int ANTI_DOS_WORK_WINDOW{144};
 /** Average delay between local address broadcasts */
 static constexpr auto AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL{24h};
 /** Average delay between peer address broadcasts */
@@ -2660,9 +2662,9 @@ arith_uint256 PeerManagerImpl::GetAntiDoSWorkThreshold()
     LOCK(cs_main);
     if (m_chainman.ActiveChain().Tip() != nullptr) {
         const CBlockIndex *tip = m_chainman.ActiveChain().Tip();
-        // Use a 144 block buffer, so that we'll accept headers that fork from
-        // near our tip.
-        near_chaintip_work = tip->nChainWork - std::min<arith_uint256>(144*GetBlockProof(*tip), tip->nChainWork);
+        // Use the aggregate work of the recent window so that the buffer does
+        // not depend on which Cadence lane produced the current tip.
+        near_chaintip_work = tip->nChainWork - GetRecentChainWork(*tip, ANTI_DOS_WORK_WINDOW);
     }
     return std::max(near_chaintip_work, m_chainman.MinimumChainWork());
 }

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -136,6 +136,70 @@ std::shared_ptr<const CAuxPow> HeadersGeneratorSetup::MakeAuxpowPayloadWithScrip
 
 BOOST_FIXTURE_TEST_SUITE(headers_sync_chainwork_tests, HeadersGeneratorSetup)
 
+BOOST_AUTO_TEST_CASE(recent_chainwork_uses_mixed_lane_window)
+{
+    static constexpr int WORK_WINDOW{144};
+    const auto chain_params = CreateChainParams(*m_node.args, ChainType::MAIN);
+    const auto& consensus = chain_params->GetConsensus();
+    const uint32_t permissionless_bits{consensus.asertAnchorParams.nBitsLegacy};
+    const uint32_t auxpow_bits{consensus.asertAnchorParams.nBitsAuxPow};
+
+    CBlockIndex permissionless_index;
+    permissionless_index.nBits = permissionless_bits;
+    CBlockIndex auxpow_index;
+    auxpow_index.nBits = auxpow_bits;
+    const arith_uint256 permissionless_work{GetBlockProof(permissionless_index)};
+    const arith_uint256 auxpow_work{GetBlockProof(auxpow_index)};
+    BOOST_REQUIRE_NE(permissionless_work, auxpow_work);
+
+    std::vector<CBlockIndex> auxpow_tip_chain(WORK_WINDOW + 2);
+    std::vector<CBlockIndex> permissionless_tip_chain(WORK_WINDOW + 2);
+    const auto build_chain = [&](std::vector<CBlockIndex>& blocks, const bool auxpow_tip) {
+        uint64_t auxpow_count{0};
+        for (int height = 0; height < static_cast<int>(blocks.size()); ++height) {
+            // Give both windows the same 115:29 lane mix while changing which
+            // lane produced the block at height 144.
+            const bool auxpow{height > 0 && height <= WORK_WINDOW &&
+                              (auxpow_tip ? height <= 28 || height == WORK_WINDOW : height <= 29)};
+            CBlockIndex& block{blocks[height]};
+            block.nHeight = height;
+            block.pprev = height == 0 ? nullptr : &blocks[height - 1];
+            block.nVersion = MakeVersion(auxpow ? static_cast<uint16_t>(consensus.nAuxpowChainId) : 0,
+                                         auxpow,
+                                         /*version_bits=*/0);
+            block.nBits = auxpow ? auxpow_bits : permissionless_bits;
+            auxpow_count += auxpow;
+            block.nAuxPow = auxpow_count;
+            block.nChainWork = (block.pprev ? block.pprev->nChainWork : arith_uint256{}) + GetBlockProof(block);
+            block.BuildSkip();
+        }
+    };
+    build_chain(auxpow_tip_chain, /*auxpow_tip=*/true);
+    build_chain(permissionless_tip_chain, /*auxpow_tip=*/false);
+
+    const arith_uint256 expected_window{permissionless_work * 115 + auxpow_work * 29};
+    BOOST_CHECK_EQUAL(GetRecentChainWork(auxpow_tip_chain[WORK_WINDOW], WORK_WINDOW), expected_window);
+    BOOST_CHECK_EQUAL(GetRecentChainWork(permissionless_tip_chain[WORK_WINDOW], WORK_WINDOW), expected_window);
+    BOOST_CHECK_NE(GetBlockProof(auxpow_tip_chain[WORK_WINDOW]) * WORK_WINDOW,
+                   GetBlockProof(permissionless_tip_chain[WORK_WINDOW]) * WORK_WINDOW);
+
+    // Short chains use all available work, while full windows exclude the
+    // ancestor immediately before the window.
+    BOOST_CHECK_EQUAL(GetRecentChainWork(auxpow_tip_chain[0], WORK_WINDOW), auxpow_tip_chain[0].nChainWork);
+    BOOST_CHECK_EQUAL(GetRecentChainWork(auxpow_tip_chain[WORK_WINDOW - 1], WORK_WINDOW),
+                      auxpow_tip_chain[WORK_WINDOW - 1].nChainWork);
+    BOOST_CHECK_EQUAL(GetRecentChainWork(auxpow_tip_chain[WORK_WINDOW], WORK_WINDOW),
+                      auxpow_tip_chain[WORK_WINDOW].nChainWork - auxpow_tip_chain[0].nChainWork);
+    BOOST_CHECK_EQUAL(GetRecentChainWork(auxpow_tip_chain[WORK_WINDOW + 1], WORK_WINDOW),
+                      auxpow_tip_chain[WORK_WINDOW + 1].nChainWork - auxpow_tip_chain[1].nChainWork);
+
+    arith_uint256 expected_warning_window{0};
+    for (int height = WORK_WINDOW - 5; height <= WORK_WINDOW; ++height) {
+        expected_warning_window += GetBlockProof(auxpow_tip_chain[height]);
+    }
+    BOOST_CHECK_EQUAL(GetRecentChainWork(auxpow_tip_chain[WORK_WINDOW], 6), expected_warning_window);
+}
+
 // In this test, we construct two sets of headers from genesis, one with
 // sufficient proof of work and one without.
 // 1. We deliver the first set of headers and verify that the headers sync state

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -115,6 +115,8 @@ const std::vector<std::string> CHECKLEVEL_DOC {
  *  noticeably interfere with the pruning mechanism.
  * */
 static constexpr int PRUNE_LOCK_BUFFER{10};
+/** Recent-work margin for warning about a substantially better invalid chain. */
+static constexpr int INVALID_CHAIN_WORK_WINDOW{6};
 static constexpr auto RECOVERED_WITNESS_READ_FAILED{"recovered-witness-read-failed"};
 static constexpr auto RECOVERED_WITNESS_VALIDATION_FAILED{"recovered-witness-validation-failed"};
 
@@ -2061,7 +2063,10 @@ void Chainstate::CheckForkWarningConditions()
         return;
     }
 
-    if (m_chainman.m_best_invalid && m_chainman.m_best_invalid->nChainWork > m_chain.Tip()->nChainWork + (GetBlockProof(*m_chain.Tip()) * 6)) {
+    const CBlockIndex& tip{*Assert(m_chain.Tip())};
+    const arith_uint256 invalid_chain_work_margin{GetRecentChainWork(tip, INVALID_CHAIN_WORK_WINDOW)};
+    if (m_chainman.m_best_invalid &&
+        m_chainman.m_best_invalid->nChainWork > tip.nChainWork + invalid_chain_work_margin) {
         LogPrintf("%s: Warning: Found invalid chain at least ~6 blocks longer than our best chain.\nChain state database corruption likely.\n", __func__);
         m_chainman.GetNotifications().warningSet(
             kernel::Warning::LARGE_WORK_INVALID_CHAIN,

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -60,6 +60,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_not_equal,
     assert_equal,
+    assert_raises_rpc_error,
     softfork_active,
 )
 from test_framework.wallet import MiniWallet
@@ -645,25 +646,28 @@ class CompactBlocksTest(BitcoinTestFramework):
         bad_peer.wait_for_disconnect()
 
     def test_low_work_compactblocks(self, test_node):
-        # A compactblock with insufficient work won't get its header included
+        # Compact blocks at the threshold are admitted, while a compact block
+        # one proof below it does not get its header included.
         node = self.nodes[0]
-        hashPrevBlock = int(node.getblockhash(node.getblockcount() - 150), 16)
-        block = self.build_block_on_tip(node)
-        block.hashPrevBlock = hashPrevBlock
-        block.solve()
+        height = node.getblockcount()
+        assert height > 146
 
-        comp_block = HeaderAndShortIDs()
-        comp_block.initialize_from_block(block)
+        def build_compact_block(parent_height):
+            block = self.build_block_on_tip(node)
+            block.hashPrevBlock = int(node.getblockhash(parent_height), 16)
+            block.solve()
+            compact = HeaderAndShortIDs()
+            compact.initialize_from_block(block)
+            return block, compact
+
+        accepted, accepted_compact = build_compact_block(height - 145)
+        test_node.send_and_ping(msg_cmpctblock(accepted_compact.to_p2p()))
+        assert_equal(node.getblockheader(accepted.hash_hex)["hash"], accepted.hash_hex)
+
+        rejected, rejected_compact = build_compact_block(height - 146)
         with self.nodes[0].assert_debug_log(['[net] Ignoring low-work compact block from peer 0']):
-            test_node.send_and_ping(msg_cmpctblock(comp_block.to_p2p()))
-
-        tips = node.getchaintips()
-        found = False
-        for x in tips:
-            if x["hash"] == block.hash_hex:
-                found = True
-                break
-        assert not found
+            test_node.send_and_ping(msg_cmpctblock(rejected_compact.to_p2p()))
+        assert_raises_rpc_error(-5, "Block not found", node.getblockheader, rejected.hash_hex)
 
     def test_compactblocks_not_at_tip(self, test_node):
         node = self.nodes[0]

--- a/test/functional/p2p_headers_sync_with_minchainwork.py
+++ b/test/functional/p2p_headers_sync_with_minchainwork.py
@@ -20,6 +20,7 @@ from test_framework.messages import (
 from test_framework.blocktools import (
     NORMAL_GBT_REQUEST_PARAMS,
     create_block,
+    create_coinbase,
 )
 
 from test_framework.util import (
@@ -163,6 +164,38 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         # getpeerinfo should show a sync in progress
         assert_equal(node.getpeerinfo()[0]['presynced_headers'], 2000)
 
+    def test_dynamic_work_threshold_boundary(self):
+        self.log.info("Test the dynamic recent-work threshold boundary for headers")
+        node = self.nodes[0]
+        height = node.getblockcount()
+        assert height > 146
+        peer = node.add_p2p_connection(P2PInterface())
+        template = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
+
+        def build_fork_header(parent_height):
+            block = create_block(
+                hashprev=int(node.getblockhash(parent_height), 16),
+                coinbase=create_coinbase(parent_height + 1),
+                ntime=template["curtime"],
+                tmpl=template,
+            )
+            block.solve()
+            return block
+
+        # On constant-work regtest, this header's chainwork is exactly the
+        # active tip's chainwork minus the most recent 144-block work window.
+        accepted = build_fork_header(height - 145)
+        peer.send_and_ping(msg_headers(headers=[accepted]))
+        assert_equal(node.getblockheader(accepted.hash_hex)["hash"], accepted.hash_hex)
+
+        # Moving the parent back one more block leaves the candidate one proof
+        # below the threshold, so it must not enter the block index.
+        rejected = build_fork_header(height - 146)
+        with node.assert_debug_log(expected_msgs=[f"[net] Ignoring low-work chain (height={height - 145})"]):
+            peer.send_and_ping(msg_headers(headers=[rejected]))
+        assert_raises_rpc_error(-5, "Block not found", node.getblockheader, rejected.hash_hex)
+        peer.peer_disconnect()
+
     def test_large_reorgs_can_succeed(self):
         self.log.info("Test that a 2000+ block reorg, starting from a point that is more than 2000 blocks before a locator entry, can succeed")
 
@@ -188,6 +221,8 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
 
     def run_test(self):
         self.test_chains_sync_when_long_enough()
+
+        self.test_dynamic_work_threshold_boundary()
 
         self.test_large_reorgs_can_succeed()
 

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -42,6 +42,10 @@ Node1 is unused in tests 3-7:
 7. Send Node0 the missing block again.
    Node0 should process and the tip should advance.
 
+7b. Send unrequested blocks at and immediately below the dynamic recent-work
+    threshold. The exact-threshold header should be accepted, while the
+    below-threshold header should not enter the block index.
+
 8. Create a fork which is invalid at a height longer than the current chain
    (ie to which the node will try to reorg) but which has headers built on top
    of the invalid block. Check that we get disconnected if we send more headers
@@ -232,6 +236,35 @@ class AcceptBlockTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), all_blocks[286].hash_hex)
         assert_raises_rpc_error(-1, "Block not available (not fully downloaded)", self.nodes[0].getblock, all_blocks[287].hash_hex)
         self.log.info("Successfully reorged to longer chain")
+
+        # 7b. Exercise the block-message min_pow_checked gate at the dynamic
+        # recent-work threshold. On constant-work regtest, a child of the
+        # height-(tip-145) block has chainwork exactly equal to the threshold.
+        active_height = self.nodes[0].getblockcount()
+        assert active_height > 146
+        boundary_time = self.nodes[0].getblockheader(self.nodes[0].getbestblockhash())["time"] + 1
+
+        accepted_parent_height = active_height - 145
+        accepted_boundary = create_block(
+            int(self.nodes[0].getblockhash(accepted_parent_height), 16),
+            create_coinbase(accepted_parent_height + 1),
+            boundary_time,
+        )
+        accepted_boundary.solve()
+        test_node.send_and_ping(msg_block(accepted_boundary))
+        assert_equal(self.nodes[0].getblockheader(accepted_boundary.hash_hex)["hash"], accepted_boundary.hash_hex)
+        assert_raises_rpc_error(-1, "Block not available", self.nodes[0].getblock, accepted_boundary.hash_hex)
+
+        rejected_parent_height = active_height - 146
+        rejected_boundary = create_block(
+            int(self.nodes[0].getblockhash(rejected_parent_height), 16),
+            create_coinbase(rejected_parent_height + 1),
+            boundary_time,
+        )
+        rejected_boundary.solve()
+        with self.nodes[0].assert_debug_log(expected_msgs=["missing anti-dos proof-of-work validation"]):
+            test_node.send_and_ping(msg_block(rejected_boundary))
+        assert_raises_rpc_error(-5, "Block not found", self.nodes[0].getblockheader, rejected_boundary.hash_hex)
 
         # 8. Create a chain which is invalid at a height longer than the
         # current chain, but which has more blocks on top of that


### PR DESCRIPTION
## Summary

- Replace the current-tip proof proxy in the near-tip anti-DoS threshold with the aggregate chainwork of the actual recent 144-block window.
- Apply the same lane-independent calculation to the six-block best-invalid warning margin.
- Add mixed permissionless/AuxPoW unit coverage plus exact-threshold and below-threshold functional coverage for headers, compact blocks, and block messages.

Closes #78.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands and checks:

- `cmake --build build --target test_bitcoin`
- `build/bin/test_qbit --run_test=headers_sync_chainwork_tests,denialofservice_tests,peerman_tests --catch_system_errors=no --log_level=message`
- `build/bin/test_qbit --catch_system_errors=no --log_level=message` (1,218 test cases)
- `build/test/functional/test_runner.py --jobs=4 --failfast p2p_headers_sync_with_minchainwork.py p2p_compactblocks.py p2p_unrequested_blocks.py feature_minchainwork.py`
- Project Docker lint image from `ci/lint_imagefile` (all checks passed)
- `git diff --check`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- This changes P2P admission and warning policy, not consensus validation or fork choice.
- The 144-block and six-block window sizes, `MinimumChainWork()` floor, and existing strict/inclusive comparisons are unchanged.
- Review should focus on short-chain behavior, the height-143/144/145 boundary, and exact-threshold handling in all three P2P consumers.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this is an internal P2P hardening and warning-margin correction with no operator-facing interface change.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; `src/libbitcoinpqc` is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786297444&installation_id=141183937&pr_number=89&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F89&signature=875edee75abe0b6b433c7a15e69a610f36a31606d471a33a8e699ec9351713da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches P2P admission and operator warnings (not consensus), but mis-boundary behavior could admit or reject near-tip traffic incorrectly; tests focus on exact thresholds.
> 
> **Overview**
> Near-tip **P2P anti-DoS** and **invalid-chain warning** margins no longer assume every recent block has the same work as the current tip block. A new **`GetRecentChainWork`** helper returns the sum of work over the last *N* blocks (via `tip.nChainWork` minus the ancestor at `height - N`), which matters when permissionless and AuxPoW lanes mix different difficulties.
> 
> **`GetAntiDoSWorkThreshold`** now subtracts a **144-block** recent-work window instead of `144 × GetBlockProof(tip)`. The **large-work invalid chain** warning uses the same pattern with a **6-block** window instead of `6 × GetBlockProof(tip)`. Window sizes, **`MinimumChainWork()`** floor, and admission comparisons are unchanged.
> 
> Coverage adds a mixed-lane unit test and functional tests that assert headers, compact blocks, and unrequested blocks are accepted at the exact threshold and rejected one block further back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1481be8c2fa677d6647cf1d4e00dd4cd3236a349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->