### PR TITLE
qt: minimize P2MR proof exports

### DIFF
--- a/doc/design/p2mr-datapqchash.md
+++ b/doc/design/p2mr-datapqchash.md
@@ -46,9 +46,12 @@ The RPC:
 
 Signing uses the same wallet PQC signing provider path as transaction signing,
 so stateful PQC signature counters advance and the normal PQC usage fields are
-included unless `include_pqc_usage` is set to false.
+included in the RPC result unless `include_pqc_usage` is set to false. These
+fields describe wallet-local operational state and can include public keys from
+failed signing attempts when the wallet retries a later P2MR leaf. Set
+`include_pqc_usage=false` before sharing an RPC result as a portable proof.
 
-The response includes:
+The RPC response includes:
 
 - `address`
 - `message_hash`
@@ -64,11 +67,36 @@ The response includes:
 - `p2mr_merkle_root`
 - optional PQC usage fields
 
+`datasig_hash`, `domain`, `algorithm`, and `p2mr_merkle_root` are informational
+RPC result fields. Verification recomputes the data-signature hash and P2MR
+Merkle root instead of trusting them.
+
+## Portable Proof Schema
+
+A portable `p2mr-pubkey` proof contains only the fields required for stateless
+verification:
+
+- `address`
+- `message_hash`
+- `signature`
+- `pubkey`
+- `leaf_script`
+- `control_block`
+- `leaf_version`
+- `proof_mode`
+
+qbit-qt displays and copies this minimal schema. PQC usage data remains local:
+the signer status continues to show the overall usage state, single-key
+remaining budget, and any threshold or reminder warnings. Counts, limits,
+warnings, and keys observed during retry attempts are not part of the proof
+JSON. Proofs created by older qbit-qt versions can contain those additional
+fields; both Qt and RPC verification continue to accept them.
+
 ## Verification Flow
 
 `verifydatapqchash "p2mr_proof"` is a non-wallet utility RPC.
 
-The proof must include:
+The proof must include the portable proof fields:
 
 - `address`
 - `message_hash`

--- a/doc/release-notes-95.md
+++ b/doc/release-notes-95.md
@@ -1,0 +1,15 @@
+Qt P2MR/PQC proof privacy
+=========================
+
+The qbit-qt Sign/Verify dialog now displays and copies only the fields required
+to verify a P2MR/PQC data-signature proof. Wallet-local PQC signature counts,
+limits, remaining budget, usage states, warnings, and public keys observed in
+failed leaf retry attempts are no longer included in Qt proof JSON.
+
+PQC usage warnings and remaining-budget information continue to be shown in
+the local signer status. Existing proof JSON containing the former optional
+fields remains accepted by both qbit-qt and the `verifydatapqchash` RPC.
+
+The `signdatapqchash` RPC response and its `include_pqc_usage` default are
+unchanged. Set `include_pqc_usage=false` when using that RPC result as a
+portable proof.

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -57,14 +57,6 @@ constexpr int P2MR_SIGN_INPUT_HASH{1};
 constexpr int P2MR_VERIFY_INPUT_TEXT{0};
 constexpr int P2MR_VERIFY_INPUT_HASH{1};
 constexpr int P2MR_VERIFY_INPUT_PROOF_ONLY{2};
