### PR TITLE
Bound qbit-qt P2MR proof parsing

### DIFF
--- a/doc/design/p2mr-datapqchash.md
+++ b/doc/design/p2mr-datapqchash.md
@@ -45,11 +45,11 @@ The RPC:
 8. returns the signature plus enough proof material for stateless verification.
 
 Signing uses the same wallet PQC signing provider path as transaction signing,
-so stateful PQC signature counters advance and the normal PQC usage fields are
-included in the RPC result unless `include_pqc_usage` is set to false. These
-fields describe wallet-local operational state and can include public keys from
-failed signing attempts when the wallet retries a later P2MR leaf. Set
-`include_pqc_usage=false` before sharing an RPC result as a portable proof.
+so stateful PQC signature counters advance. The RPC omits wallet-local PQC usage
+fields by default, keeping its result bounded and portable. Set
+`include_pqc_usage=true` to include those fields for local diagnostics. They can
+reveal exact remaining signature budgets and public keys from failed signing
+attempts when the wallet retries a later P2MR leaf.
 
 The RPC response includes:
 

--- a/doc/design/p2mr-datapqchash.md
+++ b/doc/design/p2mr-datapqchash.md
@@ -90,7 +90,10 @@ the signer status continues to show the overall usage state, single-key
 remaining budget, and any threshold or reminder warnings. Counts, limits,
 warnings, and keys observed during retry attempts are not part of the proof
 JSON. Proofs created by older qbit-qt versions can contain those additional
-fields; both Qt and RPC verification continue to accept them.
+fields. Qt accepts them when the complete proof document is at most 32,768
+characters, while RPC verification continues to accept them. For larger legacy
+exports, remove wallet-local usage fields before importing the proof into
+qbit-qt.
 
 ## Verification Flow
 

--- a/doc/release-notes-95.md
+++ b/doc/release-notes-95.md
@@ -10,6 +10,6 @@ PQC usage warnings and remaining-budget information continue to be shown in
 the local signer status. Existing proof JSON containing the former optional
 fields remains accepted by both qbit-qt and the `verifydatapqchash` RPC.
 
-The `signdatapqchash` RPC response and its `include_pqc_usage` default are
-unchanged. Set `include_pqc_usage=false` when using that RPC result as a
-portable proof.
+The `signdatapqchash` RPC now omits wallet-local PQC usage fields by default so
+its result remains bounded and portable. Set `include_pqc_usage=true` to include
+those fields for local diagnostics.

--- a/doc/release-notes-95.md
+++ b/doc/release-notes-95.md
@@ -7,8 +7,10 @@ limits, remaining budget, usage states, warnings, and public keys observed in
 failed leaf retry attempts are no longer included in Qt proof JSON.
 
 PQC usage warnings and remaining-budget information continue to be shown in
-the local signer status. Existing proof JSON containing the former optional
-fields remains accepted by both qbit-qt and the `verifydatapqchash` RPC.
+the local signer status. Existing proofs containing the former optional fields
+remain schema-compatible with both qbit-qt and `verifydatapqchash`. qbit-qt
+applies a 32,768-character document limit; strip wallet-local usage fields or
+recreate a portable proof before importing a larger legacy export.
 
 The `signdatapqchash` RPC now omits wallet-local PQC usage fields by default so
 its result remains bounded and portable. Set `include_pqc_usage=true` to include

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -17,14 +17,17 @@
 #include <key_io.h>
 #include <outputtype.h>
 #include <script/interpreter.h>
+#include <script/p2mr_sizing.h>
 #include <util/strencodings.h>
 #include <util/translation.h>
 #include <wallet/pqc_usage.h>
 #include <wallet/wallet.h>
 
 #include <optional>
+#include <set>
 #include <span>
 #include <string>
+#include <string_view>
 #include <variant>
 #include <vector>
 
@@ -33,6 +36,7 @@
 #include <QComboBox>
 #include <QPlainTextEdit>
 #include <QStringList>
+#include <QTextDocument>
 
 #include <univalue.h>
 
@@ -58,6 +62,20 @@ constexpr int P2MR_VERIFY_INPUT_TEXT{0};
 constexpr int P2MR_VERIFY_INPUT_HASH{1};
 constexpr int P2MR_VERIFY_INPUT_PROOF_ONLY{2};
 
