### PR TITLE
Prevent closing wallet progress dialogs

### DIFF
--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -33,6 +33,7 @@ if(ENABLE_WALLET)
     PRIVATE
       addressbooktests.cpp
       walletcontrollertests.cpp
+      walletactivitytests.cpp
       wallettests.cpp
       ../../wallet/test/wallet_test_fixture.cpp
   )

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -20,6 +20,7 @@
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
 #include <qt/test/walletcontrollertests.h>
+#include <qt/test/walletactivitytests.h>
 #include <qt/test/wallettests.h>
 #endif // ENABLE_WALLET
 
@@ -108,6 +109,9 @@ int main(int argc, char* argv[])
 
         AddressBookTests test6(app.node());
         num_test_failures += QTest::qExec(&test6);
+
+        WalletActivityTests wallet_activity_tests(app.node());
+        num_test_failures += QTest::qExec(&wallet_activity_tests);
 #endif
 
         if (num_test_failures) {

--- a/src/qt/test/walletactivitytests.cpp
+++ b/src/qt/test/walletactivitytests.cpp
@@ -1,0 +1,404 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#include <qt/test/walletactivitytests.h>
+
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+#include <qt/clientmodel.h>
+#include <qt/optionsmodel.h>
+#include <qt/platformstyle.h>
+#include <qt/walletcontroller.h>
+#include <qt/walletmodel.h>
+#include <rpc/server.h>
+#include <univalue.h>
+#include <util/check.h>
+#include <wallet/context.h>
+#include <wallet/test/wallet_test_fixture.h>
+#include <wallet/wallet.h>
+
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <QCoreApplication>
+#include <QDialog>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QPointer>
+#include <QProgressDialog>
+#include <QSignalSpy>
+#include <QWidget>
+
+namespace {
+constexpr int WAIT_TIMEOUT_MS{30'000};
+constexpr auto EXISTING_WALLET_NAME{"existing"};
+constexpr auto CREATED_WALLET_NAME{"created"};
+
+template <typename Predicate>
+bool WaitUntil(Predicate&& predicate, int timeout_ms = WAIT_TIMEOUT_MS)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < timeout_ms) {
+        if (predicate()) return true;
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        QTest::qWait(10);
+    }
+    return predicate();
+}
+
+template <typename Predicate>
+void WaitForActivityCompletion(Predicate&& completed)
+{
+    // Wallet creation is intentionally non-cancellable. If an assertion fails
+    // while the worker is paused at a lifecycle latch, keep the GUI event loop
+    // running until the activity has actually finished. Returning early would
+    // let WalletController teardown wait on a worker that still needs queued
+    // GUI work, masking the original failure with a test timeout.
+    while (!completed()) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        QTest::qWait(10);
+    }
+}
+
+class CreateWalletStageLatch
+{
+public:
+    explicit CreateWalletStageLatch(wallet::CreateWalletStage stage) : m_stage(stage) {}
+
+    ~CreateWalletStageLatch() { release(); }
+
+    void reach(wallet::CreateWalletStage stage)
+    {
+        if (stage != m_stage) return;
+
+        std::unique_lock lock{m_mutex};
+        m_reached = true;
+        m_cv.notify_all();
+        m_cv.wait(lock, [this] { return m_released; });
+    }
+
+    bool reached() const
+    {
+        std::lock_guard lock{m_mutex};
+        return m_reached;
+    }
+
+    void release()
+    {
+        {
+            std::lock_guard lock{m_mutex};
+            m_released = true;
+        }
+        m_cv.notify_all();
+    }
+
+private:
+    const wallet::CreateWalletStage m_stage;
+    mutable std::mutex m_mutex;
+    std::condition_variable m_cv;
+    bool m_reached{false};
+    bool m_released{false};
+};
+
+class TestProgressActivity final : public WalletControllerActivity
+{
+public:
+    TestProgressActivity(WalletController* controller, QWidget* parent)
+        : WalletControllerActivity(controller, parent)
+    {
+    }
+
+    void show()
+    {
+        showProgressDialog(QStringLiteral("Test operation"), QStringLiteral("Testing operation…"));
+    }
+};
+
+class ScopeExit
+{
+public:
+    explicit ScopeExit(std::function<void()> cleanup) : m_cleanup(std::move(cleanup)) {}
+    ~ScopeExit()
+    {
+        if (m_cleanup) m_cleanup();
+    }
+
+    void dismiss() { m_cleanup = {}; }
+
+private:
+    std::function<void()> m_cleanup;
+};
+
+std::set<std::string> RpcWalletNames(interfaces::Node& node, const std::string& command)
+{
+    UniValue result;
+    try {
+        result = node.executeRpc(command, UniValue{UniValue::VARR}, /*uri=*/"");
+    } catch (const UniValue& error) {
+        throw std::runtime_error{command + " RPC failed: " + error.write()};
+    }
+    const UniValue& wallets{command == "listwalletdir" ? result.find_value("wallets") : result};
+    std::set<std::string> names;
+    for (const UniValue& wallet : wallets.getValues()) {
+        names.emplace(command == "listwalletdir" ? wallet.find_value("name").get_str() : wallet.get_str());
+    }
+    return names;
+}
+
+std::vector<std::string> StartupWalletNames(interfaces::Node& node)
+{
+    const common::SettingsValue setting{node.getPersistentSetting("wallet")};
+    std::vector<std::string> names;
+    if (!setting.isArray()) return names;
+    for (const UniValue& wallet : setting.getValues()) {
+        if (wallet.isStr()) names.push_back(wallet.get_str());
+    }
+    return names;
+}
+
+std::set<std::string> AsSet(const std::vector<std::string>& values)
+{
+    return {values.begin(), values.end()};
+}
+
+void ConfigureNode(interfaces::Node& node, wallet::WalletTestingSetup& setup)
+{
+    setup.m_node.wallet_loader = setup.m_wallet_loader.get();
+    node.setContext(&setup.m_node);
+    if (RPCIsInWarmup(nullptr)) SetRPCWarmupFinished();
+}
+
+struct QtWalletModels {
+    explicit QtWalletModels(interfaces::Node& node, const PlatformStyle* platform_style)
+        : options_model{std::make_unique<OptionsModel>(node)}
+    {
+        bilingual_str error;
+        if (!options_model->Init(error)) {
+            throw std::runtime_error{"Failed to initialize Qt options: " + error.original};
+        }
+        client_model = std::make_unique<ClientModel>(node, options_model.get());
+        controller = std::make_unique<WalletController>(*client_model, platform_style, nullptr);
+    }
+
+    void reset()
+    {
+        controller.reset();
+        client_model.reset();
+        options_model.reset();
+    }
+
+    std::unique_ptr<OptionsModel> options_model;
+    std::unique_ptr<ClientModel> client_model;
+    std::unique_ptr<WalletController> controller;
+};
+} // namespace
+
+void WalletActivityTests::createWalletProgress_data()
+{
+    QTest::addColumn<int>("stage_value");
+    QTest::addColumn<bool>("use_escape");
+
+    const std::vector<std::pair<const char*, wallet::CreateWalletStage>> stages{
+        {"before-database", wallet::CreateWalletStage::BEFORE_DATABASE_CREATION},
+        {"during-encryption", wallet::CreateWalletStage::ENCRYPTION_COMMITTED_BEFORE_FINAL_DESCRIPTORS},
+        {"before-load-notification", wallet::CreateWalletStage::BEFORE_LOAD_NOTIFICATION},
+        {"before-created-signal", wallet::CreateWalletStage::MODEL_ADOPTED_BEFORE_CREATED_SIGNAL},
+    };
+    for (const auto& [name, stage] : stages) {
+        QTest::newRow((std::string{name} + "-close").c_str()) << static_cast<int>(stage) << false;
+        QTest::newRow((std::string{name} + "-escape").c_str()) << static_cast<int>(stage) << true;
+    }
+}
+
+void WalletActivityTests::createWalletProgress()
+{
+    QFETCH(int, stage_value);
+    QFETCH(bool, use_escape);
+    const auto stage{static_cast<wallet::CreateWalletStage>(stage_value)};
+
+    wallet::WalletTestingSetup setup{ChainType::REGTEST, {.extra_args = {"-p2mronly=0", "-keypool=1"}}};
+    ConfigureNode(m_node, setup);
+
+    std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    QVERIFY(platform_style);
+    QWidget parent;
+    parent.show();
+    QtWalletModels models{m_node, platform_style.get()};
+
+    WalletModel* existing_model{nullptr};
+    QSignalSpy initial_wallet_added_spy{models.controller.get(), &WalletController::walletAdded};
+    connect(models.controller.get(), &WalletController::walletAdded, models.controller.get(),
+            [&existing_model](WalletModel* wallet_model) {
+                if (!existing_model) existing_model = wallet_model;
+            });
+    std::vector<bilingual_str> warnings;
+    auto existing_wallet{setup.m_wallet_loader->createWallet(
+        EXISTING_WALLET_NAME, /*passphrase=*/{}, wallet::WALLET_FLAG_DESCRIPTORS, warnings)};
+    QVERIFY(existing_wallet);
+    QVERIFY(warnings.empty());
+    QVERIFY(WaitUntil([&] { return initial_wallet_added_spy.count() == 1; }));
+    QVERIFY(existing_model);
+    std::unique_ptr<interfaces::Wallet> existing_wallet_interface{std::move(*existing_wallet)};
+    existing_wallet_interface.reset();
+
+    CreateWalletStageLatch latch{stage};
+    wallet::WalletContext& context{*Assert(setup.m_wallet_loader->context())};
+    context.create_wallet_stage_fn = [&latch](wallet::CreateWalletStage reached_stage) { latch.reach(reached_stage); };
+
+    QSignalSpy wallet_added_spy{models.controller.get(), &WalletController::walletAdded};
+    QPointer<CreateWalletActivity> activity{new CreateWalletActivity(models.controller.get(), &parent)};
+    QSignalSpy created_spy{activity, &CreateWalletActivity::created};
+    QSignalSpy finished_spy{activity, &CreateWalletActivity::finished};
+    WalletModel* active_wallet{existing_model};
+    connect(activity, &CreateWalletActivity::created, activity, [&active_wallet](WalletModel* wallet_model) {
+        active_wallet = wallet_model;
+    });
+    ScopeExit creation_cleanup{[&] {
+        latch.release();
+        WaitForActivityCompletion([&] { return !activity || finished_spy.count() == 1; });
+        context.create_wallet_stage_fn = {};
+    }};
+
+    activity->m_passphrase.assign("test-passphrase");
+    activity->createWallet(QString::fromLatin1(CREATED_WALLET_NAME), wallet::WALLET_FLAG_DESCRIPTORS);
+
+    QPointer<QProgressDialog> progress_dialog{
+        parent.findChild<QProgressDialog*>(QStringLiteral("walletControllerProgressDialog"))};
+    QVERIFY(progress_dialog);
+    QVERIFY(WaitUntil([&] { return progress_dialog && progress_dialog->isVisible() && latch.reached(); }));
+    QCOMPARE(progress_dialog->windowModality(), Qt::ApplicationModal);
+    QVERIFY(!progress_dialog->windowFlags().testFlag(Qt::WindowCloseButtonHint));
+    QVERIFY(progress_dialog->labelText().contains(QStringLiteral("cannot be canceled")));
+    QSignalSpy canceled_spy{progress_dialog, &QProgressDialog::canceled};
+    QSignalSpy rejected_spy{progress_dialog, &QDialog::rejected};
+
+    if (use_escape) {
+        QTest::keyClick(progress_dialog, Qt::Key_Escape);
+    } else {
+        QVERIFY(!progress_dialog->close());
+    }
+    QCoreApplication::processEvents();
+
+    QVERIFY(progress_dialog);
+    QVERIFY(progress_dialog->isVisible());
+    QCOMPARE(canceled_spy.count(), 0);
+    QCOMPARE(rejected_spy.count(), 0);
+    QCOMPARE(created_spy.count(), 0);
+    QCOMPARE(finished_spy.count(), 0);
+    QCOMPARE(active_wallet, existing_model);
+
+    const bool database_exists{stage != wallet::CreateWalletStage::BEFORE_DATABASE_CREATION};
+    const bool model_adopted{stage == wallet::CreateWalletStage::MODEL_ADOPTED_BEFORE_CREATED_SIGNAL};
+    const std::set<std::string> existing_only{EXISTING_WALLET_NAME};
+    const std::set<std::string> both_wallets{EXISTING_WALLET_NAME, CREATED_WALLET_NAME};
+    QVERIFY(RpcWalletNames(m_node, "listwalletdir") == (database_exists ? both_wallets : existing_only));
+    QVERIFY(RpcWalletNames(m_node, "listwallets") == (model_adopted ? both_wallets : existing_only));
+    QVERIFY(AsSet(StartupWalletNames(m_node)) == (model_adopted ? both_wallets : existing_only));
+    QCOMPARE(wallet_added_spy.count(), model_adopted ? 1 : 0);
+
+    latch.release();
+    QVERIFY(WaitUntil([&] { return finished_spy.count() == 1; }));
+    QCOMPARE(created_spy.count(), 1);
+    QVERIFY(WaitUntil([&] { return progress_dialog.isNull(); }));
+    QVERIFY(active_wallet);
+    QCOMPARE(active_wallet->getWalletName(), QString::fromLatin1(CREATED_WALLET_NAME));
+    QVERIFY(RpcWalletNames(m_node, "listwalletdir") == both_wallets);
+    QVERIFY(RpcWalletNames(m_node, "listwallets") == both_wallets);
+    QVERIFY(AsSet(StartupWalletNames(m_node)) == both_wallets);
+    QCOMPARE(wallet_added_spy.count(), 1);
+    context.create_wallet_stage_fn = {};
+    creation_cleanup.dismiss();
+
+    // Simulate shutdown and startup with the persisted wallet setting. Destroy
+    // every GUI wallet wrapper before unloading the core wallets.
+    models.reset();
+    setup.m_wallet_loader->stop();
+    QVERIFY(RpcWalletNames(m_node, "listwallets").empty());
+    QVERIFY(RpcWalletNames(m_node, "listwalletdir") == both_wallets);
+    QVERIFY(AsSet(StartupWalletNames(m_node)) == both_wallets);
+    QVERIFY(setup.m_wallet_loader->verify());
+    QVERIFY(setup.m_wallet_loader->load());
+    QVERIFY(RpcWalletNames(m_node, "listwallets") == both_wallets);
+
+    QtWalletModels restarted_models{m_node, platform_style.get()};
+    WalletModel* startup_active_wallet{nullptr};
+    connect(restarted_models.controller.get(), &WalletController::walletAdded,
+            restarted_models.controller.get(), [&startup_active_wallet](WalletModel* wallet_model) {
+                if (!startup_active_wallet) startup_active_wallet = wallet_model;
+            });
+    QPointer<LoadWalletsActivity> load_activity{
+        new LoadWalletsActivity(restarted_models.controller.get(), &parent)};
+    QSignalSpy load_finished_spy{load_activity, &LoadWalletsActivity::finished};
+    load_activity->load(/*show_loading_minimized=*/false);
+    QVERIFY(WaitUntil([&] { return load_finished_spy.count() == 1; }));
+    QVERIFY(startup_active_wallet);
+    QCOMPARE(startup_active_wallet->getWalletName(), QString::fromLatin1(EXISTING_WALLET_NAME));
+    QVERIFY(RpcWalletNames(m_node, "listwalletdir") == both_wallets);
+    QVERIFY(RpcWalletNames(m_node, "listwallets") == both_wallets);
+    QVERIFY(AsSet(StartupWalletNames(m_node)) == both_wallets);
+    const std::vector<std::string> startup_wallets{StartupWalletNames(m_node)};
+    QCOMPARE(startup_wallets.size(), size_t{2});
+    QCOMPARE(startup_wallets.front(), std::string{EXISTING_WALLET_NAME});
+
+    restarted_models.reset();
+    setup.m_wallet_loader->stop();
+}
+
+void WalletActivityTests::ordinaryLoadAndShutdown()
+{
+    wallet::WalletTestingSetup setup{ChainType::REGTEST, {.extra_args = {"-p2mronly=0", "-keypool=1"}}};
+    ConfigureNode(m_node, setup);
+
+    std::vector<bilingual_str> warnings;
+    auto wallet{setup.m_wallet_loader->createWallet(
+        EXISTING_WALLET_NAME, /*passphrase=*/{}, wallet::WALLET_FLAG_DESCRIPTORS, warnings)};
+    QVERIFY(wallet);
+    QVERIFY(warnings.empty());
+    std::unique_ptr<interfaces::Wallet> wallet_interface{std::move(*wallet)};
+    wallet_interface.reset();
+
+    std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    QVERIFY(platform_style);
+    QWidget parent;
+    parent.show();
+    QtWalletModels models{m_node, platform_style.get()};
+
+    QSignalSpy wallet_added_spy{models.controller.get(), &WalletController::walletAdded};
+    QPointer<LoadWalletsActivity> load_activity{new LoadWalletsActivity(models.controller.get(), &parent)};
+    QSignalSpy load_finished_spy{load_activity, &LoadWalletsActivity::finished};
+    load_activity->load(/*show_loading_minimized=*/false);
+    QVERIFY(WaitUntil([&] { return load_finished_spy.count() == 1; }));
+    QCOMPARE(wallet_added_spy.count(), 1);
+    QVERIFY(WaitUntil([&] { return load_activity.isNull(); }));
+    QVERIFY(parent.findChild<QProgressDialog*>(QStringLiteral("walletControllerProgressDialog")) == nullptr);
+
+    QElapsedTimer shutdown_timer;
+    shutdown_timer.start();
+    models.reset();
+    QVERIFY(shutdown_timer.elapsed() < 5'000);
+
+    // A controller teardown also owns and destroys an unfinished activity and
+    // its application-modal progress surface.
+    QtWalletModels teardown_models{m_node, platform_style.get()};
+    QPointer<TestProgressActivity> activity{
+        new TestProgressActivity(teardown_models.controller.get(), &parent)};
+    activity->show();
+    QPointer<QProgressDialog> progress_dialog{
+        parent.findChild<QProgressDialog*>(QStringLiteral("walletControllerProgressDialog"))};
+    QVERIFY(progress_dialog);
+    QVERIFY(WaitUntil([&] { return progress_dialog->isVisible(); }));
+    teardown_models.reset();
+    QVERIFY(activity.isNull());
+    QVERIFY(progress_dialog.isNull());
+
+    setup.m_wallet_loader->stop();
+}

--- a/src/qt/test/walletactivitytests.h
+++ b/src/qt/test/walletactivitytests.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit/.
+
+#ifndef QBIT_QT_TEST_WALLETACTIVITYTESTS_H
+#define QBIT_QT_TEST_WALLETACTIVITYTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+class WalletActivityTests : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit WalletActivityTests(interfaces::Node& node) : m_node(node) {}
+
+private Q_SLOTS:
+    void createWalletProgress_data();
+    void createWalletProgress();
+    void ordinaryLoadAndShutdown();
+
+private:
+    interfaces::Node& m_node;
+};
+
+#endif // QBIT_QT_TEST_WALLETACTIVITYTESTS_H

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -17,6 +17,7 @@
 #include <util/string.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