-constexpr const char* P2MR_MESSAGE_HASH_SOURCE_UTF8_TEXT{"utf8-text"};
-constexpr const char* P2MR_MESSAGE_HASH_SOURCE_HEX_HASH{"hex-hash"};
-constexpr const char* P2MR_MESSAGE_HASH_ALGORITHM_SHA256{"sha256"};
-
-struct P2MRMessageHashMetadata {
-    std::optional<std::string> source;
-    std::optional<std::string> algorithm;
-};
 
 uint256 HashP2MRUtf8Text(const QString& text)
 {
@@ -218,43 +210,6 @@ bool ParseExpectedP2MRSigner(const QString& address_text, std::optional<WitnessV
     return true;
 }
 
-void AppendPQCUsageJson(UniValue& object, const wallet::PQCUsageReport& report)
-{
-    if (report.key_states.empty()) return;
-
-    UniValue key_states(UniValue::VARR);
-    for (const wallet::PQCUsageSnapshot& key_state : report.key_states) {
-        UniValue state(UniValue::VOBJ);
-        state.pushKV("pubkey", HexStr(std::span<const unsigned char>{key_state.pubkey.begin(), key_state.pubkey.end()}));
-        state.pushKV("pqc_signature_count", static_cast<int64_t>(key_state.signature_count));
-        state.pushKV("pqc_signature_limit", static_cast<int64_t>(key_state.signature_limit));
-        state.pushKV("pqc_signatures_remaining", static_cast<int64_t>(key_state.signatures_remaining));
-        state.pushKV("pqc_limit_state", std::string{wallet::PQCSignatureLimitStateName(key_state.limit_state)});
-        key_states.push_back(std::move(state));
-    }
-    object.pushKV("pqc_key_states", std::move(key_states));
-
-    if (report.overall_state.has_value()) {
-        object.pushKV("pqc_overall_limit_state", std::string{wallet::PQCSignatureLimitStateName(*report.overall_state)});
-    }
-    if (report.key_states.size() == 1) {
-        const wallet::PQCUsageSnapshot& key_state{report.key_states.front()};
-        object.pushKV("pqc_signature_count", static_cast<int64_t>(key_state.signature_count));
-        object.pushKV("pqc_signature_limit", static_cast<int64_t>(key_state.signature_limit));
-        object.pushKV("pqc_signatures_remaining", static_cast<int64_t>(key_state.signatures_remaining));
-        object.pushKV("pqc_limit_state", std::string{wallet::PQCSignatureLimitStateName(key_state.limit_state)});
-    }
-
-    const std::vector<bilingual_str> warnings{wallet::FormatPQCUsageWarnings(report.warnings)};
-    if (!warnings.empty()) {
-        UniValue warning_values(UniValue::VARR);
-        for (const bilingual_str& warning : warnings) {
-            warning_values.push_back(warning.translated.empty() ? warning.original : warning.translated);
-        }
-        object.pushKV("warnings", std::move(warning_values));
-    }
-}
-
 QString FormatPQCUsageStatus(const wallet::PQCUsageReport& report)
 {
     QStringList lines;
@@ -288,31 +243,19 @@ common::P2MRDataSignatureProof MakeP2MRDataSignatureProof(const interfaces::P2MR
     };
 }
 
-UniValue BuildP2MRProofJson(const interfaces::P2MRDataSignatureResult& result, const P2MRMessageHashMetadata& metadata)
+// Keep the portable proof limited to fields consumed by both Qt and RPC
+// verification. Wallet-local usage belongs in the signer status only.
+UniValue BuildP2MRProofJson(const common::P2MRDataSignatureProof& proof)
 {
-    const common::P2MRDataSignatureProof proof{MakeP2MRDataSignatureProof(result)};
     UniValue object(UniValue::VOBJ);
     object.pushKV("address", EncodeDestination(CTxDestination{proof.output}));
     object.pushKV("message_hash", HashToHexString(proof.message_hash));
-    if (metadata.source.has_value()) {
-        object.pushKV("message_hash_source", *metadata.source);
-    }
-    if (metadata.algorithm.has_value()) {
-        object.pushKV("message_hash_algorithm", *metadata.algorithm);
-    }
-    object.pushKV("datasig_hash", HashToHexString(proof.datasig_hash));
-    object.pushKV("domain", common::P2MR_DATA_SIGNATURE_DOMAIN);
-    object.pushKV("algorithm", common::P2MR_DATA_SIGNATURE_ALGORITHM);
     object.pushKV("proof_mode", common::P2MR_DATA_SIGNATURE_PROOF_MODE);
     object.pushKV("pubkey", HexStr(std::span<const unsigned char>{proof.pubkey.begin(), proof.pubkey.end()}));
     object.pushKV("signature", HexStr(proof.signature));
     object.pushKV("leaf_version", static_cast<int>(proof.leaf_version));
     object.pushKV("leaf_script", HexStr(proof.leaf_script));
     object.pushKV("control_block", HexStr(proof.control_block));
-    object.pushKV("p2mr_merkle_root", HashToHexString(proof.output.GetMerkleRoot()));
-    if (result.pqc_usage) {
-        AppendPQCUsageJson(object, *result.pqc_usage);
-    }
     return object;
 }
 
@@ -623,19 +566,16 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
         }
 
         uint256 message_hash;