+constexpr size_t P2MR_PROOF_MAX_ADDRESS_CHARS{64};
+constexpr size_t P2MR_PROOF_REQUIRED_HEX_CHARS{
+    2 * (uint256::size() + PQC_PUBKEY_SIZE + PQC_SIG_SIZE + P2MR_V1_PK_LEAF_SCRIPT_SIZE + P2MR_CONTROL_MAX_SIZE)};
+static_assert(P2MR_PROOF_REQUIRED_HEX_CHARS == 15'750);
+
+// The largest proof qbit-qt can currently produce has a maximum-length qbrt
+// address, a 128-node control path, and the longest PQC usage/exhaustion
+// metadata. Its 16,331 value characters plus 661 pretty-printed JSON syntax
+// characters total 16,992. The next power of two leaves room for compatible
+// informational fields while keeping GUI-thread work strictly bounded.
+constexpr size_t P2MR_MAX_GENERATED_PROOF_JSON_CHARS{16'331 + 661};
+static_assert(SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS == 32'768);
+static_assert(SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS >= P2MR_MAX_GENERATED_PROOF_JSON_CHARS);
+
 uint256 HashP2MRUtf8Text(const QString& text)
 {
     const QByteArray bytes{text.toUtf8()};
@@ -70,16 +88,19 @@ uint256 HashP2MRUtf8Text(const QString& text)
 
 bool ParseHexBytes(const QString& text, std::string_view name, size_t expected_size, std::vector<unsigned char>& bytes, QString& error)
 {
-    const std::string value{text.trimmed().toStdString()};
-    if (!IsHex(value)) {
-        error = SignVerifyMessageDialog::tr("%1 must be hex.").arg(QString::fromStdString(std::string{name}));
-        return false;
-    }
-    bytes = ParseHex(value);
-    if (bytes.size() != expected_size) {
+    const QString trimmed{text.trimmed()};
+    if (static_cast<size_t>(trimmed.size()) != expected_size * 2) {
         error = SignVerifyMessageDialog::tr("%1 must be exactly %2 bytes.").arg(QString::fromStdString(std::string{name})).arg(expected_size);
         return false;
     }
+
+    const QByteArray value{trimmed.toLatin1()};
+    const std::string_view value_view{value.constData(), static_cast<size_t>(value.size())};
+    if (!IsHex(value_view)) {
+        error = SignVerifyMessageDialog::tr("%1 must be hex.").arg(QString::fromStdString(std::string{name}));
+        return false;
+    }
+    bytes = ParseHex(value_view);
     return true;
 }
 
@@ -93,55 +114,89 @@ bool ParseDataHash(const QString& text, uint256& hash, QString& error)
     return true;
 }
 
-bool ReadRequiredString(const UniValue& object, const char* name, std::string& value, QString& error)
+const std::string* GetRequiredString(const UniValue& object, const char* name, QString& error)
 {
     const UniValue& field{object.find_value(name)};
     if (!field.isStr()) {
         error = SignVerifyMessageDialog::tr("Proof field \"%1\" must be a string.").arg(name);
-        return false;
+        return nullptr;
     }
-    value = field.get_str();
+    return &field.get_str();
+}
+
+bool RejectDuplicateProofFields(const UniValue& object, QString& error)
+{
+    std::set<std::string_view> fields;
+    for (const std::string& key : object.getKeys()) {
+        if (!fields.insert(key).second) {
+            error = SignVerifyMessageDialog::tr("Proof field \"%1\" is duplicated.").arg(QString::fromStdString(key));
+            return false;
+        }
+    }
     return true;
 }
 
-bool ParseProofHexField(const UniValue& object, const char* name, size_t expected_size, std::vector<unsigned char>& bytes, QString& error)
+bool ParseExactProofHex(const UniValue& object, const char* name, size_t expected_size, std::vector<unsigned char>& bytes, QString& error)
 {
-    std::string text;
-    if (!ReadRequiredString(object, name, text, error)) return false;
-    return ParseHexBytes(QString::fromStdString(text), name, expected_size, bytes, error);
-}
-
-bool ParseProofScriptField(const UniValue& object, const char* name, CScript& script, QString& error)
-{
-    std::string text;
-    if (!ReadRequiredString(object, name, text, error)) return false;
-    if (!IsHex(text)) {
+    const std::string* text{GetRequiredString(object, name, error)};
+    if (!text) return false;
+    if (text->size() != expected_size * 2) {
+        error = SignVerifyMessageDialog::tr("%1 must be exactly %2 bytes.").arg(name).arg(expected_size);
+        return false;
+    }
+    if (!IsHex(*text)) {
         error = SignVerifyMessageDialog::tr("Proof field \"%1\" must be hex.").arg(name);
         return false;
     }
-    const std::vector<unsigned char> bytes{ParseHex(text)};
-    script = CScript{bytes.begin(), bytes.end()};
+    bytes = ParseHex(*text);
+    return true;
+}
+
+bool ParseControlBlock(const UniValue& object, std::vector<unsigned char>& control_block, QString& error)
+{
+    const std::string* text{GetRequiredString(object, "control_block", error)};
+    if (!text) return false;
+
+    constexpr size_t MIN_HEX_CHARS{P2MR_CONTROL_BASE_SIZE * 2};
+    constexpr size_t MAX_HEX_CHARS{P2MR_CONTROL_MAX_SIZE * 2};
+    constexpr size_t NODE_HEX_CHARS{P2MR_CONTROL_NODE_SIZE * 2};
+    if (text->size() < MIN_HEX_CHARS || text->size() > MAX_HEX_CHARS ||
+        (text->size() - MIN_HEX_CHARS) % NODE_HEX_CHARS != 0) {
+        error = SignVerifyMessageDialog::tr("Proof field \"control_block\" must be 1 + 32*n bytes for n from 0 to 128.");
+        return false;
+    }
+    if (!IsHex(*text)) {
+        error = SignVerifyMessageDialog::tr("Proof field \"control_block\" must be hex.");
+        return false;
+    }
+    control_block = ParseHex(*text);
     return true;
 }
 
 bool ParseP2MRProofJson(const QString& proof_json, common::P2MRDataSignatureProof& proof, QString& error)
 {
+    const QByteArray proof_utf8{proof_json.toUtf8()};
     UniValue object;
-    if (!object.read(proof_json.toStdString()) || !object.isObject()) {
+    if (!object.read(std::string_view{proof_utf8.constData(), static_cast<size_t>(proof_utf8.size())}) || !object.isObject()) {
         error = SignVerifyMessageDialog::tr("Proof must be a JSON object.");
         return false;
     }
+    if (!RejectDuplicateProofFields(object, error)) return false;
 
-    std::string proof_mode;
-    if (!ReadRequiredString(object, "proof_mode", proof_mode, error)) return false;
-    if (proof_mode != common::P2MR_DATA_SIGNATURE_PROOF_MODE) {
+    const std::string* proof_mode{GetRequiredString(object, "proof_mode", error)};
+    if (!proof_mode) return false;
+    if (*proof_mode != common::P2MR_DATA_SIGNATURE_PROOF_MODE) {
         error = SignVerifyMessageDialog::tr("Unsupported proof_mode.");
         return false;
     }
 
-    std::string address;
-    if (!ReadRequiredString(object, "address", address, error)) return false;
-    const CTxDestination dest{DecodeDestination(address)};
+    const std::string* address{GetRequiredString(object, "address", error)};
+    if (!address) return false;
+    if (address->size() > P2MR_PROOF_MAX_ADDRESS_CHARS) {
+        error = SignVerifyMessageDialog::tr("Proof address is too long.");
+        return false;
+    }
+    const CTxDestination dest{DecodeDestination(*address)};
     if (!IsValidDestination(dest)) {
         error = SignVerifyMessageDialog::tr("Proof address is invalid.");
         return false;
@@ -154,29 +209,24 @@ bool ParseP2MRProofJson(const QString& proof_json, common::P2MRDataSignatureProo
     proof.output = *output;
 
     std::vector<unsigned char> bytes;
-    if (!ParseProofHexField(object, "message_hash", uint256::size(), bytes, error)) return false;
+    if (!ParseExactProofHex(object, "message_hash", uint256::size(), bytes, error)) return false;
     proof.message_hash = uint256{std::span<const unsigned char>{bytes.data(), bytes.size()}};
     proof.datasig_hash = ComputeQbitDataSigPQCHash(
         std::span<const unsigned char>{proof.message_hash.begin(), proof.message_hash.end()});
 
-    if (!ParseProofHexField(object, "pubkey", PQC_PUBKEY_SIZE, bytes, error)) return false;
+    if (!ParseExactProofHex(object, "pubkey", PQC_PUBKEY_SIZE, bytes, error)) return false;
     proof.pubkey = CPQCPubKey{bytes};
 
-    if (!ParseProofHexField(object, "signature", PQC_SIG_SIZE, proof.signature, error)) return false;
+    if (!ParseExactProofHex(object, "signature", PQC_SIG_SIZE, proof.signature, error)) return false;
 
-    if (!ParseProofScriptField(object, "leaf_script", proof.leaf_script, error)) return false;
+    if (!ParseExactProofHex(object, "leaf_script", P2MR_V1_PK_LEAF_SCRIPT_SIZE, bytes, error)) return false;
+    proof.leaf_script = CScript{bytes.begin(), bytes.end()};
 
-    std::string control_block;
-    if (!ReadRequiredString(object, "control_block", control_block, error)) return false;
-    if (!IsHex(control_block)) {
-        error = SignVerifyMessageDialog::tr("Proof field \"control_block\" must be hex.");
-        return false;
-    }
-    proof.control_block = ParseHex(control_block);
+    if (!ParseControlBlock(object, proof.control_block, error)) return false;
 
     const UniValue& leaf_version{object.find_value("leaf_version")};
     if (!leaf_version.isNum()) {
-        error = SignVerifyMessageDialog::tr("Proof field \"leaf_version\" must be a number.");
+        error = SignVerifyMessageDialog::tr("Proof field \"leaf_version\" must be an integer from 0 to 255.");
         return false;
     }
     const auto leaf_version_int{ToIntegral<uint8_t>(leaf_version.getValStr())};
@@ -297,9 +347,14 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformS
     });
     connect(ui->messageIn_SM, &QPlainTextEdit::textChanged, this, &SignVerifyMessageDialog::updateP2MRSignHashPreview);
     connect(ui->p2mrVerifyInputMode_VM, qOverload<int>(&QComboBox::currentIndexChanged), this, [this] {
+        clearVerifyStatus();
         updateP2MRVerifyModeUi();
     });
     connect(ui->p2mrDataIn_VM, &QPlainTextEdit::textChanged, this, &SignVerifyMessageDialog::updateP2MRVerifyHashPreview);
+    connect(ui->addressIn_VM, &QLineEdit::textChanged, this, &SignVerifyMessageDialog::clearVerifyStatus);
+    connect(ui->messageIn_VM, &QPlainTextEdit::textChanged, this, &SignVerifyMessageDialog::clearVerifyStatus);
+    connect(ui->signatureIn_VM, &QLineEdit::textChanged, this, &SignVerifyMessageDialog::clearVerifyStatus);
+    connect(ui->p2mrDataIn_VM, &QPlainTextEdit::textChanged, this, &SignVerifyMessageDialog::clearVerifyStatus);
 
     updateP2MRDataModeUi();
 
@@ -497,6 +552,12 @@ void SignVerifyMessageDialog::updateP2MRVerifyHashPreview()
     ui->p2mrVerifyMessageHash_VM->setText(QString::fromStdString(HashToHexString(message_hash)));
 }
 
+void SignVerifyMessageDialog::clearVerifyStatus()
+{
+    ui->statusLabel_VM->clear();
+    ui->statusLabel_VM->setStyleSheet({});
+}
+
 void SignVerifyMessageDialog::setAddress_SM(const QString &address)
 {
     ui->addressIn_SM->setText(address);
@@ -692,6 +753,8 @@ void SignVerifyMessageDialog::on_addressBookButton_VM_clicked()
 
 void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
 {
+    clearVerifyStatus();
+
     if (isP2MRDataMode()) {
         const auto set_error = [this](const QString& text) {
             ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
@@ -705,6 +768,12 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
             ui->statusLabel_VM->setStyleSheet("QLabel { color: green; }");
             ui->statusLabel_VM->setText(text);
         };
+
+        const int proof_character_count{ui->messageIn_VM->document()->characterCount() - 1};
+        if (proof_character_count > MAX_P2MR_PROOF_DOCUMENT_CHARS) {
+            set_error(tr("Proof JSON exceeds the maximum size of %1 characters.").arg(MAX_P2MR_PROOF_DOCUMENT_CHARS));
+            return;
+        }
 
         common::P2MRDataSignatureProof proof;
         QString parse_error;
@@ -858,8 +927,7 @@ void SignVerifyMessageDialog::on_clearButton_VM_clicked()
     ui->signatureIn_VM->clear();
     ui->messageIn_VM->clear();
     ui->p2mrDataIn_VM->clear();
-    ui->statusLabel_VM->clear();
-    ui->statusLabel_VM->setStyleSheet("");
+    clearVerifyStatus();
 
     ui->addressIn_VM->setFocus();
 }
@@ -883,8 +951,7 @@ bool SignVerifyMessageDialog::eventFilter(QObject *object, QEvent *event)
         else if (ui->tabWidget->currentIndex() == 1)
         {
             /* Clear status message on focus change */
-            ui->statusLabel_VM->clear();
-            ui->statusLabel_VM->setStyleSheet("");
+            clearVerifyStatus();
         }
     }
     return QDialog::eventFilter(object, event);

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -67,12 +67,20 @@ constexpr size_t P2MR_PROOF_REQUIRED_HEX_CHARS{
     2 * (uint256::size() + PQC_PUBKEY_SIZE + PQC_SIG_SIZE + P2MR_V1_PK_LEAF_SCRIPT_SIZE + P2MR_CONTROL_MAX_SIZE)};
 static_assert(P2MR_PROOF_REQUIRED_HEX_CHARS == 15'750);
 
-// The largest proof qbit-qt can currently produce has a maximum-length qbrt
-// address, a 128-node control path, and the longest PQC usage/exhaustion
-// metadata. Its 16,331 value characters plus 661 pretty-printed JSON syntax
-// characters total 16,992. The next power of two leaves room for compatible
-// informational fields while keeping GUI-thread work strictly bounded.
-constexpr size_t P2MR_MAX_GENERATED_PROOF_JSON_CHARS{16'331 + 661};
+// The portable proof has eight fields. At their protocol maxima, the address,
+// fixed-size hex fields, proof mode, and decimal leaf version use 15,828 value
+// characters. UniValue::write(2) adds exactly 160 JSON syntax characters.
+// Keeping the input limit at the next power of two leaves room for compatible
+// legacy/RPC informational fields while strictly bounding GUI-thread work.
+constexpr size_t P2MR_PROOF_MODE_CHARS{std::string_view{common::P2MR_DATA_SIGNATURE_PROOF_MODE}.size()};
+constexpr size_t P2MR_MAX_LEAF_VERSION_CHARS{3};
+constexpr size_t P2MR_MAX_GENERATED_PROOF_VALUE_CHARS{
+    P2MR_PROOF_MAX_ADDRESS_CHARS + P2MR_PROOF_REQUIRED_HEX_CHARS + P2MR_PROOF_MODE_CHARS + P2MR_MAX_LEAF_VERSION_CHARS};
+constexpr size_t P2MR_GENERATED_PROOF_JSON_SYNTAX_CHARS{160};
+constexpr size_t P2MR_MAX_GENERATED_PROOF_JSON_CHARS{
+    P2MR_MAX_GENERATED_PROOF_VALUE_CHARS + P2MR_GENERATED_PROOF_JSON_SYNTAX_CHARS};
+static_assert(P2MR_MAX_GENERATED_PROOF_VALUE_CHARS == 15'828);
+static_assert(P2MR_MAX_GENERATED_PROOF_JSON_CHARS == 15'988);
 static_assert(SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS == 32'768);
 static_assert(SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS >= P2MR_MAX_GENERATED_PROOF_JSON_CHARS);
 

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -19,6 +19,13 @@ class SignVerifyMessageDialog : public QDialog
     Q_OBJECT
 
 public:
+    /**
+     * Inclusive limit for P2MR proof JSON entered in the Qt verifier.
+     * QTextDocument::characterCount() includes its final paragraph separator,
+     * so callers must subtract one before comparing against this value.
+     */
+    static constexpr int MAX_P2MR_PROOF_DOCUMENT_CHARS{32 * 1024};
+
     explicit SignVerifyMessageDialog(const PlatformStyle *platformStyle, QWidget *parent);
     ~SignVerifyMessageDialog();
 
@@ -40,6 +47,7 @@ private:
     void updateP2MRSignHashPreview();
     void updateP2MRVerifyModeUi();
     void updateP2MRVerifyHashPreview();
+    void clearVerifyStatus();
 
     Ui::SignVerifyMessageDialog *ui;
     WalletModel* model{nullptr};

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -34,7 +34,9 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <rpc/server.h>
+#include <script/interpreter.h>
 #include <script/p2mr.h>
+#include <script/p2mr_sizing.h>
 #include <script/solver.h>
 #include <consensus/consensus.h>
 #include <test/util/setup_common.h>
@@ -49,7 +51,10 @@
 #include <memory>
 #include <set>
 #include <span>
+#include <string>
+#include <string_view>
 #include <utility>
+#include <vector>
 
 #include <QAbstractButton>
 #include <QAction>
@@ -99,7 +104,7 @@ QString MakeP2MRProofJson(std::string leaf_version)
     proof.pushKV("message_hash", std::string(uint256::size() * 2, '0'));
     proof.pushKV("pubkey", std::string(PQC_PUBKEY_SIZE * 2, '0'));
     proof.pushKV("signature", std::string(PQC_SIG_SIZE * 2, '0'));
-    proof.pushKV("leaf_script", "00");
+    proof.pushKV("leaf_script", std::string(P2MR_V1_PK_LEAF_SCRIPT_SIZE * 2, '0'));
     proof.pushKV("control_block", "c1");
 
     UniValue leaf_version_value;
@@ -835,6 +840,53 @@ void TestGUIWatchOnly(interfaces::Node& node, TestChain100Setup& test)
     QVERIFY(DecodeRawPSBT(psbt, MakeByteSpan(*decoded_psbt), err));
 }
 
+UniValue CopyProofWithout(const UniValue& proof, std::string_view omitted_key)
+{
+    UniValue copy(UniValue::VOBJ);
+    const std::vector<std::string>& keys{proof.getKeys()};
+    const std::vector<UniValue>& values{proof.getValues()};
+    for (size_t i{0}; i < keys.size(); ++i) {
+        if (keys[i] != omitted_key) copy.pushKVEnd(keys[i], values[i]);
+    }
+    return copy;
+}
+
+UniValue ProofWithControlDepth(const UniValue& proof, size_t depth)
+{
+    assert(depth <= P2MR_CONTROL_MAX_NODE_COUNT);
+
+    UniValue result{proof};
+    std::vector<unsigned char> control_block{ParseHex(proof.find_value("control_block").get_str())};
+    control_block.resize(P2MR_CONTROL_BASE_SIZE);
+    for (size_t node{0}; node < depth; ++node) {
+        for (size_t byte{0}; byte < P2MR_CONTROL_NODE_SIZE; ++byte) {
+            control_block.push_back(static_cast<unsigned char>(node + byte + 1));
+        }
+    }
+
+    const std::vector<unsigned char> leaf_script{ParseHex(proof.find_value("leaf_script").get_str())};
+    const uint8_t leaf_version{proof.find_value("leaf_version").getInt<uint8_t>()};
+    const uint256 leaf_hash{ComputeP2MRLeafHash(leaf_version, leaf_script)};
+    const uint256 merkle_root{ComputeP2MRMerkleRoot(control_block, leaf_hash)};
+    result.pushKV("control_block", HexStr(control_block));
+    result.pushKV("address", EncodeDestination(WitnessV2P2MR{merkle_root}));
+    result.pushKV("p2mr_merkle_root", HexStr(std::span<const unsigned char>{merkle_root.begin(), merkle_root.end()}));
+    return result;
+}
+
+QString ProofWithNestedArrays(const UniValue& proof, size_t array_count)
+{
+    std::string json{proof.write()};
+    assert(!json.empty() && json.back() == '}');
+    json.pop_back();
+    json += ",\"nested\":";
+    json.append(array_count, '[');
+    json += '0';
+    json.append(array_count, ']');
+    json += '}';
+    return QString::fromStdString(json);
+}
+
 void TestP2MRReceiveAddressTypes(interfaces::Node& node)
 {
     TestChain100Setup test{ChainType::REGTEST, {.extra_args = {"-p2mronly=1"}}};
@@ -1027,6 +1079,187 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     QVERIFY(verify_address->text().isEmpty());
     QVERIFY(proof_input->toPlainText().isEmpty());
     QVERIFY(verify_data_input->toPlainText().isEmpty());
+
+    UniValue valid_proof;
+    QVERIFY(valid_proof.read(proof_json.toStdString()));
+    QVERIFY(valid_proof.isObject());
+
+    const auto verify_json = [&](const QString& json) {
+        verify_address->clear();
+        verify_input_mode->setCurrentIndex(2);
+        proof_input->setPlainText(json);
+        verify_button->click();
+        return verify_status->text();
+    };
+    const auto write_proof = [](const UniValue& proof) {
+        return QString::fromStdString(proof.write());
+    };
+    const auto proof_with_field = [&](const UniValue& proof, const char* name, std::string value) {
+        UniValue modified{proof};
+        modified.pushKV(name, std::move(value));
+        return write_proof(modified);
+    };
+    const auto expect_valid = [&](const QString& json) {
+        const QString status{verify_json(json)};
+        QVERIFY2(status.contains("cryptographically valid"), status.toLocal8Bit().constData());
+        QVERIFY(verify_status->styleSheet().isEmpty());
+    };
+    const auto expect_error = [&](const QString& json, const QString& expected) {
+        const QString status{verify_json(json)};
+        QVERIFY2(status.contains(expected), status.toLocal8Bit().constData());
+        QVERIFY(verify_status->styleSheet().contains("red"));
+    };
+
+    expect_valid(write_proof(valid_proof));
+
+    struct ExactHexField {
+        const char* name;
+        size_t bytes;
+    };
+    const std::array exact_hex_fields{
+        ExactHexField{"message_hash", uint256::size()},
+        ExactHexField{"pubkey", PQC_PUBKEY_SIZE},
+        ExactHexField{"signature", PQC_SIG_SIZE},
+        ExactHexField{"leaf_script", P2MR_V1_PK_LEAF_SCRIPT_SIZE},
+    };
+    // The genuine proof above is simultaneously the at-limit case for every
+    // exact-size field. Exercise one byte below/above, odd, and same-size
+    // non-hex inputs independently for each field.
+    for (const ExactHexField& field : exact_hex_fields) {
+        expect_error(proof_with_field(valid_proof, field.name, std::string((field.bytes - 1) * 2, '0')), "must be exactly");
+        expect_error(proof_with_field(valid_proof, field.name, std::string(field.bytes * 2 + 2, '0')), "must be exactly");
+        expect_error(proof_with_field(valid_proof, field.name, std::string(field.bytes * 2 - 1, '0')), "must be exactly");
+        expect_error(proof_with_field(valid_proof, field.name, std::string(field.bytes * 2, 'g')), "must be hex");
+    }
+    // A large non-hex value must fail on its size before the decoder scans it.
+    expect_error(proof_with_field(valid_proof, "signature", std::string(20'000, 'g')), "must be exactly");
+
+    const std::array valid_control_depths{size_t{0}, size_t{1}, P2MR_CONTROL_MAX_NODE_COUNT};
+    for (const size_t depth : valid_control_depths) {
+        const UniValue proof{ProofWithControlDepth(valid_proof, depth)};
+        QCOMPARE(proof.find_value("control_block").get_str().size(), GetP2MRControlBlockSize(depth) * 2);
+        expect_valid(write_proof(proof));
+    }
+    // Boundaries around the minimum, first node, and protocol maximum:
+    // 0/1/2, 32/33/34, and 4096/4097/4098 serialized bytes.
+    const std::array invalid_control_sizes{size_t{0}, size_t{2}, size_t{32}, size_t{34}, P2MR_CONTROL_MAX_SIZE - 1, P2MR_CONTROL_MAX_SIZE + 1};
+    for (const size_t byte_count : invalid_control_sizes) {
+        expect_error(proof_with_field(valid_proof, "control_block", std::string(byte_count * 2, '0')), "must be 1 + 32*n bytes");
+    }
+    expect_error(proof_with_field(valid_proof, "control_block", std::string(P2MR_CONTROL_MAX_SIZE * 2, 'g')), "must be hex");
+
+    const std::string valid_address{valid_proof.find_value("address").get_str()};
+    QCOMPARE(valid_address.size(), size_t{64});
+    expect_error(proof_with_field(valid_proof, "address", std::string(63, 'q')), "address is invalid");
+    expect_valid(write_proof(valid_proof));
+    expect_error(proof_with_field(valid_proof, "address", std::string(65, 'q')), "address is too long");
+
+    const std::array required_fields{
+        "proof_mode", "address", "message_hash", "pubkey", "signature", "leaf_version", "leaf_script", "control_block",
+    };
+    UniValue minimal_rpc_proof(UniValue::VOBJ);
+    for (const char* field : required_fields) {
+        minimal_rpc_proof.pushKVEnd(field, valid_proof.find_value(field));
+    }
+    expect_valid(write_proof(minimal_rpc_proof));
+
+    for (const char* field : required_fields) {
+        expect_error(write_proof(CopyProofWithout(valid_proof, field)), QString::fromLatin1(field));
+    }
+
+    std::vector<UniValue> invalid_string_types;
+    invalid_string_types.emplace_back();
+    UniValue number;
+    number.setInt(1);
+    invalid_string_types.push_back(number);
+    invalid_string_types.emplace_back(UniValue::VARR);
+    invalid_string_types.emplace_back(UniValue::VOBJ);
+    for (const UniValue& invalid_type : invalid_string_types) {
+        UniValue proof{valid_proof};
+        proof.pushKV("message_hash", invalid_type);
+        expect_error(write_proof(proof), "must be a string");
+    }
+
+    for (const std::string& leaf_version : {"-1", "256", "1.5", "999999999999999999999999"}) {
+        UniValue proof{valid_proof};
+        UniValue version;
+        version.setNumStr(leaf_version);
+        proof.pushKV("leaf_version", version);
+        expect_error(write_proof(proof), "integer from 0 to 255");
+    }
+    for (const int leaf_version : {0, 255}) {
+        UniValue proof{valid_proof};
+        proof.pushKV("leaf_version", leaf_version);
+        expect_error(write_proof(proof), "proof verification failed");
+    }
+
+    expect_error("[]", "JSON object");
+    expect_error("{", "JSON object");
+    expect_error(write_proof(valid_proof) + " trailing", "JSON object");
+
+    UniValue nested_value(UniValue::VOBJ);
+    UniValue nested_array(UniValue::VARR);
+    nested_array.push_back("compatible metadata");
+    nested_value.pushKV("array", std::move(nested_array));
+    UniValue proof_with_unknown{valid_proof};
+    proof_with_unknown.pushKV("unknown", std::move(nested_value));
+    expect_valid(write_proof(proof_with_unknown));
+
+    // UniValue permits at most 512 simultaneously open containers. The proof
+    // object consumes one level, so 510/511/512 nested arrays cover below, at,
+    // and above the parser's limit.
+    expect_valid(ProofWithNestedArrays(valid_proof, 510));
+    expect_valid(ProofWithNestedArrays(valid_proof, 511));
+    expect_error(ProofWithNestedArrays(valid_proof, 512), "JSON object");
+
+    for (const char* field : required_fields) {
+        UniValue duplicate{valid_proof};
+        duplicate.pushKVEnd(field, valid_proof.find_value(field));
+        expect_error(write_proof(duplicate), "duplicated");
+    }
+    UniValue duplicate_first(UniValue::VOBJ);
+    duplicate_first.pushKVEnd("signature", valid_proof.find_value("signature"));
+    duplicate_first.pushKVs(valid_proof);
+    expect_error(write_proof(duplicate_first), "duplicated");
+    UniValue duplicate_unknown{valid_proof};
+    duplicate_unknown.pushKVEnd("unknown", 1);
+    duplicate_unknown.pushKVEnd("unknown", 2);
+    expect_error(write_proof(duplicate_unknown), "duplicated");
+
+    const UniValue maximum_control_proof{ProofWithControlDepth(valid_proof, P2MR_CONTROL_MAX_NODE_COUNT)};
+    QString maximum_json{write_proof(maximum_control_proof)};
+    QVERIFY(maximum_json.size() < SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS - 1);
+    for (const int document_size : {SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS - 1,
+                                    SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS}) {
+        QString padded{maximum_json};
+        padded.append(QString(document_size - padded.size(), ' '));
+        QCOMPARE(padded.size(), static_cast<qsizetype>(document_size));
+        expect_valid(padded);
+    }
+
+    // Editing after a success must clear both the old message and status style.
+    proof_input->setPlainText(QString(SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS + 1, ' '));
+    QVERIFY(verify_status->text().isEmpty());
+    QVERIFY(verify_status->styleSheet().isEmpty());
+    bool heartbeat{false};
+    QTimer::singleShot(0, [&] { heartbeat = true; });
+    QElapsedTimer rejection_timer;
+    rejection_timer.start();
+    verify_button->click();
+    QVERIFY2(rejection_timer.elapsed() < 1000, "Oversized proof rejection blocked the GUI thread");
+    QCoreApplication::processEvents();
+    QVERIFY(heartbeat);
+    QVERIFY(verify_status->text().contains("maximum size"));
+    QVERIFY(!verify_status->text().contains("cryptographically valid"));
+    QVERIFY(verify_status->styleSheet().contains("red"));
+
+    // Malformed input after the oversized error also replaces the status, and
+    // any subsequent edit clears it instead of leaving a stale failure/success.
+    proof_input->setPlainText("{");
+    QVERIFY(verify_status->text().isEmpty());
+    verify_button->click();
+    QVERIFY(verify_status->text().contains("JSON object"));
+    proof_input->setPlainText(write_proof(valid_proof));
     QVERIFY(verify_status->text().isEmpty());
     QVERIFY(verify_status->styleSheet().isEmpty());
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -1180,7 +1180,7 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
         expect_error(write_proof(proof), "must be a string");
     }
 
-    for (const std::string& leaf_version : {"-1", "256", "1.5", "999999999999999999999999"}) {
+    for (const char* leaf_version : {"-1", "256", "1.5", "999999999999999999999999"}) {
         UniValue proof{valid_proof};
         UniValue version;
         version.setNumStr(leaf_version);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -870,7 +870,6 @@ UniValue ProofWithControlDepth(const UniValue& proof, size_t depth)
     const uint256 merkle_root{ComputeP2MRMerkleRoot(control_block, leaf_hash)};
     result.pushKV("control_block", HexStr(control_block));
     result.pushKV("address", EncodeDestination(WitnessV2P2MR{merkle_root}));
-    result.pushKV("p2mr_merkle_root", HexStr(std::span<const unsigned char>{merkle_root.begin(), merkle_root.end()}));
     return result;
 }
 
@@ -1227,7 +1226,8 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     expect_error(write_proof(duplicate_unknown), "duplicated");
 
     const UniValue maximum_control_proof{ProofWithControlDepth(valid_proof, P2MR_CONTROL_MAX_NODE_COUNT)};
-    QString maximum_json{write_proof(maximum_control_proof)};
+    const QString maximum_json{QString::fromStdString(maximum_control_proof.write(2))};
+    QCOMPARE(maximum_json.size(), qsizetype{15'988});
     QVERIFY(maximum_json.size() < SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS - 1);
     for (const int document_size : {SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS - 1,
                                     SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS}) {
@@ -1283,11 +1283,19 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     builder.AddP2MR(/*depth=*/1, selected_leaf_bytes, P2MR_LEAF_VERSION_V1)
         .AddP2MR(/*depth=*/1, alternate_leaf_bytes, P2MR_LEAF_VERSION_V1)
         .FinalizeP2MR();
-    const WitnessV2P2MR output{builder.GetP2MROutput()};
     const P2MRSpendData spend_data{builder.GetP2MRSpendData()};
     const auto selected_leaf_it{spend_data.scripts.find({selected_leaf_bytes, P2MR_LEAF_VERSION_V1})};
     QVERIFY(selected_leaf_it != spend_data.scripts.end());
     QVERIFY(!selected_leaf_it->second.empty());
+    std::vector<unsigned char> selected_control_block{*selected_leaf_it->second.begin()};
+    selected_control_block.resize(P2MR_CONTROL_BASE_SIZE);
+    for (size_t node{0}; node < P2MR_CONTROL_MAX_NODE_COUNT; ++node) {
+        for (size_t byte{0}; byte < P2MR_CONTROL_NODE_SIZE; ++byte) {
+            selected_control_block.push_back(static_cast<unsigned char>(node + byte + 1));
+        }
+    }
+    const uint256 selected_leaf_hash{ComputeP2MRLeafHash(P2MR_LEAF_VERSION_V1, selected_leaf_bytes)};
+    const WitnessV2P2MR output{ComputeP2MRMerkleRoot(selected_control_block, selected_leaf_hash)};
 
     const uint256 message_hash{uint256::ONE};
     const uint256 datasig_hash{ComputeQbitDataSigPQCHash(std::span<const unsigned char>{message_hash.begin(), message_hash.end()})};
@@ -1296,14 +1304,36 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     QVERIFY(selected_key.Sign(datasig_hash, signature, signature_counter));
     QCOMPARE(signature_counter, 1U);
 
+    // The old rich exporter exceeded the 32 KiB verifier limit with this many
+    // advanced retry keys and exhaustion warnings. The portable proof must be
+    // independent of the wallet-local report's cardinality.
+    constexpr size_t FAILED_RETRY_KEY_COUNT{37};
+    std::set<CPQCPubKey> failed_retry_pubkeys{alternate_pubkey};
+    for (unsigned char marker{1}; failed_retry_pubkeys.size() < FAILED_RETRY_KEY_COUNT; ++marker) {
+        std::array<unsigned char, PQC_PUBKEY_SIZE> pubkey_bytes;
+        pubkey_bytes.fill(marker);
+        const CPQCPubKey pubkey{std::span<const unsigned char>{pubkey_bytes}};
+        if (pubkey.IsValid() && pubkey != selected_pubkey) failed_retry_pubkeys.insert(pubkey);
+    }
+
     wallet::PQCUsageReport retry_report;
-    retry_report.key_states.push_back({
-        .pubkey = alternate_pubkey,
-        .signature_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
-        .signature_limit = PQC_MAX_SIGNATURES,
-        .signatures_remaining = PQC_MAX_SIGNATURES - wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
-        .limit_state = wallet::PQCSignatureLimitState::WARNING,
-    });
+    for (const CPQCPubKey& failed_pubkey : failed_retry_pubkeys) {
+        retry_report.key_states.push_back({
+            .pubkey = failed_pubkey,
+            .signature_count = PQC_MAX_SIGNATURES,
+            .signature_limit = PQC_MAX_SIGNATURES,
+            .signatures_remaining = 0,
+            .limit_state = wallet::PQCSignatureLimitState::EXHAUSTED,
+        });
+        retry_report.warnings.push_back({
+            .pubkey = failed_pubkey,
+            .previous_count = PQC_MAX_SIGNATURES - 1,
+            .new_count = PQC_MAX_SIGNATURES,
+            .previous_state = wallet::PQCSignatureLimitState::CRITICAL,
+            .current_state = wallet::PQCSignatureLimitState::EXHAUSTED,
+            .kind = wallet::PQCUsageWarningKind::TRANSITION,
+        });
+    }
     retry_report.key_states.push_back({
         .pubkey = selected_pubkey,
         .signature_count = 1,
@@ -1311,15 +1341,9 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
         .signatures_remaining = PQC_MAX_SIGNATURES - 1,
         .limit_state = wallet::PQCSignatureLimitState::NORMAL,
     });
-    retry_report.overall_state = wallet::PQCSignatureLimitState::WARNING;
-    retry_report.warnings.push_back({
-        .pubkey = alternate_pubkey,
-        .previous_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD - 1,
-        .new_count = wallet::PQC_WARNING_SIGNATURE_THRESHOLD,
-        .previous_state = wallet::PQCSignatureLimitState::NORMAL,
-        .current_state = wallet::PQCSignatureLimitState::WARNING,
-        .kind = wallet::PQCUsageWarningKind::TRANSITION,
-    });
+    retry_report.overall_state = wallet::PQCSignatureLimitState::EXHAUSTED;
+    QCOMPARE(retry_report.key_states.size(), FAILED_RETRY_KEY_COUNT + 1);
+    QCOMPARE(retry_report.warnings.size(), FAILED_RETRY_KEY_COUNT);
 
     interfaces::P2MRDataSignatureResult synthetic_result{
         .output = output,
@@ -1328,7 +1352,7 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
         .pubkey = std::vector<unsigned char>{selected_pubkey.begin(), selected_pubkey.end()},
         .signature = signature,
         .leaf_script = selected_leaf,
-        .control_block = *selected_leaf_it->second.begin(),
+        .control_block = selected_control_block,
         .leaf_version = P2MR_LEAF_VERSION_V1,
         .pqc_usage = std::make_shared<const wallet::PQCUsageReport>(retry_report),
     };
@@ -1353,10 +1377,12 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
 
     const QString proof_text{generated_proof->toPlainText()};
     QVERIFY(!proof_text.isEmpty());
+    QCOMPARE(proof_text.size(), qsizetype{15'988});
+    QVERIFY(proof_text.size() <= SignVerifyMessageDialog::MAX_P2MR_PROOF_DOCUMENT_CHARS);
     UniValue proof_object;
     QVERIFY(proof_object.read(proof_text.toStdString()));
     QVERIFY(proof_object.isObject());
-    const std::set<std::string> required_fields{
+    const std::set<std::string> portable_fields{
         "address",
         "message_hash",
         "pubkey",
@@ -1366,8 +1392,8 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
         "leaf_version",
         "proof_mode",
     };
-    QCOMPARE(proof_object.getKeys().size(), required_fields.size());
-    for (const std::string& field : required_fields) {
+    QCOMPARE(proof_object.getKeys().size(), portable_fields.size());
+    for (const std::string& field : portable_fields) {
         QVERIFY(proof_object.exists(field));
     }
 
@@ -1392,7 +1418,7 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
     const QString alternate_pubkey_hex{QString::fromStdString(HexStr(std::span<const unsigned char>{alternate_pubkey.begin(), alternate_pubkey.end()}))};
     QVERIFY(!proof_text.contains(alternate_pubkey_hex));
     QVERIFY(proof_status->text().contains(alternate_pubkey_hex));
-    QVERIFY(proof_status->text().contains("PQC usage state after signing: warning."));
+    QVERIFY(proof_status->text().contains("PQC usage state after signing: exhausted."));
 
     QApplication::clipboard()->clear();
     proof_copy_button->click();
@@ -1484,7 +1510,7 @@ void TestP2MRReceiveAddressTypes(interfaces::Node& node)
                                            .arg(signatures_remaining)));
     UniValue single_key_proof;
     QVERIFY(single_key_proof.read(single_key_proof_output->toPlainText().toStdString()));
-    QCOMPARE(single_key_proof.getKeys().size(), required_fields.size());
+    QCOMPARE(single_key_proof.getKeys().size(), portable_fields.size());
     for (const char* field : local_or_informational_fields) {
         QVERIFY(!single_key_proof.exists(field));
     }

--- a/src/wallet/rpc/signmessage.cpp
+++ b/src/wallet/rpc/signmessage.cpp
@@ -163,7 +163,7 @@ RPCHelpMan signdatapqchash()
                     {"pubkey", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Optional 32-byte P2MR pubkey to select when the address commits to more than one single-key leaf."},
                     {"leaf_script", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Optional exact P2MR leaf script to sign against."},
                     {"control_block", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, "Optional exact P2MR control block to prove with."},
-                    {"include_pqc_usage", RPCArg::Type::BOOL, RPCArg::Default{true}, "Include wallet-local PQC key-usage counters and warnings in the result. These fields may reveal exact remaining signature budget and public keys from failed retry attempts; set false when sharing the result as a portable proof."},
+                    {"include_pqc_usage", RPCArg::Type::BOOL, RPCArg::Default{false}, "Include wallet-local PQC key-usage counters and warnings in the result. These fields may reveal exact remaining signature budget and public keys from failed retry attempts; enable only for local diagnostics."},
                 },
                 RPCArgOptions{.oneline_description="options"}},
         },
@@ -227,7 +227,7 @@ RPCHelpMan signdatapqchash()
             const std::optional<CPQCPubKey> requested_pubkey{ParseOptionalP2MRPubKey(options)};
             const std::optional<CScript> requested_leaf_script{ParseOptionalScript(options)};
             const std::optional<std::vector<unsigned char>> requested_control_block{ParseOptionalControlBlock(options)};
-            const bool include_pqc_usage{!options.exists("include_pqc_usage") || options.find_value("include_pqc_usage").get_bool()};
+            const bool include_pqc_usage{options.exists("include_pqc_usage") && options.find_value("include_pqc_usage").get_bool()};
 
             PQCUsageRecorder pqc_usage_recorder;
             util::Result<DataPQCSignatureProof> proof{pwallet->SignDataPQCHash(

--- a/test/functional/feature_p2mr.py
+++ b/test/functional/feature_p2mr.py
@@ -774,8 +774,18 @@ class FeatureP2MRTest(BitcoinTestFramework):
         assert_equal(proof["leaf_version"], P2MR_LEAF_VERSION)
         assert_equal(proof["leaf_script"], f"20{proof['pubkey']}b3")
         assert_equal(proof["control_block"], "c1")
-        assert_equal(proof["pqc_signature_count"], 1)
-        assert_equal(proof["pqc_key_states"][0]["pubkey"], proof["pubkey"])
+
+        usage_fields = (
+            "pqc_key_states",
+            "pqc_overall_limit_state",
+            "pqc_signature_count",
+            "pqc_signature_limit",
+            "pqc_signatures_remaining",
+            "pqc_limit_state",
+            "warnings",
+        )
+        for field in usage_fields:
+            assert field not in proof
 
         verified = node.verifydatapqchash(proof)
         assert_equal(verified["valid"], True)
@@ -800,23 +810,15 @@ class FeatureP2MRTest(BitcoinTestFramework):
         assert_equal(set(minimal_proof), minimal_proof_fields)
         assert_equal(node.verifydatapqchash(minimal_proof)["valid"], True)
 
-        explicit_proof = p2mr_wallet.signdatapqchash(address, message_hash, {
+        usage_proof = p2mr_wallet.signdatapqchash(address, message_hash, {
             "pubkey": proof["pubkey"],
             "leaf_script": proof["leaf_script"],
             "control_block": proof["control_block"],
-            "include_pqc_usage": False,
+            "include_pqc_usage": True,
         })
-        assert_equal(node.verifydatapqchash(explicit_proof)["valid"], True)
-        for field in (
-            "pqc_key_states",
-            "pqc_overall_limit_state",
-            "pqc_signature_count",
-            "pqc_signature_limit",
-            "pqc_signatures_remaining",
-            "pqc_limit_state",
-            "warnings",
-        ):
-            assert field not in explicit_proof
+        assert_equal(node.verifydatapqchash(usage_proof)["valid"], True)
+        assert_equal(usage_proof["pqc_signature_count"], 2)
+        assert_equal(usage_proof["pqc_key_states"][0]["pubkey"], proof["pubkey"])
 
         wrong_message = dict(proof)
         wrong_message["message_hash"] = "22" * 32

--- a/test/functional/wallet_pqc_usage.py
+++ b/test/functional/wallet_pqc_usage.py
@@ -205,14 +205,14 @@ class WalletPQCUsageTest(BitcoinTestFramework):
         self.wait_pqc_key_validation_ready(signer)
         self.assert_pqc_signature_count(signer, address, 0)
 
-        proof = signer.signdatapqchash(address, "55" * 32)
+        proof = signer.signdatapqchash(address, "55" * 32, {"include_pqc_usage": True})
         assert_equal(proof["address"], address)
         self.assert_pqc_fields(proof, min_signature_count=1)
         assert_equal(proof["pqc_signature_count"], 1)
         assert_equal(proof["pqc_key_states"][0]["pubkey"], proof["pubkey"])
         self.assert_pqc_signature_count(signer, address, 1)
 
-        hidden_usage = signer.signdatapqchash(address, "56" * 32, {"include_pqc_usage": False})
+        hidden_usage = signer.signdatapqchash(address, "56" * 32)
         self.assert_no_pqc_fields(hidden_usage)
         self.assert_pqc_signature_count(signer, address, 2)
 
@@ -257,7 +257,7 @@ class WalletPQCUsageTest(BitcoinTestFramework):
             "59" * 32,
         )
         locked.walletpassphrase(passphrase, 60)
-        locked_proof = locked.signdatapqchash(locked_address, "5a" * 32)
+        locked_proof = locked.signdatapqchash(locked_address, "5a" * 32, {"include_pqc_usage": True})
         self.assert_pqc_fields(locked_proof, min_signature_count=1)
         self.assert_pqc_signature_count(locked, locked_address, 1)
 


### PR DESCRIPTION
## Summary

Closes #93.

qbit-qt previously copied and synchronously parsed an unrestricted P2MR proof document on the GUI thread. Fixed-size and protocol-bounded hex fields were also decoded before their serialized sizes were validated, allowing malformed proofs to cause excessive transient allocation and event-loop blocking.

This change:

- rejects proof documents above 32,768 characters before `toPlainText()`, UTF-8 conversion, or JSON parsing;
- derives that cap from the 15,750 required proof hex characters and the exact 15,988-character largest portable proof qbit-qt generates after #95;
- validates fixed-size fields, the 34-byte single-key leaf script, and the `1 + 32*n` control-block shape before hex decoding;
- rejects duplicate top-level proof fields;
- avoids redundant string copies before UniValue parsing; and
- clears stale verification status whenever proof inputs change.

Existing valid qbit-qt proofs, minimal RPC proof objects, and unique informational metadata remain accepted. The default `signdatapqchash` result now omits optional wallet-local usage metadata; `include_pqc_usage=true` preserves the rich diagnostics response. Shared proof verification and consensus behavior are unchanged.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason: Not applicable; all relevant checks were run.

Commands and checks:

- `cmake --preset dev-mode -B build -DWITH_USDT=OFF -DENABLE_IPC=OFF`
- `cmake --build build --target test_bitcoin-qt -j4`
- `QT_QPA_PLATFORM=cocoa QTEST_FUNCTION_TIMEOUT=600000 build/bin/test_qbit-qt`
- `ulimit -n 10240; build/test/functional/test_runner.py feature_p2mr.py`
- `cmake --build build --target rpcdocs -j6`
- Full repository lint runner in the Docker image built from `ci/lint_imagefile`
- `git diff --check`

The Qt coverage uses a genuine wallet-generated SLH-DSA proof and includes document and field boundaries, the maximum 4,097-byte control block, malformed and nested JSON, duplicate fields, oversized values, minimal RPC compatibility, stale-success state, event-loop responsiveness, and a maximum-depth proof carrying a synthetic report for 37 failed retry keys that remains exactly 15,988 characters with the minimal export from #95. It also runs alongside the leaf-version validation coverage now present on `1.0.0`.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

This is security/resource hardening primarily in qbit-qt. It also makes wallet-local PQC usage metadata opt-in for `signdatapqchash`, ensuring the default RPC result is bounded and portable while preserving `include_pqc_usage=true` for local diagnostics. It does not change required proof fields, shared verification rules, script execution, or consensus. `QPlainTextEdit` can still allocate while initially receiving a very large paste; the Verify path is bounded before it copies or parses the document.

## Docs / Process Impact

- [x] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [ ] No public docs update needed.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; `src/libbitcoinpqc` is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet RPC defaults and PQC-related proof handling, but consensus and shared verification rules are unchanged; main risk is integrators expecting PQC usage fields by default from `signdatapqchash`.
> 
> **Overview**
> **qbit-qt** now rejects P2MR proof JSON over **32,768 characters** before copying or parsing on the GUI thread, with compile-time sizing tied to the largest portable proof (~15,988 chars). Parsing validates **exact hex lengths**, the **34-byte** single-key leaf script, and **control-block** shape (`1 + 32*n` bytes) **before** `ParseHex`, rejects **duplicate** top-level keys, caps **address** length, and clears verification status when inputs change.
> 
> **`signdatapqchash`** flips **`include_pqc_usage`** to default **false** so default RPC results stay portable; **`include_pqc_usage=true`** keeps diagnostic counters and retry-key metadata. Docs and functional/Qt tests are updated for the new defaults, verifier limits, and legacy-proof compatibility within the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a557a7307de19270cc1451221d93b6a772c2ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->