### PR TITLE
validation: reject height-invalid AuxPoW substitutions

### DIFF
--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <limits>
 #include <memory>
 #include <string>
@@ -108,8 +109,9 @@ std::vector<unsigned char> MakeCommitment(std::vector<unsigned char> prefix, con
     return MakeCommitment(std::move(prefix), AuxpowCommitmentRootBytes(root), merkle_size, nonce);
 }
 
-std::shared_ptr<const CAuxPow> MakeAuxpowPayload(const uint256& aux_block_hash, const Consensus::Params& consensus, const uint32_t target_bits, const uint32_t parent_time)
+std::shared_ptr<const CAuxPow> MakeAuxpowPayload(const uint256& aux_block_hash, const Consensus::Params& consensus, const uint32_t target_bits, const uint32_t parent_time, const auxpow::CommitmentValidation commitment_order = auxpow::CommitmentValidation::DISPLAY)
 {
+    assert(commitment_order != auxpow::CommitmentValidation::EITHER);
     auto auxpow = std::make_shared<CAuxPow>();
     auxpow->coinbase_merkle_branch.clear();
     auxpow->coinbase_branch_index = 0;
@@ -118,7 +120,8 @@ std::shared_ptr<const CAuxPow> MakeAuxpowPayload(const uint256& aux_block_hash, 
 
     std::vector<unsigned char> commitment;
     commitment.insert(commitment.end(), MERGED_MINING_HEADER.begin(), MERGED_MINING_HEADER.end());
-    commitment = MakeCommitment(std::move(commitment), aux_block_hash, /*merkle_size=*/1, /*nonce=*/0);
+    const auto commitment_root = commitment_order == auxpow::CommitmentValidation::DISPLAY ? AuxpowCommitmentRootBytes(aux_block_hash) : InternalUint256Bytes(aux_block_hash);
+    commitment = MakeCommitment(std::move(commitment), commitment_root, /*merkle_size=*/1, /*nonce=*/0);
 
     auxpow->coinbase_tx = MakeParentCoinbase(commitment);
     auxpow->parent_block.nVersion = 1;
@@ -1049,6 +1052,63 @@ BOOST_AUTO_TEST_CASE(auxpow_header_reject_reason_and_index_accounting)
     const CBlockIndex* tip = WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain().Tip());
     BOOST_REQUIRE(tip != nullptr);
     BOOST_CHECK_EQUAL(tip->nAuxPow, 1U);
+}
+
+BOOST_AUTO_TEST_CASE(auxpow_known_header_rejects_height_invalid_payload_substitution)
+{
+    const auto& consensus = Params().GetConsensus();
+    bool new_block{false};
+    BOOST_REQUIRE(m_node.chainman->ProcessNewBlock(std::make_shared<CBlock>(Params().GenesisBlock()), /*force_processing=*/true, /*min_pow_checked=*/true, &new_block));
+
+    auto block = CreateBlockTemplate();
+    block->nVersion = MakeVersion(static_cast<uint16_t>(consensus.nAuxpowChainId), /*auxpow=*/true, block->GetVersionBits());
+    FinalizeBlock(*block);
+
+    CBlockHeader display_header{block->GetBlockHeader()};
+    display_header.auxpow = MakeAuxpowPayload(display_header.GetHash(), consensus, display_header.nBits, display_header.nTime, auxpow::CommitmentValidation::DISPLAY);
+    const uint256 indexed_parent_hash{display_header.auxpow->GetParentBlockHash()};
+
+    BlockValidationState state;
+    const CBlockIndex* pindex{nullptr};
+    BOOST_REQUIRE(m_node.chainman->ProcessNewBlockHeaders({{display_header}}, /*min_pow_checked=*/true, state, &pindex));
+    BOOST_REQUIRE(pindex != nullptr);
+    BOOST_REQUIRE(pindex->auxpow);
+    BOOST_CHECK_EQUAL(pindex->auxpow->GetParentBlockHash(), indexed_parent_hash);
+
+    auto internal_block = std::make_shared<CBlock>(*block);
+    internal_block->auxpow = MakeAuxpowPayload(internal_block->GetHash(), consensus, internal_block->nBits, internal_block->nTime + 1, auxpow::CommitmentValidation::INTERNAL);
+
+    state = BlockValidationState{};
+    BOOST_CHECK(!m_node.chainman->ProcessNewBlockHeaders({{internal_block->GetBlockHeader()}}, /*min_pow_checked=*/true, state));
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "bad-auxpow-commitment");
+
+    // force_processing=true exercises the requested-block path used by
+    // getblockfrompeer after a header has already been accepted.
+    new_block = true;
+    BOOST_CHECK(!m_node.chainman->ProcessNewBlock(internal_block, /*force_processing=*/true, /*min_pow_checked=*/true, &new_block));
+    BOOST_CHECK(!new_block);
+    const uint32_t rejected_status{WITH_LOCK(::cs_main, return pindex->nStatus)};
+    BOOST_CHECK(!(rejected_status & BLOCK_HAVE_DATA));
+    BOOST_CHECK(!(rejected_status & BLOCK_FAILED_MASK));
+    BOOST_REQUIRE(pindex->auxpow);
+    BOOST_CHECK_EQUAL(pindex->auxpow->GetParentBlockHash(), indexed_parent_hash);
+
+    auto alternate_display_block = std::make_shared<CBlock>(*block);
+    alternate_display_block->auxpow = MakeAuxpowPayload(alternate_display_block->GetHash(), consensus, alternate_display_block->nBits, alternate_display_block->nTime + 2, auxpow::CommitmentValidation::DISPLAY);
+    BOOST_REQUIRE_NE(alternate_display_block->auxpow->GetParentBlockHash(), indexed_parent_hash);
+
+    BOOST_REQUIRE(m_node.chainman->ProcessNewBlock(alternate_display_block, /*force_processing=*/true, /*min_pow_checked=*/true, &new_block));
+    BOOST_CHECK(new_block);
+    const uint32_t accepted_status{WITH_LOCK(::cs_main, return pindex->nStatus)};
+    BOOST_CHECK(accepted_status & BLOCK_HAVE_DATA);
+    BOOST_CHECK(!(accepted_status & BLOCK_FAILED_MASK));
+    BOOST_REQUIRE(pindex->auxpow);
+    BOOST_CHECK_EQUAL(pindex->auxpow->GetParentBlockHash(), indexed_parent_hash);
+
+    CBlock stored_block;
+    BOOST_REQUIRE(m_node.chainman->m_blockman.ReadBlock(stored_block, *pindex));
+    BOOST_REQUIRE(stored_block.auxpow);
+    BOOST_CHECK_EQUAL(stored_block.auxpow->GetParentBlockHash(), alternate_display_block->auxpow->GetParentBlockHash());
 }
 
 BOOST_AUTO_TEST_CASE(has_valid_proof_of_work_rejects_bad_permissionless_headers)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4715,6 +4715,12 @@ bool ChainstateManager::AcceptBlockHeader(const CBlockHeader& block, BlockValida
                 LogDebug(BCLog::VALIDATION, "%s: block %s is marked invalid\n", __func__, hash.ToString());
                 return state.Invalid(BlockValidationResult::BLOCK_CACHED_INVALID, "duplicate-invalid");
             }