-        P2MRMessageHashMetadata metadata;
-        if (ui->p2mrDataInputMode_SM->currentIndex() == P2MR_SIGN_INPUT_HASH) {
+        const bool hash_input{ui->p2mrDataInputMode_SM->currentIndex() == P2MR_SIGN_INPUT_HASH};
+        if (hash_input) {
             QString parse_error;
             if (!ParseDataHash(ui->messageIn_SM->document()->toPlainText(), message_hash, parse_error)) {
                 ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
                 ui->statusLabel_SM->setText(parse_error);
                 return;
             }
-            metadata.source = P2MR_MESSAGE_HASH_SOURCE_HEX_HASH;
         } else {
             message_hash = HashP2MRUtf8Text(ui->messageIn_SM->document()->toPlainText());
-            metadata.source = P2MR_MESSAGE_HASH_SOURCE_UTF8_TEXT;
-            metadata.algorithm = P2MR_MESSAGE_HASH_ALGORITHM_SHA256;
         }
         ui->p2mrMessageHash_SM->setText(QString::fromStdString(HashToHexString(message_hash)));
 
@@ -662,10 +602,10 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
             return;
         }
 
-        ui->signatureOut_SM->setPlainText(QString::fromStdString(BuildP2MRProofJson(*result, metadata).write(2)));
-        QString status{metadata.algorithm.has_value() ?
-            tr("P2MR/PQC data proof signed.") :
-            tr("P2MR/PQC data-hash proof signed.")};
+        ui->signatureOut_SM->setPlainText(QString::fromStdString(BuildP2MRProofJson(proof).write(2)));
+        QString status{hash_input ?
+            tr("P2MR/PQC data-hash proof signed.") :
+            tr("P2MR/PQC data proof signed.")};
         const QString pqc_usage_status{result->pqc_usage ? FormatPQCUsageStatus(*result->pqc_usage) : QString{}};
         if (!pqc_usage_status.isEmpty()) {
             status.append("\n");

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -33,6 +33,8 @@
 #include <outputtype.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <rpc/server.h>
+#include <script/p2mr.h>
 #include <script/solver.h>
 #include <consensus/consensus.h>
 #include <test/util/setup_common.h>
@@ -42,8 +44,10 @@
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 
+#include <array>
 #include <chrono>
 #include <memory>
+#include <set>
 #include <span>
 #include <utility>
 
@@ -538,6 +542,7 @@ class SyntheticPQCReportWallet : public interfaces::Wallet
 {
 public:
     explicit SyntheticPQCReportWallet(wallet::PQCUsageReport report) : m_report(std::move(report)) {}
+    explicit SyntheticPQCReportWallet(interfaces::P2MRDataSignatureResult result) : m_p2mr_result(std::move(result)) {}
 
     bool encryptWallet(const SecureString&) override { return false; }
     bool isCrypted() override { return false; }
@@ -551,7 +556,11 @@ public:
     util::Result<CTxDestination> getNewDestination(const OutputType, const std::string&) override { return CTxDestination{PKHash{}}; }
     bool getPubKey(const CScript&, const CKeyID&, CPubKey&) override { return false; }
     SigningResult signMessage(const std::string&, const PKHash&, std::string&) override { return SigningResult::PRIVATE_KEY_NOT_AVAILABLE; }
-    util::Result<interfaces::P2MRDataSignatureResult> signP2MRDataHash(const CTxDestination&, const uint256&) override { return util::Error{Untranslated("P2MR data-hash signing unavailable")}; }
+    util::Result<interfaces::P2MRDataSignatureResult> signP2MRDataHash(const CTxDestination&, const uint256&) override
+    {
+        if (!m_p2mr_result) return util::Error{Untranslated("P2MR data-hash signing unavailable")};
+        return *m_p2mr_result;
+    }
     bool isSpendable(const CTxDestination&) override { return false; }
     bool setAddressBook(const CTxDestination&, const std::string&, const std::optional<wallet::AddressPurpose>&) override { return false; }
     bool delAddressBook(const CTxDestination&) override { return false; }
@@ -637,6 +646,7 @@ public:
 
 private:
     wallet::PQCUsageReport m_report;
+    std::optional<interfaces::P2MRDataSignatureResult> m_p2mr_result;
 };
 
 //! Simple qt wallet tests.
@@ -1019,6 +1029,232 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     QVERIFY(verify_data_input->toPlainText().isEmpty());
     QVERIFY(verify_status->text().isEmpty());
     QVERIFY(verify_status->styleSheet().isEmpty());
+
+    CPQCKey selected_key;
+    selected_key.MakeNewKey();
+    QVERIFY(selected_key.IsValid());
+    const CPQCPubKey selected_pubkey{selected_key.GetPubKey()};
+
+    std::array<unsigned char, PQC_PUBKEY_SIZE> alternate_pubkey_bytes;
+    alternate_pubkey_bytes.fill(0x5a);
+    const CPQCPubKey alternate_pubkey{std::span<const unsigned char>{alternate_pubkey_bytes}};
+    QVERIFY(alternate_pubkey.IsValid());
+    QVERIFY(alternate_pubkey != selected_pubkey);
+
+    const CScript selected_leaf{p2mr::BuildPKScript(selected_pubkey)};
+    const CScript alternate_leaf{p2mr::BuildPKScript(alternate_pubkey)};
+    const std::vector<unsigned char> selected_leaf_bytes{selected_leaf.begin(), selected_leaf.end()};
+    const std::vector<unsigned char> alternate_leaf_bytes{alternate_leaf.begin(), alternate_leaf.end()};
+
+    TaprootBuilder builder;
+    builder.AddP2MR(/*depth=*/1, selected_leaf_bytes, P2MR_LEAF_VERSION_V1)
+        .AddP2MR(/*depth=*/1, alternate_leaf_bytes, P2MR_LEAF_VERSION_V1)
+        .FinalizeP2MR();
+    const WitnessV2P2MR output{builder.GetP2MROutput()};
+    const P2MRSpendData spend_data{builder.GetP2MRSpendData()};
+    const auto selected_leaf_it{spend_data.scripts.find({selected_leaf_bytes, P2MR_LEAF_VERSION_V1})};
+    QVERIFY(selected_leaf_it != spend_data.scripts.end());
+    QVERIFY(!selected_leaf_it->second.empty());
+
+    const uint256 message_hash{uint256::ONE};
+    const uint256 datasig_hash{ComputeQbitDataSigPQCHash(std::span<const unsigned char>{message_hash.begin(), message_hash.end()})};
+    std::vector<unsigned char> signature;
+    uint32_t signature_counter{0};
+    QVERIFY(selected_key.Sign(datasig_hash, signature, signature_counter));
+    QCOMPARE(signature_counter, 1U);
+
+    wallet::PQCUsageReport retry_report;
+    retry_report.key_states.push_back({
+        .pubkey = alternate_pubkey,
+        .signature_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
+        .signature_limit = PQC_MAX_SIGNATURES,
+        .signatures_remaining = PQC_MAX_SIGNATURES - wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
+        .limit_state = wallet::PQCSignatureLimitState::WARNING,
+    });
+    retry_report.key_states.push_back({
+        .pubkey = selected_pubkey,
+        .signature_count = 1,
+        .signature_limit = PQC_MAX_SIGNATURES,
+        .signatures_remaining = PQC_MAX_SIGNATURES - 1,
+        .limit_state = wallet::PQCSignatureLimitState::NORMAL,
+    });
+    retry_report.overall_state = wallet::PQCSignatureLimitState::WARNING;
+    retry_report.warnings.push_back({
+        .pubkey = alternate_pubkey,
+        .previous_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD - 1,
+        .new_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
+        .previous_state = wallet::PQCSignatureLimitState::NORMAL,
+        .current_state = wallet::PQCSignatureLimitState::WARNING,
+        .kind = wallet::PQCUsageWarningKind::TRANSITION,
+    });
+
+    interfaces::P2MRDataSignatureResult synthetic_result{
+        .output = output,
+        .message_hash = message_hash,
+        .datasig_hash = datasig_hash,
+        .pubkey = std::vector<unsigned char>{selected_pubkey.begin(), selected_pubkey.end()},
+        .signature = signature,
+        .leaf_script = selected_leaf,
+        .control_block = *selected_leaf_it->second.begin(),
+        .leaf_version = P2MR_LEAF_VERSION_V1,
+        .pqc_usage = std::make_shared<const wallet::PQCUsageReport>(retry_report),
+    };
+
+    WalletModel proof_wallet_model(std::make_unique<SyntheticPQCReportWallet>(synthetic_result), *mini_gui.clientModel, platformStyle.get());
+    SignVerifyMessageDialog proof_dialog(platformStyle.get(), nullptr);
+    proof_dialog.setModel(&proof_wallet_model);
+
+    QValidatedLineEdit* proof_address = proof_dialog.findChild<QValidatedLineEdit*>("addressIn_SM");
+    QComboBox* proof_sign_mode = proof_dialog.findChild<QComboBox*>("p2mrDataInputMode_SM");
+    QPlainTextEdit* proof_message = proof_dialog.findChild<QPlainTextEdit*>("messageIn_SM");
+    QPushButton* proof_sign_button = proof_dialog.findChild<QPushButton*>("signMessageButton_SM");
+    QPlainTextEdit* generated_proof = proof_dialog.findChild<QPlainTextEdit*>("signatureOut_SM");
+    QLabel* proof_status = proof_dialog.findChild<QLabel*>("statusLabel_SM");
+    QPushButton* proof_copy_button = proof_dialog.findChild<QPushButton*>("copySignatureButton_SM");
+    QVERIFY(proof_address && proof_sign_mode && proof_message && proof_sign_button && generated_proof && proof_status && proof_copy_button);
+
+    proof_address->setText(QString::fromStdString(EncodeDestination(CTxDestination{output})));
+    proof_sign_mode->setCurrentIndex(1);
+    proof_message->setPlainText(QString::fromStdString(HexStr(std::span<const unsigned char>{message_hash.begin(), message_hash.end()})));
+    proof_sign_button->click();
+
+    const QString proof_text{generated_proof->toPlainText()};
+    QVERIFY(!proof_text.isEmpty());
+    UniValue proof_object;
+    QVERIFY(proof_object.read(proof_text.toStdString()));
+    QVERIFY(proof_object.isObject());
+    const std::set<std::string> required_fields{
+        "address",
+        "message_hash",
+        "pubkey",
+        "signature",
+        "leaf_script",
+        "control_block",
+        "leaf_version",
+        "proof_mode",
+    };
+    QCOMPARE(proof_object.getKeys().size(), required_fields.size());
+    for (const std::string& field : required_fields) {
+        QVERIFY(proof_object.exists(field));
+    }
+
+    const std::array<const char*, 13> local_or_informational_fields{
+        "message_hash_source",
+        "message_hash_algorithm",
+        "datasig_hash",
+        "domain",
+        "algorithm",
+        "p2mr_merkle_root",
+        "pqc_key_states",
+        "pqc_overall_limit_state",
+        "pqc_signature_count",
+        "pqc_signature_limit",
+        "pqc_signatures_remaining",
+        "pqc_limit_state",
+        "warnings",
+    };
+    for (const char* field : local_or_informational_fields) {
+        QVERIFY(!proof_object.exists(field));
+    }
+    const QString alternate_pubkey_hex{QString::fromStdString(HexStr(std::span<const unsigned char>{alternate_pubkey.begin(), alternate_pubkey.end()}))};
+    QVERIFY(!proof_text.contains(alternate_pubkey_hex));
+    QVERIFY(proof_status->text().contains(alternate_pubkey_hex));
+    QVERIFY(proof_status->text().contains("PQC usage state after signing: warning."));
+
+    QApplication::clipboard()->clear();
+    proof_copy_button->click();
+    QCOMPARE(QApplication::clipboard()->text(), proof_text);
+
+    QComboBox* proof_verify_mode = proof_dialog.findChild<QComboBox*>("p2mrVerifyInputMode_VM");
+    QPlainTextEdit* proof_verify_input = proof_dialog.findChild<QPlainTextEdit*>("messageIn_VM");
+    QPushButton* proof_verify_button = proof_dialog.findChild<QPushButton*>("verifyMessageButton_VM");
+    QLabel* proof_verify_status = proof_dialog.findChild<QLabel*>("statusLabel_VM");
+    QVERIFY(proof_verify_mode && proof_verify_input && proof_verify_button && proof_verify_status);
+    proof_verify_mode->setCurrentIndex(2);
+    proof_verify_input->setPlainText(proof_text);
+    proof_verify_button->click();
+    QVERIFY(proof_verify_status->text().contains("P2MR/PQC proof is cryptographically valid"));
+
+    JSONRPCRequest request;
+    request.context = &test.m_node;
+    request.strMethod = "verifydatapqchash";
+    request.params = UniValue{UniValue::VARR};
+    request.params.push_back(proof_object);
+    if (RPCIsInWarmup(nullptr)) SetRPCWarmupFinished();
+    const UniValue rpc_result{tableRPC.execute(request)};
+    QVERIFY(rpc_result["valid"].get_bool());
+
+    UniValue legacy_proof{proof_object};
+    legacy_proof.pushKV("datasig_hash", HexStr(std::span<const unsigned char>{datasig_hash.begin(), datasig_hash.end()}));
+    legacy_proof.pushKV("domain", common::P2MR_DATA_SIGNATURE_DOMAIN);
+    legacy_proof.pushKV("algorithm", common::P2MR_DATA_SIGNATURE_ALGORITHM);
+    const uint256 merkle_root{output.GetMerkleRoot()};
+    legacy_proof.pushKV("p2mr_merkle_root", HexStr(std::span<const unsigned char>{merkle_root.begin(), merkle_root.end()}));
+    UniValue legacy_key_states{UniValue::VARR};
+    UniValue legacy_key_state{UniValue::VOBJ};
+    legacy_key_state.pushKV("pubkey", alternate_pubkey_hex.toStdString());
+    legacy_key_state.pushKV("pqc_signature_count", static_cast<int64_t>(wallet::PQC_WARNING_SIGNATURE_THRESHOLD));
+    legacy_key_state.pushKV("pqc_signature_limit", static_cast<int64_t>(PQC_MAX_SIGNATURES));
+    legacy_key_state.pushKV("pqc_signatures_remaining", static_cast<int64_t>(PQC_MAX_SIGNATURES - wallet::PQC_WARNING_SIGNATURE_THRESHOLD));
+    legacy_key_state.pushKV("pqc_limit_state", "warning");
+    legacy_key_states.push_back(std::move(legacy_key_state));
+    legacy_proof.pushKV("pqc_key_states", std::move(legacy_key_states));
+    legacy_proof.pushKV("pqc_overall_limit_state", "warning");
+    UniValue legacy_warnings{UniValue::VARR};
+    legacy_warnings.push_back("legacy local PQC warning");
+    legacy_proof.pushKV("warnings", std::move(legacy_warnings));
+
+    proof_verify_input->setPlainText(QString::fromStdString(legacy_proof.write(2)));
+    proof_verify_button->click();
+    QVERIFY(proof_verify_status->text().contains("P2MR/PQC proof is cryptographically valid"));
+
+    wallet::PQCUsageReport single_key_report;
+    single_key_report.key_states.push_back({
+        .pubkey = selected_pubkey,
+        .signature_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
+        .signature_limit = PQC_MAX_SIGNATURES,
+        .signatures_remaining = PQC_MAX_SIGNATURES - wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
+        .limit_state = wallet::PQCSignatureLimitState::WARNING,
+    });
+    single_key_report.overall_state = wallet::PQCSignatureLimitState::WARNING;
+    single_key_report.warnings.push_back({
+        .pubkey = selected_pubkey,
+        .previous_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD - 1,
+        .new_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
+        .previous_state = wallet::PQCSignatureLimitState::NORMAL,
+        .current_state = wallet::PQCSignatureLimitState::WARNING,
+        .kind = wallet::PQCUsageWarningKind::TRANSITION,
+    });
+    synthetic_result.pqc_usage = std::make_shared<const wallet::PQCUsageReport>(single_key_report);
+
+    WalletModel single_key_wallet_model(std::make_unique<SyntheticPQCReportWallet>(synthetic_result), *mini_gui.clientModel, platformStyle.get());
+    SignVerifyMessageDialog single_key_dialog(platformStyle.get(), nullptr);
+    single_key_dialog.setModel(&single_key_wallet_model);
+    QValidatedLineEdit* single_key_address = single_key_dialog.findChild<QValidatedLineEdit*>("addressIn_SM");
+    QComboBox* single_key_sign_mode = single_key_dialog.findChild<QComboBox*>("p2mrDataInputMode_SM");
+    QPlainTextEdit* single_key_message = single_key_dialog.findChild<QPlainTextEdit*>("messageIn_SM");
+    QPushButton* single_key_sign_button = single_key_dialog.findChild<QPushButton*>("signMessageButton_SM");
+    QLabel* single_key_status_label = single_key_dialog.findChild<QLabel*>("statusLabel_SM");
+    QPlainTextEdit* single_key_proof_output = single_key_dialog.findChild<QPlainTextEdit*>("signatureOut_SM");
+    QVERIFY(single_key_address && single_key_sign_mode && single_key_message && single_key_sign_button && single_key_status_label && single_key_proof_output);
+    single_key_address->setText(QString::fromStdString(EncodeDestination(CTxDestination{output})));
+    single_key_sign_mode->setCurrentIndex(1);
+    single_key_message->setPlainText(QString::fromStdString(HexStr(std::span<const unsigned char>{message_hash.begin(), message_hash.end()})));
+    single_key_sign_button->click();
+
+    const QString single_key_status{single_key_status_label->text()};
+    const uint32_t signatures_remaining{PQC_MAX_SIGNATURES - wallet::PQC_WARNING_SIGNATURE_THRESHOLD};
+    QVERIFY(single_key_status.contains(QString("Signatures remaining for this key: %1 of %2.").arg(signatures_remaining).arg(PQC_MAX_SIGNATURES)));
+    QVERIFY(single_key_status.contains(QString("%1 of %2 signatures used, %3 remaining")
+                                           .arg(wallet::PQC_WARNING_SIGNATURE_THRESHOLD)
+                                           .arg(PQC_MAX_SIGNATURES)
+                                           .arg(signatures_remaining)));
+    UniValue single_key_proof;
+    QVERIFY(single_key_proof.read(single_key_proof_output->toPlainText().toStdString()));
+    QCOMPARE(single_key_proof.getKeys().size(), required_fields.size());
+    for (const char* field : local_or_informational_fields) {
+        QVERIFY(!single_key_proof.exists(field));
+    }
 }
 
 void TestSendPQCReportPropagation(interfaces::Node& node)

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -163,7 +163,7 @@ RPCHelpMan signdatapqchash()
                     {"pubkey", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Optional 32-byte P2MR pubkey to select when the address commits to more than one single-key leaf."},
                     {"leaf_script", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Optional exact P2MR leaf script to sign against."},
                     {"control_block", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Optional exact P2MR control block to prove with."},
-                    {"include_pqc_usage", RPCArg::Type::BOOL, RPCArg::Default{true}, "Include PQC key-usage counters and warnings in the result."},
+                    {"include_pqc_usage", RPCArg::Type::BOOL, RPCArg::Default{true}, "Include wallet-local PQC key-usage counters and warnings in the result. These fields may reveal exact remaining signature budget and public keys from failed retry attempts; set false when sharing the result as a portable proof."},
                 },
                 RPCArgOptions{.oneline_description="options"}},
         },

