### PR TITLE
Fix Qt wallet shutdown lifetime

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -359,6 +359,11 @@ void BitcoinApplication::requestShutdown()
     pollShutdownTimer->stop();
 
 #ifdef ENABLE_WALLET
+    // Wallet views own background send workers and temporary unlock contexts
+    // which reference WalletModel objects parented to the wallet controller.
+    // Destroy the views and join their workers before deleting those models.
+    window->removeAllWallets();
+
     // Delete wallet controller here manually, instead of relying on Qt object
     // tracking (https://doc.qt.io/qt-5/objecttrees.html). This makes sure
     // walletmodel m_handle_* notification handlers are deleted before wallets

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -846,10 +846,12 @@ void BitcoinGUI::setCurrentWalletBySelectorIndex(int index)
 
 void BitcoinGUI::removeAllWallets()
 {
-    if(!walletFrame)
-        return;
+    if (!walletFrame) return;
+
     setWalletActionsEnabled(false);
-    walletFrame->removeAllWallets();
+    for (WalletModel* wallet_model : walletFrame->getWalletModels()) {
+        removeWallet(wallet_model);
+    }
 }
 #endif // ENABLE_WALLET
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -708,6 +708,15 @@ void SendCoinsDialog::prepareTransactionFinished(uint64_t generation, std::share
 
     clearPrepareProgressDialog();
 
+    if (!model) {
+        m_prepare_cancel_requested = false;
+        m_prepare_counters_reserved = false;
+        fNewRecipientAllowed = true;
+        m_current_transaction.reset();
+        m_prepare_unlock_context.reset();
+        return;
+    }
+
     if (m_prepare_cancel_requested.load() && !counters_reserved) {
         m_prepare_cancel_requested = false;
         m_prepare_counters_reserved = false;

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -88,7 +88,7 @@ private:
 
     Ui::SendCoinsDialog *ui;
     ClientModel* clientModel{nullptr};
-    WalletModel* model{nullptr};
+    QPointer<WalletModel> model;
     std::unique_ptr<wallet::CCoinControl> m_coin_control;
     std::unique_ptr<WalletModelTransaction> m_current_transaction;
     std::unique_ptr<WalletModel::UnlockContext> m_prepare_unlock_context;

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -32,6 +32,7 @@ if(ENABLE_WALLET)
   target_sources(test_bitcoin-qt
     PRIVATE
       addressbooktests.cpp
+      syntheticwallet.cpp
       walletcontrollertests.cpp
       walletactivitytests.cpp
       wallettests.cpp

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -142,7 +142,7 @@ void AppTests::appTests()
     QVERIFY(m_shutdown_wallet_state);
 
     const auto state{m_shutdown_wallet_state};
-    std::jthread watchdog{[state] {
+    std::thread watchdog{[state] {
         std::unique_lock lock{state->mutex};
         if (!state->condition.wait_for(lock, 5s, [state] {
                 return state->create_finished || state->shutdown_complete;

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -7,21 +7,24 @@
 #include <bitcoin-build-config.h> // IWYU pragma: keep
 
 #include <chainparams.h>
-#include <common/args.h>
-#include <interfaces/wallet.h>
 #include <key.h>
 #include <logging.h>
 #include <qt/bitcoin.h>
 #include <qt/bitcoingui.h>
 #include <qt/networkstyle.h>
 #include <qt/rpcconsole.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#ifdef ENABLE_WALLET
+#include <common/args.h>
+#include <interfaces/wallet.h>
 #include <qt/sendcoinsdialog.h>
 #include <qt/walletcontroller.h>
 #include <qt/walletview.h>
-#include <test/util/setup_common.h>
 #include <univalue.h>
-#include <validation.h>
 #include <wallet/wallet.h>
+#endif // ENABLE_WALLET
 
 #include <QAction>
 #include <QLineEdit>
@@ -124,6 +127,15 @@ void AppTests::guiTests(BitcoinGUI* window)
     QVERIFY(controller);
 
     for (const std::string name : {"qt-shutdown-lifetime-1", "qt-shutdown-lifetime-2"}) {
+        QSignalSpy wallet_added_spy(controller, &WalletController::walletAdded);
+        QVERIFY(wallet_added_spy.isValid());
+        WalletModel* wallet_model{nullptr};
+        QObject wallet_added_context;
+        connect(
+            controller,
+            &WalletController::walletAdded,
+            &wallet_added_context,
+            [&](WalletModel* model) { wallet_model = model; });
         std::vector<bilingual_str> warnings;
         auto wallet{m_app.node().walletLoader().createWallet(
             name,
@@ -131,7 +143,7 @@ void AppTests::guiTests(BitcoinGUI* window)
             wallet::WALLET_FLAG_DESCRIPTORS | wallet::WALLET_FLAG_BLANK_WALLET,
             warnings)};
         QVERIFY(wallet);
-        WalletModel* const wallet_model{controller->getOrCreateWallet(std::move(*wallet))};
+        if (!wallet_model) QVERIFY(wallet_added_spy.wait(5000));
         QVERIFY(wallet_model);
 
         if (!m_shutdown_wallet_model) {

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -19,26 +19,71 @@
 #ifdef ENABLE_WALLET
 #include <common/args.h>
 #include <interfaces/wallet.h>
+#include <key_io.h>
+#include <qt/bitcoinamountfield.h>
+#include <qt/qvalidatedlineedit.h>
 #include <qt/sendcoinsdialog.h>
+#include <qt/sendcoinsentry.h>
+#include <qt/test/syntheticwallet.h>
 #include <qt/walletcontroller.h>
 #include <qt/walletview.h>
 #include <univalue.h>
+#include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 #endif // ENABLE_WALLET
 
+#include <chrono>
+#include <thread>
+
 #include <QAction>
+#include <QDialogButtonBox>
+#include <QElapsedTimer>
+#include <QEvent>
 #include <QLineEdit>
+#include <QPushButton>
 #include <QRegularExpression>
 #include <QScopedPointer>
 #include <QSignalSpy>
 #include <QString>
 #include <QTest>
 #include <QTextEdit>
+#include <QTimer>
+#include <QVBoxLayout>
 #include <QtGlobal>
 #include <QtTest/QtTestWidgets>
 #include <QtTest/QtTestGui>
 
 namespace {
+using namespace std::chrono_literals;
+
+#ifdef ENABLE_WALLET
+class TestWalletAdoptionActivity : public WalletControllerActivity
+{
+public:
+    using WalletControllerActivity::WalletControllerActivity;
+
+    void adopt(std::unique_ptr<interfaces::Wallet> wallet, std::function<void(WalletModel*)> callback)
+    {
+        scheduleWalletModel(std::move(wallet), std::move(callback));
+    }
+};
+
+void AcceptWalletUnlock()
+{
+    QTimer::singleShot(0, qApp, [] {
+        for (QWidget* widget : QApplication::topLevelWidgets()) {
+            if (!widget->inherits("AskPassphraseDialog")) continue;
+            QLineEdit* const passphrase{widget->findChild<QLineEdit*>("passEdit1")};
+            QDialogButtonBox* const buttons{widget->findChild<QDialogButtonBox*>("buttonBox")};
+            if (!passphrase || !buttons) return;
+            passphrase->setText("test-passphrase");
+            buttons->button(QDialogButtonBox::Ok)->click();
+            return;
+        }
+    });
+}
+#endif // ENABLE_WALLET
+
 //! Regex find a string group inside of the console output
 QString FindInConsole(const QString& output, const QString& pattern)
 {
@@ -94,15 +139,78 @@ void AppTests::appTests()
     QVERIFY(m_shutdown_wallet_model);
     QVERIFY(m_shutdown_wallet_view);
     QVERIFY(m_shutdown_send_dialog);
-#endif // ENABLE_WALLET
+    QVERIFY(m_shutdown_wallet_state);
+
+    const auto state{m_shutdown_wallet_state};
+    std::jthread watchdog{[state] {
+        std::unique_lock lock{state->mutex};
+        if (!state->condition.wait_for(lock, 5s, [state] {
+                return state->create_finished || state->shutdown_complete;
+            })) {
+            state->watchdog_released = true;
+            state->allow_create = true;
+            lock.unlock();
+            state->condition.notify_all();
+        }
+    }};
+
+    QElapsedTimer shutdown_timer;
+    shutdown_timer.start();
+    QEvent quit_event{QEvent::Quit};
+    const bool quit_delivered{QCoreApplication::sendEvent(&m_app, &quit_event)};
+    m_shutdown_elapsed_ms = shutdown_timer.elapsed();
+
+    {
+        std::lock_guard lock{state->mutex};
+        state->shutdown_complete = true;
+        state->allow_create = true;
+    }
+    state->condition.notify_all();
+    watchdog.join();
+
+    bool worker_destroyed{false};
+    {
+        std::unique_lock lock{state->mutex};
+        worker_destroyed = state->condition.wait_for(lock, 5s, [state] {
+            return state->background_clone_destroyed;
+        });
+    }
+#else
     m_app.requestShutdown();
+#endif // ENABLE_WALLET
+    m_app.exec();
+
 #ifdef ENABLE_WALLET
+    bool cancel_observed{false};
+    bool watchdog_released{false};
+    bool locked{false};
+    int lock_calls{0};
+    int unlock_calls{0};
+    {
+        std::lock_guard lock{state->mutex};
+        cancel_observed = state->cancel_observed;
+        watchdog_released = state->watchdog_released;
+        locked = state->locked;
+        lock_calls = state->lock_calls;
+        unlock_calls = state->unlock_calls;
+    }
+    QVERIFY(quit_delivered);
+    QVERIFY2(m_shutdown_elapsed_ms < 5000, "Qt wallet shutdown exceeded the five-second bound");
+    QVERIFY(!watchdog_released);
+    QVERIFY(cancel_observed);
+    QVERIFY(worker_destroyed);
     QVERIFY(m_shutdown_wallet_model.isNull());
     QVERIFY(m_shutdown_wallet_view.isNull());
     QVERIFY(m_shutdown_send_dialog.isNull());
     QVERIFY(m_wallet_dependents_destroyed_before_model);
+    QVERIFY(locked);
+    QCOMPARE(unlock_calls, 1);
+    QCOMPARE(lock_calls, 1);
+    QCOMPARE(m_shutdown_coins_sent, 0);
+    for (QWidget* widget : QApplication::topLevelWidgets()) {
+        QVERIFY(!widget->inherits("SendConfirmationDialog"));
+    }
 #endif // ENABLE_WALLET
-    m_app.exec();
 
 #ifdef ENABLE_WALLET
     // WalletLoader::createWallet persists startup entries. Remove test-only
@@ -145,25 +253,72 @@ void AppTests::guiTests(BitcoinGUI* window)
         QVERIFY(wallet);
         if (!wallet_model) QVERIFY(wallet_added_spy.wait(5000));
         QVERIFY(wallet_model);
+    }
 
-        if (!m_shutdown_wallet_model) {
-            m_shutdown_wallet_model = wallet_model;
-            for (WalletView* wallet_view : window->findChildren<WalletView*>()) {
-                if (wallet_view->getWalletModel() == wallet_model) {
-                    m_shutdown_wallet_view = wallet_view;
-                    m_shutdown_send_dialog = wallet_view->findChild<SendCoinsDialog*>();
-                    break;
-                }
-            }
-            QVERIFY(m_shutdown_wallet_view);
-            QVERIFY(m_shutdown_send_dialog);
-            connect(wallet_model, &QObject::destroyed, this, [this] {
-                m_wallet_dependents_destroyed_before_model =
-                    m_shutdown_wallet_view.isNull() && m_shutdown_send_dialog.isNull();
-            });
+    m_shutdown_wallet_state = std::make_shared<qt_test::SyntheticWalletState>();
+    {
+        std::lock_guard lock{m_shutdown_wallet_state->mutex};
+        m_shutdown_wallet_state->allow_create = false;
+        m_shutdown_wallet_state->wait_for_cancel = true;
+        m_shutdown_wallet_state->encrypted = true;
+        m_shutdown_wallet_state->locked = true;
+    }
+
+    QSignalSpy wallet_added_spy(controller, &WalletController::walletAdded);
+    QVERIFY(wallet_added_spy.isValid());
+    auto* adoption_activity{new TestWalletAdoptionActivity(controller, window)};
+    adoption_activity->adopt(
+        qt_test::MakeSyntheticWallet(wallet::PQCUsageReport{}, m_shutdown_wallet_state),
+        [this, adoption_activity](WalletModel* model) {
+            m_shutdown_wallet_model = model;
+            adoption_activity->deleteLater();
+        });
+    if (!m_shutdown_wallet_model) QVERIFY(wallet_added_spy.wait(5000));
+    QVERIFY(m_shutdown_wallet_model);
+
+    for (WalletView* wallet_view : window->findChildren<WalletView*>()) {
+        if (wallet_view->getWalletModel() == m_shutdown_wallet_model) {
+            m_shutdown_wallet_view = wallet_view;
+            m_shutdown_send_dialog = wallet_view->findChild<SendCoinsDialog*>();
+            break;
         }
     }
-    QCOMPARE(window->findChildren<WalletView*>().size(), 2);
+    QVERIFY(m_shutdown_wallet_view);
+    QVERIFY(m_shutdown_send_dialog);
+    connect(m_shutdown_wallet_model, &QObject::destroyed, this, [this] {
+        m_wallet_dependents_destroyed_before_model =
+            m_shutdown_wallet_view.isNull() && m_shutdown_send_dialog.isNull();
+    });
+    connect(m_shutdown_send_dialog, &SendCoinsDialog::coinsSent, this, [this] {
+        ++m_shutdown_coins_sent;
+    });
+
+    m_shutdown_wallet_model->pollBalanceChanged();
+    QVBoxLayout* const entries{m_shutdown_send_dialog->findChild<QVBoxLayout*>("entries")};
+    QVERIFY(entries);
+    SendCoinsEntry* const entry{qobject_cast<SendCoinsEntry*>(entries->itemAt(0)->widget())};
+    QVERIFY(entry);
+    entry->findChild<QValidatedLineEdit*>("payTo")->setText(QString::fromStdString(EncodeDestination(WitnessV2P2MR{})));
+    entry->findChild<BitcoinAmountField*>("payAmount")->setValue(COIN);
+    m_shutdown_send_dialog->getCoinControl()->Select(COutPoint{Txid{}, 0});
+    QVERIFY(entry->validate(m_app.node()));
+    QVERIFY(m_shutdown_send_dialog->getCoinControl()->HasSelected());
+    QCOMPARE(
+        m_shutdown_wallet_model->wallet().getAvailableBalance(*m_shutdown_send_dialog->getCoinControl()),
+        50 * COIN);
+
+    AcceptWalletUnlock();
+    QVERIFY(QMetaObject::invokeMethod(m_shutdown_send_dialog, "sendButtonClicked", Q_ARG(bool, false)));
+    {
+        std::unique_lock lock{m_shutdown_wallet_state->mutex};
+        QVERIFY(m_shutdown_wallet_state->condition.wait_for(lock, 5s, [this] {
+            return m_shutdown_wallet_state->create_entered;
+        }));
+        QCOMPARE(m_shutdown_wallet_state->unlock_calls, 1);
+        QVERIFY(!m_shutdown_wallet_state->locked);
+    }
+
+    QCOMPARE(window->findChildren<WalletView*>().size(), 3);
 #endif // ENABLE_WALLET
 
     connect(window, &BitcoinGUI::consoleShown, this, &AppTests::consoleTests);

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -4,15 +4,24 @@
 
 #include <qt/test/apptests.h>
 
+#include <bitcoin-build-config.h> // IWYU pragma: keep
+
 #include <chainparams.h>
+#include <common/args.h>
+#include <interfaces/wallet.h>
 #include <key.h>
 #include <logging.h>
 #include <qt/bitcoin.h>
 #include <qt/bitcoingui.h>
 #include <qt/networkstyle.h>
 #include <qt/rpcconsole.h>
+#include <qt/sendcoinsdialog.h>
+#include <qt/walletcontroller.h>
+#include <qt/walletview.h>
 #include <test/util/setup_common.h>
+#include <univalue.h>
 #include <validation.h>
+#include <wallet/wallet.h>
 
 #include <QAction>
 #include <QLineEdit>
@@ -77,8 +86,29 @@ void AppTests::appTests()
     m_app.baseInitialize();
     m_app.requestInitialize();
     m_app.exec();
+
+#ifdef ENABLE_WALLET
+    QVERIFY(m_shutdown_wallet_model);
+    QVERIFY(m_shutdown_wallet_view);
+    QVERIFY(m_shutdown_send_dialog);
+#endif // ENABLE_WALLET
     m_app.requestShutdown();
+#ifdef ENABLE_WALLET
+    QVERIFY(m_shutdown_wallet_model.isNull());
+    QVERIFY(m_shutdown_wallet_view.isNull());
+    QVERIFY(m_shutdown_send_dialog.isNull());
+    QVERIFY(m_wallet_dependents_destroyed_before_model);
+#endif // ENABLE_WALLET
     m_app.exec();
+
+#ifdef ENABLE_WALLET
+    // WalletLoader::createWallet persists startup entries. Remove test-only
+    // entries so later options tests see their original settings fixture.
+    gArgs.LockSettings([](common::Settings& settings) {
+        settings.rw_settings.erase("wallet");
+    });
+    QVERIFY(gArgs.WriteSettingsFile());
+#endif // ENABLE_WALLET
 
     // Reset global state to avoid interfering with later tests.
     LogInstance().DisconnectTestLogger();
@@ -88,6 +118,42 @@ void AppTests::appTests()
 void AppTests::guiTests(BitcoinGUI* window)
 {
     HandleCallback callback{"guiTests", *this};
+
+#ifdef ENABLE_WALLET
+    WalletController* const controller{window->getWalletController()};
+    QVERIFY(controller);
+
+    for (const std::string name : {"qt-shutdown-lifetime-1", "qt-shutdown-lifetime-2"}) {
+        std::vector<bilingual_str> warnings;
+        auto wallet{m_app.node().walletLoader().createWallet(
+            name,
+            SecureString{},
+            wallet::WALLET_FLAG_DESCRIPTORS | wallet::WALLET_FLAG_BLANK_WALLET,
+            warnings)};
+        QVERIFY(wallet);
+        WalletModel* const wallet_model{controller->getOrCreateWallet(std::move(*wallet))};
+        QVERIFY(wallet_model);
+
+        if (!m_shutdown_wallet_model) {
+            m_shutdown_wallet_model = wallet_model;
+            for (WalletView* wallet_view : window->findChildren<WalletView*>()) {
+                if (wallet_view->getWalletModel() == wallet_model) {
+                    m_shutdown_wallet_view = wallet_view;
+                    m_shutdown_send_dialog = wallet_view->findChild<SendCoinsDialog*>();
+                    break;
+                }
+            }
+            QVERIFY(m_shutdown_wallet_view);
+            QVERIFY(m_shutdown_send_dialog);
+            connect(wallet_model, &QObject::destroyed, this, [this] {
+                m_wallet_dependents_destroyed_before_model =
+                    m_shutdown_wallet_view.isNull() && m_shutdown_send_dialog.isNull();
+            });
+        }
+    }
+    QCOMPARE(window->findChildren<WalletView*>().size(), 2);
+#endif // ENABLE_WALLET
+
     connect(window, &BitcoinGUI::consoleShown, this, &AppTests::consoleTests);
     expectCallback("consoleTests");
     QAction* action = window->findChild<QAction*>("openRPCConsoleAction");
@@ -98,6 +164,9 @@ void AppTests::guiTests(BitcoinGUI* window)
 void AppTests::consoleTests(RPCConsole* console)
 {
     HandleCallback callback{"consoleTests", *this};
+#ifdef ENABLE_WALLET
+    console->setCurrentWallet(nullptr);
+#endif // ENABLE_WALLET
     TestRpcCommand(console);
 }
 

--- a/src/qt/test/apptests.h
+++ b/src/qt/test/apptests.h
@@ -6,6 +6,7 @@
 #define QBIT_QT_TEST_APPTESTS_H
 
 #include <QObject>
+#include <QPointer>
 #include <set>
 #include <string>
 #include <utility>
@@ -13,6 +14,9 @@
 class BitcoinApplication;
 class BitcoinGUI;
 class RPCConsole;
+class SendCoinsDialog;
+class WalletModel;
+class WalletView;
 
 class AppTests : public QObject
 {
@@ -45,6 +49,11 @@ private:
     //! either run or thrown exceptions. This could be a simple int counter
     //! instead of a set of names, but the names might be useful for debugging.
     std::multiset<std::string> m_callbacks;
+
+    QPointer<WalletModel> m_shutdown_wallet_model;
+    QPointer<WalletView> m_shutdown_wallet_view;
+    QPointer<SendCoinsDialog> m_shutdown_send_dialog;
+    bool m_wallet_dependents_destroyed_before_model{false};
 };
 
 #endif // QBIT_QT_TEST_APPTESTS_H

--- a/src/qt/test/apptests.h
+++ b/src/qt/test/apptests.h
@@ -7,6 +7,8 @@
 
 #include <QObject>
 #include <QPointer>
+#include <cstdint>
+#include <memory>
 #include <set>
 #include <string>
 #include <utility>
@@ -17,6 +19,10 @@ class RPCConsole;
 class SendCoinsDialog;
 class WalletModel;
 class WalletView;
+
+namespace qt_test {
+struct SyntheticWalletState;
+}
 
 class AppTests : public QObject
 {
@@ -53,6 +59,9 @@ private:
     QPointer<WalletModel> m_shutdown_wallet_model;
     QPointer<WalletView> m_shutdown_wallet_view;
     QPointer<SendCoinsDialog> m_shutdown_send_dialog;
+    std::shared_ptr<qt_test::SyntheticWalletState> m_shutdown_wallet_state;
+    int64_t m_shutdown_elapsed_ms{-1};
+    int m_shutdown_coins_sent{0};
     bool m_wallet_dependents_destroyed_before_model{false};
 };
 

--- a/src/qt/test/syntheticwallet.cpp
+++ b/src/qt/test/syntheticwallet.cpp
@@ -1,0 +1,239 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/syntheticwallet.h>
+
+#include <interfaces/handler.h>
+#include <outputtype.h>
+#include <policy/fees.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <util/translation.h>
+#include <wallet/wallet.h>
+
+#include <chrono>
+#include <optional>
+#include <set>
+#include <utility>
+
+namespace qt_test {
+namespace {
+
+using namespace std::chrono_literals;
+
+class SyntheticWallet : public interfaces::Wallet
+{
+public:
+    explicit SyntheticWallet(
+        wallet::PQCUsageReport report,
+        std::shared_ptr<SyntheticWalletState> state,
+        bool background_clone = false)
+        : m_report(std::move(report)), m_state(std::move(state)), m_background_clone(background_clone)
+    {
+    }
+    explicit SyntheticWallet(interfaces::P2MRDataSignatureResult result)
+        : m_p2mr_result(std::move(result)),
+          m_state(std::make_shared<SyntheticWalletState>()),
+          m_background_clone(false)
+    {
+    }
+
+    ~SyntheticWallet() override
+    {
+        if (!m_background_clone) return;
+        {
+            std::lock_guard lock{m_state->mutex};
+            m_state->background_clone_destroyed = true;
+        }
+        m_state->condition.notify_all();
+    }
+
+    bool encryptWallet(const SecureString&) override { return false; }
+    bool isCrypted() override
+    {
+        std::lock_guard lock{m_state->mutex};
+        return m_state->encrypted;
+    }
+    bool lock() override
+    {
+        std::lock_guard lock{m_state->mutex};
+        m_state->locked = true;
+        ++m_state->lock_calls;
+        return true;
+    }
+    bool unlock(const SecureString&) override
+    {
+        std::lock_guard lock{m_state->mutex};
+        m_state->locked = false;
+        ++m_state->unlock_calls;
+        return true;
+    }
+    bool isLocked() override
+    {
+        std::lock_guard lock{m_state->mutex};
+        return m_state->locked;
+    }
+    bool changeWalletPassphrase(const SecureString&, const SecureString&) override { return false; }
+    void abortRescan() override {}
+    bool backupWallet(const std::string&) override { return false; }
+    std::string getWalletName() override { return "synthetic-pqc-report"; }
+    std::unique_ptr<interfaces::Wallet> clone() override
+    {
+        return std::make_unique<SyntheticWallet>(m_report, m_state, /*background_clone=*/true);
+    }
+    util::Result<CTxDestination> getNewDestination(const OutputType, const std::string&) override { return CTxDestination{PKHash{}}; }
+    bool getPubKey(const CScript&, const CKeyID&, CPubKey&) override { return false; }
+    SigningResult signMessage(const std::string&, const PKHash&, std::string&) override { return SigningResult::PRIVATE_KEY_NOT_AVAILABLE; }
+    util::Result<interfaces::P2MRDataSignatureResult> signP2MRDataHash(const CTxDestination&, const uint256&) override
+    {
+        if (!m_p2mr_result) return util::Error{Untranslated("P2MR data-hash signing unavailable")};
+        return *m_p2mr_result;
+    }
+    bool isSpendable(const CTxDestination&) override { return false; }
+    bool setAddressBook(const CTxDestination&, const std::string&, const std::optional<wallet::AddressPurpose>&) override { return false; }
+    bool delAddressBook(const CTxDestination&) override { return false; }
+    bool getAddress(const CTxDestination&, std::string*, wallet::AddressPurpose*) override { return false; }
+    std::vector<interfaces::WalletAddress> getAddresses() override { return {}; }
+    std::vector<OutputType> getAvailableAddressTypes() override { return {OutputType::P2MR}; }
+    std::vector<std::string> getAddressReceiveRequests() override { return {}; }
+    bool setAddressReceiveRequest(const CTxDestination&, const std::string&, const std::string&) override { return false; }
+    util::Result<void> displayAddress(const CTxDestination&) override { return {}; }
+    bool lockCoin(const COutPoint&, const bool) override { return false; }
+    bool unlockCoin(const COutPoint&) override { return false; }
+    bool isLockedCoin(const COutPoint&) override { return false; }
+    void listLockedCoins(std::vector<COutPoint>&) override {}
+    util::Result<CTransactionRef> createTransaction(const std::vector<wallet::CRecipient>& recipients,
+        const wallet::CCoinControl&,
+        bool,
+        int& change_pos,
+        CAmount& fee,
+        wallet::PQCUsageReport* pqc_usage,
+        const SigningProgressCallback& progress_callback) override
+    {
+        bool wait_for_cancel{false};
+        {
+            std::unique_lock lock{m_state->mutex};
+            m_state->create_entered = true;
+            wait_for_cancel = m_state->wait_for_cancel;
+            m_state->condition.notify_all();
+            if (!wait_for_cancel) {
+                m_state->condition.wait(lock, [this] { return m_state->allow_create; });
+            }
+        }
+
+        bool cancel_observed{false};
+        if (wait_for_cancel) {
+            while (true) {
+                {
+                    std::lock_guard lock{m_state->mutex};
+                    if (m_state->allow_create) break;
+                }
+                if (progress_callback && !progress_callback(SigningProgress{
+                        .phase = SigningProgressPhase::PREPARING_TRANSACTION,
+                        .completed = 0,
+                        .total = 1,
+                        .cancellable = true,
+                    })) {
+                    cancel_observed = true;
+                    break;
+                }
+                std::unique_lock lock{m_state->mutex};
+                m_state->condition.wait_for(lock, 10ms, [this] { return m_state->allow_create; });
+            }
+        }
+
+        {
+            std::lock_guard lock{m_state->mutex};
+            m_state->cancel_observed = cancel_observed;
+            m_state->create_finished = true;
+        }
+        m_state->condition.notify_all();
+        if (cancel_observed) {
+            return util::Error{Untranslated("Transaction preparation cancelled")};
+        }
+
+        CMutableTransaction tx;
+        if (!recipients.empty()) {
+            tx.vout.emplace_back(recipients.front().nAmount, CScript{} << OP_TRUE);
+        }
+        change_pos = -1;
+        fee = 1000;
+        if (pqc_usage) {
+            *pqc_usage = m_report;
+        }
+        return MakeTransactionRef(std::move(tx));
+    }
+    void commitTransaction(CTransactionRef, interfaces::WalletValueMap, interfaces::WalletOrderForm) override {}
+    bool transactionCanBeAbandoned(const Txid&) override { return false; }
+    bool abandonTransaction(const Txid&) override { return false; }
+    bool transactionCanBeBumped(const Txid&) override { return false; }
+    bool createBumpTransaction(const Txid&, const wallet::CCoinControl&, std::vector<bilingual_str>&, CAmount&, CAmount&, CMutableTransaction&) override { return false; }
+    bool signBumpTransaction(CMutableTransaction&) override { return false; }
+    bool commitBumpTransaction(const Txid&, CMutableTransaction&&, std::vector<bilingual_str>&, Txid&) override { return false; }
+    CTransactionRef getTx(const Txid&) override { return {}; }
+    interfaces::WalletTx getWalletTx(const Txid&) override { return {}; }
+    std::set<interfaces::WalletTx> getWalletTxs() override { return {}; }
+    bool tryGetTxStatus(const Txid&, interfaces::WalletTxStatus&, int&, int64_t&) override { return false; }
+    interfaces::WalletTx getWalletTxDetails(const Txid&, interfaces::WalletTxStatus&, interfaces::WalletOrderForm&, bool&, int&) override { return {}; }
+    std::optional<common::PSBTError> fillPSBT(std::optional<int>, bool, bool, size_t*, PartiallySignedTransaction&, bool&, wallet::PQCUsageReport*) override { return std::nullopt; }
+    interfaces::WalletBalances getBalances() override { return {.balance = 50 * COIN}; }
+    bool tryGetBalances(interfaces::WalletBalances& balances, uint256&) override
+    {
+        balances = getBalances();
+        return true;
+    }
+    CAmount getBalance() override { return 50 * COIN; }
+    CAmount getAvailableBalance(const wallet::CCoinControl&) override { return 50 * COIN; }
+    bool txinIsMine(const CTxIn&) override { return false; }
+    bool txoutIsMine(const CTxOut&) override { return false; }
+    CAmount getDebit(const CTxIn&) override { return 0; }
+    CAmount getCredit(const CTxOut&) override { return 0; }
+    CoinsList listCoins() override { return {}; }
+    std::vector<interfaces::WalletTxOut> getCoins(const std::vector<COutPoint>&) override { return {}; }
+    CAmount getRequiredFee(unsigned int) override { return 0; }
+    CAmount getMinimumFee(unsigned int, const wallet::CCoinControl&, int* returned_target, FeeReason* reason) override
+    {
+        if (returned_target) *returned_target = 6;
+        if (reason) *reason = FeeReason::NONE;
+        return 0;
+    }
+    unsigned int getConfirmTarget() override { return 6; }
+    bool hdEnabled() override { return true; }
+    bool canGetAddresses() override { return true; }
+    bool privateKeysDisabled() override { return false; }
+    bool taprootEnabled() override { return false; }
+    bool hasExternalSigner() override { return false; }
+    OutputType getDefaultAddressType() override { return OutputType::P2MR; }
+    CAmount getDefaultMaxTxFee() override { return MAX_MONEY; }
+    wallet::PQCKeyValidationInfo getPQCKeyValidationInfo() const override { return {}; }
+    void remove() override {}
+    std::unique_ptr<interfaces::Handler> handleUnload(UnloadFn) override { return interfaces::MakeCleanupHandler([] {}); }
+    std::unique_ptr<interfaces::Handler> handleShowProgress(ShowProgressFn) override { return interfaces::MakeCleanupHandler([] {}); }
+    std::unique_ptr<interfaces::Handler> handleStatusChanged(StatusChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
+    std::unique_ptr<interfaces::Handler> handleAddressBookChanged(AddressBookChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
+    std::unique_ptr<interfaces::Handler> handleTransactionChanged(TransactionChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
+    std::unique_ptr<interfaces::Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
+
+private:
+    wallet::PQCUsageReport m_report;
+    std::optional<interfaces::P2MRDataSignatureResult> m_p2mr_result;
+    std::shared_ptr<SyntheticWalletState> m_state;
+    const bool m_background_clone;
+};
+
+} // namespace
+
+std::unique_ptr<interfaces::Wallet> MakeSyntheticWallet(
+    wallet::PQCUsageReport report,
+    std::shared_ptr<SyntheticWalletState> state)
+{
+    return std::make_unique<SyntheticWallet>(std::move(report), std::move(state));
+}
+
+std::unique_ptr<interfaces::Wallet> MakeSyntheticWallet(interfaces::P2MRDataSignatureResult result)
+{
+    return std::make_unique<SyntheticWallet>(std::move(result));
+}
+
+} // namespace qt_test

--- a/src/qt/test/syntheticwallet.h
+++ b/src/qt/test/syntheticwallet.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef QBIT_QT_TEST_SYNTHETICWALLET_H
+#define QBIT_QT_TEST_SYNTHETICWALLET_H
+
+#include <interfaces/wallet.h>
+#include <wallet/pqc_usage.h>
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+namespace qt_test {
+
+struct SyntheticWalletState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool create_entered{false};
+    bool allow_create{true};
+    bool wait_for_cancel{false};
+    bool cancel_observed{false};
+    bool create_finished{false};
+    bool background_clone_destroyed{false};
+    bool shutdown_complete{false};
+    bool watchdog_released{false};
+    bool encrypted{false};
+    bool locked{false};
+    int lock_calls{0};
+    int unlock_calls{0};
+};
+
+std::unique_ptr<interfaces::Wallet> MakeSyntheticWallet(
+    wallet::PQCUsageReport report = {},
+    std::shared_ptr<SyntheticWalletState> state = std::make_shared<SyntheticWalletState>());
+std::unique_ptr<interfaces::Wallet> MakeSyntheticWallet(interfaces::P2MRDataSignatureResult result);
+
+} // namespace qt_test
+
+#endif // QBIT_QT_TEST_SYNTHETICWALLET_H

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -9,7 +9,6 @@
 #include <common/p2mr_data_signature.h>
 #include <crypto/pqc.h>
 #include <interfaces/chain.h>
-#include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <node/interface_ui.h>
@@ -26,6 +25,7 @@
 #include <qt/sendcoinsdialog.h>
 #include <qt/sendcoinsentry.h>
 #include <qt/signverifymessagedialog.h>
+#include <qt/test/syntheticwallet.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
 #include <qt/walletmodel.h>
@@ -46,9 +46,7 @@
 
 #include <array>
 #include <chrono>
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 #include <set>
 #include <span>
 #include <utility>
@@ -548,182 +546,6 @@ public:
 
 };
 
-struct SyntheticWalletState {
-    std::mutex mutex;
-    std::condition_variable condition;
-    bool create_entered{false};
-    bool allow_create{true};
-    bool background_clone_destroyed{false};
-    bool encrypted{false};
-    bool locked{false};
-    int lock_calls{0};
-    int unlock_calls{0};
-};
-
-class SyntheticPQCReportWallet : public interfaces::Wallet
-{
-public:
-    explicit SyntheticPQCReportWallet(
-        wallet::PQCUsageReport report = {},
-        std::shared_ptr<SyntheticWalletState> state = std::make_shared<SyntheticWalletState>(),
-        bool background_clone = false)
-        : m_report(std::move(report)), m_state(std::move(state)), m_background_clone(background_clone)
-    {
-    }
-    explicit SyntheticPQCReportWallet(interfaces::P2MRDataSignatureResult result)
-        : SyntheticPQCReportWallet()
-    {
-        m_p2mr_result = std::move(result);
-    }
-
-    ~SyntheticPQCReportWallet() override
-    {
-        if (!m_background_clone) return;
-        {
-            std::lock_guard lock{m_state->mutex};
-            m_state->background_clone_destroyed = true;
-        }
-        m_state->condition.notify_all();
-    }
-
-    bool encryptWallet(const SecureString&) override { return false; }
-    bool isCrypted() override
-    {
-        std::lock_guard lock{m_state->mutex};
-        return m_state->encrypted;
-    }
-    bool lock() override
-    {
-        std::lock_guard lock{m_state->mutex};
-        m_state->locked = true;
-        ++m_state->lock_calls;
-        return true;
-    }
-    bool unlock(const SecureString&) override
-    {
-        std::lock_guard lock{m_state->mutex};
-        m_state->locked = false;
-        ++m_state->unlock_calls;
-        return true;
-    }
-    bool isLocked() override
-    {
-        std::lock_guard lock{m_state->mutex};
-        return m_state->locked;
-    }
-    bool changeWalletPassphrase(const SecureString&, const SecureString&) override { return false; }
-    void abortRescan() override {}
-    bool backupWallet(const std::string&) override { return false; }
-    std::string getWalletName() override { return "synthetic-pqc-report"; }
-    std::unique_ptr<interfaces::Wallet> clone() override
-    {
-        return std::make_unique<SyntheticPQCReportWallet>(m_report, m_state, /*background_clone=*/true);
-    }
-    util::Result<CTxDestination> getNewDestination(const OutputType, const std::string&) override { return CTxDestination{PKHash{}}; }
-    bool getPubKey(const CScript&, const CKeyID&, CPubKey&) override { return false; }
-    SigningResult signMessage(const std::string&, const PKHash&, std::string&) override { return SigningResult::PRIVATE_KEY_NOT_AVAILABLE; }
-    util::Result<interfaces::P2MRDataSignatureResult> signP2MRDataHash(const CTxDestination&, const uint256&) override
-    {
-        if (!m_p2mr_result) return util::Error{Untranslated("P2MR data-hash signing unavailable")};
-        return *m_p2mr_result;
-    }
-    bool isSpendable(const CTxDestination&) override { return false; }
-    bool setAddressBook(const CTxDestination&, const std::string&, const std::optional<wallet::AddressPurpose>&) override { return false; }
-    bool delAddressBook(const CTxDestination&) override { return false; }
-    bool getAddress(const CTxDestination&, std::string*, wallet::AddressPurpose*) override { return false; }
-    std::vector<interfaces::WalletAddress> getAddresses() override { return {}; }
-    std::vector<OutputType> getAvailableAddressTypes() override { return {OutputType::P2MR}; }
-    std::vector<std::string> getAddressReceiveRequests() override { return {}; }
-    bool setAddressReceiveRequest(const CTxDestination&, const std::string&, const std::string&) override { return false; }
-    util::Result<void> displayAddress(const CTxDestination&) override { return {}; }
-    bool lockCoin(const COutPoint&, const bool) override { return false; }
-    bool unlockCoin(const COutPoint&) override { return false; }
-    bool isLockedCoin(const COutPoint&) override { return false; }
-    void listLockedCoins(std::vector<COutPoint>&) override {}
-    util::Result<CTransactionRef> createTransaction(const std::vector<wallet::CRecipient>& recipients,
-        const wallet::CCoinControl&,
-        bool,
-        int& change_pos,
-        CAmount& fee,
-        wallet::PQCUsageReport* pqc_usage,
-        const SigningProgressCallback&) override
-    {
-        {
-            std::unique_lock lock{m_state->mutex};
-            m_state->create_entered = true;
-            m_state->condition.notify_all();
-            m_state->condition.wait(lock, [this] { return m_state->allow_create; });
-        }
-
-        CMutableTransaction tx;
-        if (!recipients.empty()) {
-            tx.vout.emplace_back(recipients.front().nAmount, CScript{} << OP_TRUE);
-        }
-        change_pos = -1;
-        fee = 1000;
-        if (pqc_usage) {
-            *pqc_usage = m_report;
-        }
-        return MakeTransactionRef(std::move(tx));
-    }
-    void commitTransaction(CTransactionRef, interfaces::WalletValueMap, interfaces::WalletOrderForm) override {}
-    bool transactionCanBeAbandoned(const Txid&) override { return false; }
-    bool abandonTransaction(const Txid&) override { return false; }
-    bool transactionCanBeBumped(const Txid&) override { return false; }
-    bool createBumpTransaction(const Txid&, const wallet::CCoinControl&, std::vector<bilingual_str>&, CAmount&, CAmount&, CMutableTransaction&) override { return false; }
-    bool signBumpTransaction(CMutableTransaction&) override { return false; }
-    bool commitBumpTransaction(const Txid&, CMutableTransaction&&, std::vector<bilingual_str>&, Txid&) override { return false; }
-    CTransactionRef getTx(const Txid&) override { return {}; }
-    interfaces::WalletTx getWalletTx(const Txid&) override { return {}; }
-    std::set<interfaces::WalletTx> getWalletTxs() override { return {}; }
-    bool tryGetTxStatus(const Txid&, interfaces::WalletTxStatus&, int&, int64_t&) override { return false; }
-    interfaces::WalletTx getWalletTxDetails(const Txid&, interfaces::WalletTxStatus&, interfaces::WalletOrderForm&, bool&, int&) override { return {}; }
-    std::optional<common::PSBTError> fillPSBT(std::optional<int>, bool, bool, size_t*, PartiallySignedTransaction&, bool&, wallet::PQCUsageReport*) override { return std::nullopt; }
-    interfaces::WalletBalances getBalances() override { return {.balance = 50 * COIN}; }
-    bool tryGetBalances(interfaces::WalletBalances& balances, uint256&) override
-    {
-        balances = getBalances();
-        return true;
-    }
-    CAmount getBalance() override { return 50 * COIN; }
-    CAmount getAvailableBalance(const wallet::CCoinControl&) override { return 50 * COIN; }
-    bool txinIsMine(const CTxIn&) override { return false; }
-    bool txoutIsMine(const CTxOut&) override { return false; }
-    CAmount getDebit(const CTxIn&) override { return 0; }
-    CAmount getCredit(const CTxOut&) override { return 0; }
-    CoinsList listCoins() override { return {}; }
-    std::vector<interfaces::WalletTxOut> getCoins(const std::vector<COutPoint>&) override { return {}; }
-    CAmount getRequiredFee(unsigned int) override { return 0; }
-    CAmount getMinimumFee(unsigned int, const wallet::CCoinControl&, int* returned_target, FeeReason* reason) override
-    {
-        if (returned_target) *returned_target = 6;
-        if (reason) *reason = FeeReason::NONE;
-        return 0;
-    }
-    unsigned int getConfirmTarget() override { return 6; }
-    bool hdEnabled() override { return true; }
-    bool canGetAddresses() override { return true; }
-    bool privateKeysDisabled() override { return false; }
-    bool taprootEnabled() override { return false; }
-    bool hasExternalSigner() override { return false; }
-    OutputType getDefaultAddressType() override { return OutputType::P2MR; }
-    CAmount getDefaultMaxTxFee() override { return MAX_MONEY; }
-    wallet::PQCKeyValidationInfo getPQCKeyValidationInfo() const override { return {}; }
-    void remove() override {}
-    std::unique_ptr<interfaces::Handler> handleUnload(UnloadFn) override { return interfaces::MakeCleanupHandler([] {}); }
-    std::unique_ptr<interfaces::Handler> handleShowProgress(ShowProgressFn) override { return interfaces::MakeCleanupHandler([] {}); }
-    std::unique_ptr<interfaces::Handler> handleStatusChanged(StatusChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
-    std::unique_ptr<interfaces::Handler> handleAddressBookChanged(AddressBookChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
-    std::unique_ptr<interfaces::Handler> handleTransactionChanged(TransactionChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
-    std::unique_ptr<interfaces::Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
-
-private:
-    wallet::PQCUsageReport m_report;
-    std::optional<interfaces::P2MRDataSignatureResult> m_p2mr_result;
-    std::shared_ptr<SyntheticWalletState> m_state;
-    const bool m_background_clone;
-};
-
 //! Simple qt wallet tests.
 //
 // Test widgets can be debugged interactively calling show() on them and
@@ -1175,7 +997,7 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
         .pqc_usage = std::make_shared<const wallet::PQCUsageReport>(retry_report),
     };
 
-    WalletModel proof_wallet_model(std::make_unique<SyntheticPQCReportWallet>(synthetic_result), *mini_gui.clientModel, platformStyle.get());
+    WalletModel proof_wallet_model(qt_test::MakeSyntheticWallet(synthetic_result), *mini_gui.clientModel, platformStyle.get());
     SignVerifyMessageDialog proof_dialog(platformStyle.get(), nullptr);
     proof_dialog.setModel(&proof_wallet_model);
 
@@ -1302,7 +1124,7 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     });
     synthetic_result.pqc_usage = std::make_shared<const wallet::PQCUsageReport>(single_key_report);
 
-    WalletModel single_key_wallet_model(std::make_unique<SyntheticPQCReportWallet>(synthetic_result), *mini_gui.clientModel, platformStyle.get());
+    WalletModel single_key_wallet_model(qt_test::MakeSyntheticWallet(synthetic_result), *mini_gui.clientModel, platformStyle.get());
     SignVerifyMessageDialog single_key_dialog(platformStyle.get(), nullptr);
     single_key_dialog.setModel(&single_key_wallet_model);
     QValidatedLineEdit* single_key_address = single_key_dialog.findChild<QValidatedLineEdit*>("addressIn_SM");
@@ -1355,7 +1177,7 @@ void TestSendPQCReportPropagation(interfaces::Node& node)
     });
     expected_report.overall_state = wallet::PQCSignatureLimitState::NORMAL;
 
-    WalletModel wallet_model(std::make_unique<SyntheticPQCReportWallet>(expected_report), client_model, platformStyle.get());
+    WalletModel wallet_model(qt_test::MakeSyntheticWallet(expected_report), client_model, platformStyle.get());
     wallet::CCoinControl coin_control;
     coin_control.Select(COutPoint{Txid{}, 0});
 
@@ -1379,8 +1201,8 @@ void TestSendCompletionAfterModelDestruction(interfaces::Node& node)
 
     std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
     MiniGUI mini_gui{node, platform_style.get()};
-    auto state{std::make_shared<SyntheticWalletState>()};
-    mini_gui.initModel(std::make_unique<SyntheticPQCReportWallet>(wallet::PQCUsageReport{}, state), platform_style.get());
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    mini_gui.initModel(qt_test::MakeSyntheticWallet(wallet::PQCUsageReport{}, state), platform_style.get());
     mini_gui.walletModel->pollBalanceChanged();
 
     SendCoinsDialog& send_dialog{mini_gui.sendCoinsDialog};
@@ -1430,14 +1252,14 @@ void TestUnlockContextModelLifetime(interfaces::Node& node)
     QVERIFY(options_model.Init(error));
     ClientModel client_model{node, &options_model};
 
-    auto state{std::make_shared<SyntheticWalletState>()};
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
     {
         std::lock_guard lock{state->mutex};
         state->encrypted = true;
         state->locked = false;
     }
     auto wallet_model{std::make_unique<WalletModel>(
-        std::make_unique<SyntheticPQCReportWallet>(wallet::PQCUsageReport{}, state),
+        qt_test::MakeSyntheticWallet(wallet::PQCUsageReport{}, state),
         client_model,
         platform_style.get())};
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -46,7 +46,9 @@
 
 #include <array>
 #include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <span>
 #include <utility>
@@ -65,6 +67,7 @@
 #include <QPointer>
 #include <QPlainTextEdit>
 #include <QPushButton>
+#include <QSignalSpy>
 #include <QTabWidget>
 #include <QTimer>
 #include <QVBoxLayout>
@@ -536,23 +539,86 @@ public:
         transactionView.setModel(walletModel.get());
     }
 
+    void initModel(std::unique_ptr<interfaces::Wallet> wallet, const PlatformStyle* platformStyle)
+    {
+        walletModel = std::make_unique<WalletModel>(std::move(wallet), *clientModel, platformStyle);
+        sendCoinsDialog.setModel(walletModel.get());
+        transactionView.setModel(walletModel.get());
+    }
+
+};
+
+struct SyntheticWalletState {
+    std::mutex mutex;
+    std::condition_variable condition;
+    bool create_entered{false};
+    bool allow_create{true};
+    bool background_clone_destroyed{false};
+    bool encrypted{false};
+    bool locked{false};
+    int lock_calls{0};
+    int unlock_calls{0};
 };
 
 class SyntheticPQCReportWallet : public interfaces::Wallet
 {
 public:
-    explicit SyntheticPQCReportWallet(wallet::PQCUsageReport report) : m_report(std::move(report)) {}
-    explicit SyntheticPQCReportWallet(interfaces::P2MRDataSignatureResult result) : m_p2mr_result(std::move(result)) {}
+    explicit SyntheticPQCReportWallet(
+        wallet::PQCUsageReport report = {},
+        std::shared_ptr<SyntheticWalletState> state = std::make_shared<SyntheticWalletState>(),
+        bool background_clone = false)
+        : m_report(std::move(report)), m_state(std::move(state)), m_background_clone(background_clone)
+    {
+    }
+    explicit SyntheticPQCReportWallet(interfaces::P2MRDataSignatureResult result)
+        : SyntheticPQCReportWallet()
+    {
+        m_p2mr_result = std::move(result);
+    }
+
+    ~SyntheticPQCReportWallet() override
+    {
+        if (!m_background_clone) return;
+        {
+            std::lock_guard lock{m_state->mutex};
+            m_state->background_clone_destroyed = true;
+        }
+        m_state->condition.notify_all();
+    }
 
     bool encryptWallet(const SecureString&) override { return false; }
-    bool isCrypted() override { return false; }
-    bool lock() override { return false; }
-    bool unlock(const SecureString&) override { return true; }
-    bool isLocked() override { return false; }
+    bool isCrypted() override
+    {
+        std::lock_guard lock{m_state->mutex};
+        return m_state->encrypted;
+    }
+    bool lock() override
+    {
+        std::lock_guard lock{m_state->mutex};
+        m_state->locked = true;
+        ++m_state->lock_calls;
+        return true;
+    }
+    bool unlock(const SecureString&) override
+    {
+        std::lock_guard lock{m_state->mutex};
+        m_state->locked = false;
+        ++m_state->unlock_calls;
+        return true;
+    }
+    bool isLocked() override
+    {
+        std::lock_guard lock{m_state->mutex};
+        return m_state->locked;
+    }
     bool changeWalletPassphrase(const SecureString&, const SecureString&) override { return false; }
     void abortRescan() override {}
     bool backupWallet(const std::string&) override { return false; }
     std::string getWalletName() override { return "synthetic-pqc-report"; }
+    std::unique_ptr<interfaces::Wallet> clone() override
+    {
+        return std::make_unique<SyntheticPQCReportWallet>(m_report, m_state, /*background_clone=*/true);
+    }
     util::Result<CTxDestination> getNewDestination(const OutputType, const std::string&) override { return CTxDestination{PKHash{}}; }
     bool getPubKey(const CScript&, const CKeyID&, CPubKey&) override { return false; }
     SigningResult signMessage(const std::string&, const PKHash&, std::string&) override { return SigningResult::PRIVATE_KEY_NOT_AVAILABLE; }
@@ -582,6 +648,13 @@ public:
         wallet::PQCUsageReport* pqc_usage,
         const SigningProgressCallback&) override
     {
+        {
+            std::unique_lock lock{m_state->mutex};
+            m_state->create_entered = true;
+            m_state->condition.notify_all();
+            m_state->condition.wait(lock, [this] { return m_state->allow_create; });
+        }
+
         CMutableTransaction tx;
         if (!recipients.empty()) {
             tx.vout.emplace_back(recipients.front().nAmount, CScript{} << OP_TRUE);
@@ -647,6 +720,8 @@ public:
 private:
     wallet::PQCUsageReport m_report;
     std::optional<interfaces::P2MRDataSignatureResult> m_p2mr_result;
+    std::shared_ptr<SyntheticWalletState> m_state;
+    const bool m_background_clone;
 };
 
 //! Simple qt wallet tests.
@@ -1297,6 +1372,92 @@ void TestSendPQCReportPropagation(interfaces::Node& node)
     QCOMPARE(pqc_usage.key_states.front().signatures_remaining, PQC_MAX_SIGNATURES - 7);
 }
 
+void TestSendCompletionAfterModelDestruction(interfaces::Node& node)
+{
+    TestChain100Setup test{ChainType::REGTEST, {.extra_args = {"-p2mronly=0"}}};
+    node.setContext(&test.m_node);
+
+    std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    MiniGUI mini_gui{node, platform_style.get()};
+    auto state{std::make_shared<SyntheticWalletState>()};
+    mini_gui.initModel(std::make_unique<SyntheticPQCReportWallet>(wallet::PQCUsageReport{}, state), platform_style.get());
+    mini_gui.walletModel->pollBalanceChanged();
+
+    SendCoinsDialog& send_dialog{mini_gui.sendCoinsDialog};
+    QVBoxLayout* const entries{send_dialog.findChild<QVBoxLayout*>("entries")};
+    QVERIFY(entries);
+    SendCoinsEntry* const entry{qobject_cast<SendCoinsEntry*>(entries->itemAt(0)->widget())};
+    QVERIFY(entry);
+    entry->findChild<QValidatedLineEdit*>("payTo")->setText(QString::fromStdString(EncodeDestination(PKHash{})));
+    entry->findChild<BitcoinAmountField*>("payAmount")->setValue(COIN);
+    send_dialog.getCoinControl()->Select(COutPoint{Txid{}, 0});
+
+    QSignalSpy coins_sent{&send_dialog, &SendCoinsDialog::coinsSent};
+    QVERIFY(coins_sent.isValid());
+    QVERIFY(QMetaObject::invokeMethod(&send_dialog, "sendButtonClicked", Q_ARG(bool, false)));
+
+    {
+        std::unique_lock lock{state->mutex};
+        QVERIFY(state->condition.wait_for(lock, std::chrono::seconds{5}, [state] {
+            return state->background_clone_destroyed;
+        }));
+        QVERIFY(state->create_entered);
+    }
+
+    QPointer<WalletModel> model_guard{mini_gui.walletModel.get()};
+    mini_gui.walletModel.reset();
+    QVERIFY(model_guard.isNull());
+
+    // The worker destroyed its cloned wallet only after queueing completion.
+    // Deliver that completion while the dialog is alive but its model is gone.
+    QCoreApplication::sendPostedEvents(&send_dialog, QEvent::MetaCall);
+    QCoreApplication::processEvents();
+
+    QCOMPARE(coins_sent.count(), 0);
+    for (QWidget* widget : QApplication::topLevelWidgets()) {
+        QVERIFY(!widget->inherits("SendConfirmationDialog"));
+    }
+}
+
+void TestUnlockContextModelLifetime(interfaces::Node& node)
+{
+    TestChain100Setup test{ChainType::REGTEST, {.extra_args = {"-p2mronly=0"}}};
+    node.setContext(&test.m_node);
+
+    std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    OptionsModel options_model{node};
+    bilingual_str error;
+    QVERIFY(options_model.Init(error));
+    ClientModel client_model{node, &options_model};
+
+    auto state{std::make_shared<SyntheticWalletState>()};
+    {
+        std::lock_guard lock{state->mutex};
+        state->encrypted = true;
+        state->locked = false;
+    }
+    auto wallet_model{std::make_unique<WalletModel>(
+        std::make_unique<SyntheticPQCReportWallet>(wallet::PQCUsageReport{}, state),
+        client_model,
+        platform_style.get())};
+
+    auto lock_calls = [state] {
+        std::lock_guard lock{state->mutex};
+        return state->lock_calls;
+    };
+
+    {
+        WalletModel::UnlockContext live_context{wallet_model.get(), /*valid=*/true, /*relock=*/true};
+    }
+    QCOMPARE(lock_calls(), 1);
+
+    auto stale_context{std::make_unique<WalletModel::UnlockContext>(
+        wallet_model.get(), /*valid=*/true, /*relock=*/true)};
+    wallet_model.reset();
+    stale_context.reset();
+    QCOMPARE(lock_calls(), 1);
+}
+
 void TestSendPQCWarningFormatting()
 {
     CPQCKey key;
@@ -1366,5 +1527,7 @@ void WalletTests::walletTests()
     TestGUI(m_node);
     TestP2MRReceiveAddressTypes(m_node);
     TestSendPQCReportPropagation(m_node);
+    TestSendCompletionAfterModelDestruction(m_node);
+    TestUnlockContextModelLifetime(m_node);
     TestSendPQCWarningFormatting();
 }

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -123,12 +123,9 @@ void WalletFrame::removeWallet(WalletModel* wallet_model)
     delete walletView;
 }
 
-void WalletFrame::removeAllWallets()
+QList<WalletModel*> WalletFrame::getWalletModels() const
 {
-    QMap<WalletModel*, WalletView*>::const_iterator i;
-    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
-        walletStack->removeWidget(i.value());
-    mapWalletViews.clear();
+    return mapWalletViews.keys();
 }
 
 bool WalletFrame::handlePaymentRequest(const SendCoinsRecipient &recipient)

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -6,6 +6,7 @@
 #define QBIT_QT_WALLETFRAME_H
 
 #include <QFrame>
+#include <QList>
 #include <QMap>
 
 class ClientModel;
@@ -38,7 +39,7 @@ public:
     bool addView(WalletView* walletView);
     void setCurrentWallet(WalletModel* wallet_model);
     void removeWallet(WalletModel* wallet_model);
-    void removeAllWallets();
+    QList<WalletModel*> getWalletModels() const;
 
     bool handlePaymentRequest(const SendCoinsRecipient& recipient);
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -559,7 +559,7 @@ WalletModel::UnlockContext::UnlockContext(WalletModel *_wallet, bool _valid, boo
 }
 
 WalletModel::UnlockContext::UnlockContext(UnlockContext&& other) noexcept:
-        wallet(other.wallet),
+        wallet(std::move(other.wallet)),
         valid(other.valid),
         relock(other.relock)
 {

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include <QObject>
+#include <QPointer>
 
 enum class OutputType;
 
@@ -124,7 +125,7 @@ public:
         UnlockContext& operator=(UnlockContext&&) = delete;
 
     private:
-        WalletModel *wallet;
+        QPointer<WalletModel> wallet;
         bool valid;
         bool relock;
     };


### PR DESCRIPTION
## Summary

Fixes #80.

Qt shutdown deleted `WalletModel` objects before their wallet views. A `SendCoinsDialog` background completion or temporary `WalletModel::UnlockContext` could consequently retain a dangling model pointer and access it during shutdown.

This change:

- removes every wallet view before deleting the wallet controller and its models;
- makes bulk removal use the normal GUI, selector, and RPC-console cleanup path;
- guards send-dialog and unlock-context model references with `QPointer`;
- discards queued send completion safely when its model has already been destroyed; and
- adds deterministic coverage for multi-wallet teardown ordering, queued completion after model destruction, and stale unlock-context destruction.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason: N/A

Validation performed:

- Full `test_qbit-qt` suite.
- Full `test_qbit-qt` suite with AddressSanitizer and UndefinedBehaviorSanitizer.
- `test_qbit --run_test=wallet_p2mr_parallel_signing_tests --log_level=test_suite` (10/10 passed).
- Repository lint suite using `ci/lint_imagefile` in Docker.
- `git diff --check`.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

This PR targets the `1.0.0` release branch.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

The change affects Qt wallet object lifetime and shutdown sequencing only. It does not alter consensus, transaction construction, signing logic, wallet persistence, or network behavior. The primary review focus is destruction order and delivery of queued Qt callbacks.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: This is an internal shutdown lifetime fix with no interface or workflow changes.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

Not applicable; `src/libbitcoinpqc` is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786297858&installation_id=141183937&pr_number=90&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F90&signature=581fefff518add29671396e6cd1cc13a3570218c9709fc0612ffd1be578758d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Qt shutdown sequencing and wallet UI lifetime during async send/unlock; no consensus or on-chain behavior changes, but incorrect ordering could still cause shutdown hangs or use-after-free in the GUI.
> 
> **Overview**
> Fixes **Qt wallet shutdown** when `WalletModel` was destroyed while `SendCoinsDialog` background workers or `UnlockContext` still held raw pointers.
> 
> **Shutdown order:** `requestShutdown()` now calls `window->removeAllWallets()` before deleting the wallet controller. Bulk removal iterates `walletFrame->getWalletModels()` and uses `removeWallet()` so selector, RPC console, and per-view teardown (including send workers) run in the normal path instead of `WalletFrame::removeAllWallets()` only clearing the stack.
> 
> **Lifetime guards:** `SendCoinsDialog` and `WalletModel::UnlockContext` store `QPointer<WalletModel>`. `prepareTransactionFinished()` exits early when the model is already gone so queued completions do not show confirmations or touch a dead model.
> 
> **Tests:** Shared `syntheticwallet` test double (with cancellable `createTransaction` and background `clone()` tracking) replaces inline mocks; `AppTests` exercises multi-wallet shutdown under an in-flight send; `wallettests` cover completion after model destruction and stale unlock context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 457526b6410bdd2466632fb4fe4a7ad6dfc6e6dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->