+#include <wallet/context.h>
 #include <wallet/wallet.h>
 
 #include <algorithm>
@@ -26,6 +27,7 @@
 #include <utility>
 
 #include <QApplication>
+#include <QCloseEvent>
 #include <QMessageBox>
 #include <QMetaObject>
 #include <QThread>
@@ -43,6 +45,36 @@ struct PendingWalletModel
 {
     std::unique_ptr<interfaces::Wallet> wallet;
     std::function<void(WalletModel*)> callback;
+};
+
+class NonDismissibleProgressDialog final : public QProgressDialog
+{
+public:
+    explicit NonDismissibleProgressDialog(QWidget* parent) : QProgressDialog(parent) {}
+
+    void finishAndClose()
+    {
+        m_operation_finished = true;
+        close();
+    }
+
+protected:
+    void reject() override
+    {
+        if (m_operation_finished) QProgressDialog::reject();
+    }
+
+    void closeEvent(QCloseEvent* event) override
+    {
+        if (!m_operation_finished) {
+            event->ignore();
+            return;
+        }
+        QProgressDialog::closeEvent(event);
+    }
+
+private:
+    bool m_operation_finished{false};
 };
 } // namespace
 
@@ -214,14 +246,29 @@ void WalletControllerActivity::scheduleWalletModel(std::unique_ptr<interfaces::W
     m_wallet_controller->scheduleWalletModel(std::move(wallet), std::move(callback));
 }
 