--- a/test/functional/feature_p2mr.py
+++ b/test/functional/feature_p2mr.py
@@ -786,6 +786,20 @@ class FeatureP2MRTest(BitcoinTestFramework):
         assert_equal(verified["p2mr_merkle_root"], proof["p2mr_merkle_root"])
         assert_equal(verified["datasig_hash"], proof["datasig_hash"])
 
+        minimal_proof_fields = {
+            "address",
+            "message_hash",
+            "pubkey",
+            "signature",
+            "leaf_script",
+            "control_block",
+            "leaf_version",
+            "proof_mode",
+        }
+        minimal_proof = {field: proof[field] for field in minimal_proof_fields}
+        assert_equal(set(minimal_proof), minimal_proof_fields)
+        assert_equal(node.verifydatapqchash(minimal_proof)["valid"], True)
+
         explicit_proof = p2mr_wallet.signdatapqchash(address, message_hash, {
             "pubkey": proof["pubkey"],
             "leaf_script": proof["leaf_script"],
@@ -793,7 +807,16 @@ class FeatureP2MRTest(BitcoinTestFramework):
             "include_pqc_usage": False,
         })
         assert_equal(node.verifydatapqchash(explicit_proof)["valid"], True)
-        assert "pqc_signature_count" not in explicit_proof
+        for field in (
+            "pqc_key_states",
+            "pqc_overall_limit_state",
+            "pqc_signature_count",
+            "pqc_signature_limit",
+            "pqc_signatures_remaining",
+            "pqc_limit_state",
+            "warnings",
+        ):
+            assert field not in explicit_proof
 
         wrong_message = dict(proof)
         wrong_message["message_hash"] = "22" * 32