+            // AuxPoW is not part of the block hash, so a known header can be
+            // received again with a different payload. Validate the incoming
+            // payload for the indexed height before treating it as equivalent.
+            if (const auto error = auxpow::Validate(block, GetConsensus(), /*check_pow=*/true, auxpow::CommitmentValidationForHeight(GetConsensus(), pindex->nHeight))) {
+                return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, error->reject_reason, error->debug_message);
+            }
             return true;
         }
 


### PR DESCRIPTION
## Summary

Fixes #101.

- Revalidate incoming AuxPoW payloads for already-known headers using the commitment order required at the indexed height.
- Reject wrong-order full-block substitutions before relay or disk write without marking the legitimate indexed header invalid.
- Continue accepting distinct AuxPoW proofs that satisfy the required commitment order.
- Add regression coverage for headers-first and requested-block processing, index status safety, and strict indexed disk reads.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands and checks:

- Built the test_qbit target with CMake.
- Passed auxpow_tests.
- Passed auxpow_tests_validation, including auxpow_known_header_rejects_height_invalid_payload_substitution.
- Passed git diff --check and git clang-format --diff.
- Passed the Docker lint runner checks relevant to the change. The commit-only scripted_diff check was not run locally because this Conductor worktree cannot safely perform its checkout/reset workflow; this change contains no scripted diff.

## Target Branch

- [x] This PR targets main or a maintainer-requested release branch such as 0.1.x. The requested target is 1.0.0.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

This tightens full-block and duplicate-header acceptance to the height-specific AuxPoW commitment rule that is already enforced for new headers and indexed disk reads. It does not change activation heights or require a chain reset. Review should focus on duplicate-header semantics and ensuring alternate valid proofs remain accepted.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this enforces the existing consensus commitment-order schedule consistently and does not change operator or integration behavior.

## libbitcoinpqc Subtree Checklist (if src/libbitcoinpqc changed)

- [ ] Source commit is reachable from an immutable release tag in Qbit-Org/qbit-libbitcoinpqc.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with contrib/devtools/update-libbitcoinpqc-subtree.sh.
- [ ] test/lint/libbitcoinpqc-subtree-check.sh passes locally.
- [ ] Any default tag change in contrib/devtools/update-libbitcoinpqc-subtree.sh is intentional and matches doc/subtrees/libbitcoinpqc.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786386786&installation_id=141183937&pr_number=106&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F106&signature=9e6cd99b0576e1857114c5ad1edee15597704e37db5a28590e6f3a8b9857d738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Consensus validation change: duplicate-header acceptance now enforces AuxPoW commitment rules that were previously skippable, affecting P2P block relay and storage semantics.
> 
> **Overview**
> **Duplicate AuxPoW headers are no longer treated as equivalent without checking the payload.** Because AuxPoW is excluded from the block hash, the same header could be re-received with a different merged-mining proof; `AcceptBlockHeader` now runs `auxpow::Validate` with `CommitmentValidationForHeight` on already-indexed headers before accepting the duplicate.
> 
> Wrong commitment order at that height is rejected with `bad-auxpow-commitment` without marking the indexed entry failed or writing bad block data. A different proof that still satisfies the height rule can be accepted and stored.
> 
> Tests extend `MakeAuxpowPayload` for DISPLAY vs INTERNAL commitments and add `auxpow_known_header_rejects_height_invalid_payload_substitution` for headers-first, `force_processing` full blocks, index status, and disk reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c051450a763a586fb7904cc214db8bef803349c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->