+WalletControllerActivity::~WalletControllerActivity()
+{
+    delete m_progress_dialog.data();
+}
+
 void WalletControllerActivity::showProgressDialog(const QString& title_text, const QString& label_text, bool show_minimized)
 {
-    auto progress_dialog = new QProgressDialog(m_parent_widget);
+    assert(!m_progress_dialog);
+    auto progress_dialog = new NonDismissibleProgressDialog(m_parent_widget);
+    m_progress_dialog = progress_dialog;
     progress_dialog->setAttribute(Qt::WA_DeleteOnClose);
-    connect(this, &WalletControllerActivity::finished, progress_dialog, &QWidget::close);
+    connect(this, &WalletControllerActivity::finished, progress_dialog, &NonDismissibleProgressDialog::finishAndClose);
 
+    progress_dialog->setObjectName(QStringLiteral("walletControllerProgressDialog"));
+    Qt::WindowFlags window_flags{progress_dialog->windowFlags()};
+    window_flags.setFlag(Qt::CustomizeWindowHint);
+    window_flags.setFlag(Qt::WindowCloseButtonHint, false);
+    progress_dialog->setWindowFlags(window_flags);
     progress_dialog->setWindowTitle(title_text);
-    progress_dialog->setLabelText(label_text);
+    progress_dialog->setLabelText(
+        label_text + QStringLiteral("<br><br>") +
+        //: Explanatory text for non-cancellable wallet operations.
+        tr("This operation cannot be canceled. This window will close automatically when it is finished."));
     progress_dialog->setRange(0, 0);
     progress_dialog->setCancelButton(nullptr);
     progress_dialog->setWindowModality(Qt::ApplicationModal);
@@ -230,7 +277,11 @@ void WalletControllerActivity::showProgressDialog(const QString& title_text, con
     // See details in https://bugreports.qt.io/browse/QTBUG-47042.
     progress_dialog->setValue(0);
     // When requested, launch dialog minimized
-    if (show_minimized) progress_dialog->showMinimized();
+    if (show_minimized) {
+        progress_dialog->showMinimized();
+    } else {
+        progress_dialog->show();
+    }
 }
 
 CreateWalletActivity::CreateWalletActivity(WalletController* wallet_controller, QWidget* parent_widget)
@@ -264,14 +315,6 @@ void CreateWalletActivity::askPassphrase()
 
 void CreateWalletActivity::createWallet()
 {
-    showProgressDialog(
-        //: Title of window indicating the progress of creation of a new wallet.
-        tr("Create Wallet"),
-        /*: Descriptive text of the create wallet progress window which indicates
-            to the user which wallet is currently being created. */
-        tr("Creating Wallet <b>%1</b>…").arg(m_create_wallet_dialog->walletName().toHtmlEscaped()));
-
-    std::string name = m_create_wallet_dialog->walletName().toStdString();
     uint64_t flags = 0;
     // Enable descriptors by default.
     flags |= WALLET_FLAG_DESCRIPTORS;
@@ -285,13 +328,32 @@ void CreateWalletActivity::createWallet()
         flags |= WALLET_FLAG_EXTERNAL_SIGNER;
     }
 
-    QTimer::singleShot(0ms, worker(), [this, name, flags] {
+    createWallet(m_create_wallet_dialog->walletName(), flags);
+}
+
+void CreateWalletActivity::createWallet(const QString& name, uint64_t flags)
+{
+    showProgressDialog(
+        //: Title of window indicating the progress of creation of a new wallet.
+        tr("Create Wallet"),
+        /*: Descriptive text of the create wallet progress window which indicates
+            to the user which wallet is currently being created. */
+        tr("Creating Wallet <b>%1</b>…").arg(name.toHtmlEscaped()));
+
+    QTimer::singleShot(0ms, worker(), [this, name = name.toStdString(), flags] {
         auto wallet{node().walletLoader().createWallet(name, m_passphrase, flags, m_warning_message)};
 
         if (wallet) {
             scheduleWalletModel(std::move(*wallet), [this](WalletModel* wallet_model) {
                 m_wallet_model = wallet_model;
-                finish();
+                if (wallet::WalletContext* context{node().walletLoader().context()}; context && context->create_wallet_stage_fn) {
+                    QTimer::singleShot(0ms, worker(), [this, context] {
+                        context->create_wallet_stage_fn(wallet::CreateWalletStage::MODEL_ADOPTED_BEFORE_CREATED_SIGNAL);
+                        QTimer::singleShot(0ms, this, &CreateWalletActivity::finish);
+                    });
+                } else {
+                    finish();
+                }
             });
         } else {
             m_error_message = util::ErrorString(wallet);

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include <QMessageBox>
+#include <QPointer>
 #include <QProgressDialog>
 #include <QThread>
 #include <QTimer>
@@ -43,6 +44,7 @@ class CreateWalletDialog;
 class MigrateWalletActivity;
 class OpenWalletActivity;
 class WalletControllerActivity;
+class WalletActivityTests;
 
 /**
  * Controller between interfaces::Node, WalletModel instances and the GUI.
@@ -97,7 +99,7 @@ class WalletControllerActivity : public QObject
 
 public:
     WalletControllerActivity(WalletController* wallet_controller, QWidget* parent_widget);
-    virtual ~WalletControllerActivity() = default;
+    ~WalletControllerActivity() override;
 
 Q_SIGNALS:
     void finished();
@@ -111,6 +113,7 @@ protected:
 
     WalletController* const m_wallet_controller;
     QWidget* const m_parent_widget;
+    QPointer<QProgressDialog> m_progress_dialog;
     WalletModel* m_wallet_model{nullptr};
     bilingual_str m_error_message;
     std::vector<bilingual_str> m_warning_message;
@@ -133,11 +136,14 @@ Q_SIGNALS:
 private:
     void askPassphrase();
     void createWallet();
+    void createWallet(const QString& name, uint64_t flags);
     void finish();
 
     SecureString m_passphrase;
     CreateWalletDialog* m_create_wallet_dialog{nullptr};
     AskPassphraseDialog* m_passphrase_dialog{nullptr};
+
+    friend class WalletActivityTests;
 };
 
 class OpenWalletActivity : public WalletControllerActivity

--- a/src/wallet/context.h
+++ b/src/wallet/context.h
@@ -23,6 +23,15 @@ namespace wallet {
 class CWallet;
 using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wallet)>;
 
+enum class CreateWalletStage {
+    BEFORE_DATABASE_CREATION,
+    ENCRYPTION_COMMITTED_BEFORE_FINAL_DESCRIPTORS,
+    BEFORE_LOAD_NOTIFICATION,
+    MODEL_ADOPTED_BEFORE_CREATED_SIGNAL,
+};
+
+using CreateWalletStageFn = std::function<void(CreateWalletStage)>;
+
 //! WalletContext struct containing references to state shared between CWallet
 //! instances, like the reference to the chain interface, and the list of opened
 //! wallets.
@@ -42,6 +51,10 @@ struct WalletContext {
     Mutex wallets_mutex;
     std::vector<std::shared_ptr<CWallet>> wallets GUARDED_BY(wallets_mutex);
     std::list<LoadWalletFn> wallet_load_fns GUARDED_BY(wallets_mutex);
+
+    // Optional deterministic lifecycle hook for tests. Set before wallet
+    // creation starts and keep unchanged until creation has completed.
+    CreateWalletStageFn create_wallet_stage_fn;
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the WalletContext struct doesn't need to #include class

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -673,6 +673,10 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
         return nullptr;
     }
 
+    if (context.create_wallet_stage_fn) {
+        context.create_wallet_stage_fn(CreateWalletStage::BEFORE_DATABASE_CREATION);
+    }
+
     // Wallet::Verify will check if we're trying to create a wallet with a duplicate name.
     std::unique_ptr<WalletDatabase> database = MakeWalletDatabase(name, options, status, error);
     if (!database) {
@@ -697,6 +701,9 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
             status = DatabaseStatus::FAILED_ENCRYPT;
             return nullptr;
         }
+        if (!create_blank && context.create_wallet_stage_fn) {
+            context.create_wallet_stage_fn(CreateWalletStage::ENCRYPTION_COMMITTED_BEFORE_FINAL_DESCRIPTORS);
+        }
         if (!create_blank) {
             // Unlock the wallet
             // Unlock only long enough to rebuild the final encrypted descriptors.
@@ -716,6 +723,10 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
             // Relock the wallet
             wallet->Lock();
         }
+    }
+
+    if (context.create_wallet_stage_fn) {
+        context.create_wallet_stage_fn(CreateWalletStage::BEFORE_LOAD_NOTIFICATION);
     }
 
     NotifyWalletLoaded(context, wallet);


### PR DESCRIPTION
## Summary

Fixes #92.

Wallet operation progress dialogs removed their Cancel button but still accepted title-bar close and Escape. Because the dialog used `WA_DeleteOnClose` and had no cancellation connection, dismissing it removed the only progress surface and application modality while wallet creation continued through persistence, loading, startup registration, and active-wallet selection.

This change:

- makes shared wallet-controller progress dialogs non-dismissible until their activity finishes;
- hides the title-bar close affordance while retaining close-event and `reject()` guards for window-manager differences;
- explains that the operation cannot be canceled and that the window closes automatically;
- explicitly owns and destroys the progress dialog with its activity; and
- adds deterministic lifecycle hooks and latch-controlled Qt tests for close and Escape at every durable create-wallet boundary.

The tests assert interim and completed `listwalletdir`, `listwallets`, startup-setting, model-adoption, active-wallet, and restart behavior. They also cover ordinary wallet loading and controller/dialog teardown.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands and checks:

```sh
cmake --build build --target test_bitcoin-qt -j 10
cmake --build build --target test_bitcoin qbitd qbit-cli -j 10
ulimit -n 10240
QTEST_FUNCTION_TIMEOUT=600000 build/bin/test_qbit-qt -v1
QT_QPA_PLATFORM=cocoa QTEST_FUNCTION_TIMEOUT=600000 build/bin/test_qbit-qt -v1
build/bin/test_qbit --run_test=wallet_tests,walletload_tests,wallet_crypto_tests --log_level=test_suite
build/test/functional/test_runner.py wallet_createwallet.py wallet_startup.py --jobs=2 --failfast
build/test/functional/test_runner.py wallet_createwalletdescriptor.py --jobs=1 --failfast
clang-format --dry-run --Werror src/qt/test/walletactivitytests.cpp src/qt/test/walletactivitytests.h
git diff --check
DOCKER_BUILDKIT=1 docker build -t qbit-wallet-progress-linter --file ./ci/lint_imagefile .
```

The full Docker lint runner was then run from a disposable standalone worktree; all checks passed.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: This is wallet-safety-sensitive GUI lifecycle behavior, but it is non-consensus and does not change wallet formats, keys, encryption, RPC semantics, or persistence ordering. The lifecycle callbacks are test-only hooks that are unset in production.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: the behavior is self-contained in the progress dialog, which now includes explicit user-facing copy; no public API, integration, or operator workflow changes.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786307520&installation_id=141183937&pr_number=97&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F97&signature=093a47605cf8807545aa2e4e46b1b3cfd99d99717be14fcdf85a56dde987da25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet GUI lifecycle and adds optional test hooks on WalletContext during create-wallet; no consensus or persistence format changes, but incorrect dialog/activity teardown could affect shutdown or modal behavior.
> 
> **Overview**
> Wallet-controller progress dialogs (create, open, load, etc.) can no longer be closed via the title bar or Escape while the underlying activity is still running. A **`NonDismissibleProgressDialog`** ignores close events and `reject()` until the activity calls **`finishAndClose`** on completion; the UI hides the close button and adds copy that the operation cannot be canceled.
> 
> Progress dialogs are tracked on **`WalletControllerActivity`** (`QPointer`), explicitly destroyed in the activity destructor, and given a stable object name for tests. **`CreateWalletActivity`** exposes an overload **`createWallet(name, flags)`** for direct test invocation.
> 
> Optional **`CreateWalletStage`** callbacks on **`WalletContext`** (wired in **`wallet.cpp`** and the Qt create path) let Qt tests pause creation at durable boundaries and assert that dismissal attempts do not cancel work or skew wallet dir, loaded wallets, startup settings, or active-wallet state. New **`WalletActivityTests`** cover those scenarios plus ordinary load and controller teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b844e97a254cda4c28f656e2e3ab4632b413d923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->