### PR DESCRIPTION
## Summary

- Emit only the eight verifier-required fields in qbit-qt P2MR/PQC proof JSON.
- Keep PQC usage state, remaining budget, and warnings in the local signer status instead of the displayed or copied proof.
- Preserve Qt and RPC verification of older rich proofs, and leave the signdatapqchash include_pqc_usage contract unchanged.
- Document the portable schema and the disclosure implications of RPC usage metadata.

Fixes #94

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Checks run:

- cmake -S . -B build_qt_pqc_metadata -G Ninja -DBUILD_GUI=ON -DBUILD_GUI_TESTS=ON -DBUILD_TESTS=ON -DBUILD_DAEMON=ON -DBUILD_CLI=ON
- cmake --build build_qt_pqc_metadata --target qbit-qt test_qbit-qt test_qbit qbitd qbit-cli -j 8
- ulimit -n 1024; QTEST_FUNCTION_TIMEOUT=600000 QT_QPA_PLATFORM=cocoa build_qt_pqc_metadata/bin/test_qbit-qt
- ulimit -n 1024; build_qt_pqc_metadata/bin/test_qbit --run_test=wallet_p2mr_descriptor_tests/P2MRDataHashSigningReportsCommittedFailedLeafReservation --catch_system_errors=no --log_level=test_suite
- ulimit -n 1024; python3 test/functional/feature_p2mr.py --configfile=build_qt_pqc_metadata/test/config.ini
- ulimit -n 1024; python3 test/functional/wallet_pqc_usage.py --configfile=build_qt_pqc_metadata/test/config.ini
- Docker lint image from ci/lint_imagefile using its default entrypoint
- test/lint/lint-qbit-public-docs.py
- git diff --check origin/1.0.0...HEAD

## Target Branch

- [x] This PR targets main or a maintainer-requested release branch such as 0.1.x.

Target: 1.0.0.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- Non-consensus Qt export and wallet-privacy change.
- No signing hash, PQC counter, leaf selection, script validity, transaction validity, or RPC response behavior changes.
- The selected proof key remains exported because verification requires it; retry-only keys and local usage metadata do not.
- Failed-signing counter/error reporting remains unchanged and outside this issue.

## Docs / Process Impact

Choose exactly one:

- [x] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [ ] No public docs update needed. Reason:

Updated the P2MR data-hash design documentation, RPC help disclosure text, and release notes.

## libbitcoinpqc Subtree Checklist (if src/libbitcoinpqc changed)

Not applicable; the subtree is unchanged.

- [ ] Source commit is reachable from an immutable release tag in Qbit-Org/qbit-libbitcoinpqc.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with contrib/devtools/update-libbitcoinpqc-subtree.sh.
- [ ] test/lint/libbitcoinpqc-subtree-check.sh passes locally.
- [ ] Any default tag change in contrib/devtools/update-libbitcoinpqc-subtree.sh is intentional and matches doc/subtrees/libbitcoinpqc.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786300772&installation_id=141183937&pr_number=95&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F95&signature=2fb2f7b6a4d5f54413c6114930b15f24085e40cc239022af8b3c9c8aa71cc455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Non-consensus Qt export and privacy change only; signing, verification, and signdatapqchash defaults are unchanged aside from clearer RPC disclosure text.
> 
> **Overview**
> **qbit-qt** now displays and copies only the **eight fields** needed for stateless P2MR/PQC proof verification (`address`, `message_hash`, `signature`, `pubkey`, `leaf_script`, `control_block`, `leaf_version`, `proof_mode`). Wallet-local PQC usage counts, limits, warnings, retry-only pubkeys, and informational fields (`datasig_hash`, `domain`, `algorithm`, `p2mr_merkle_root`, hash metadata) are **removed from proof JSON** but still shown in the **signer status** after signing.
> 
> **`signdatapqchash`** behavior and `include_pqc_usage` default are unchanged; RPC help now warns that usage metadata can leak budget and failed-retry keys, and callers should set `include_pqc_usage=false` when sharing an RPC result as a portable proof. **Qt and RPC verification** still accept older “rich” proofs.
> 
> Docs add a **portable proof schema** in `p2mr-datapqchash.md` and **release notes** for the Qt change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b24a33230a3a254327c753b20b22f72eac6a6bbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->