### PR TITLE
Cache Cadence lane predecessors for constant-time validation

### DIFF
--- a/src/bench/CMakeLists.txt
+++ b/src/bench/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(bench_bitcoin
   block_assemble.cpp
   blockencodings.cpp
   ccoins_caching.cpp
+  cadence.cpp
   chacha20.cpp
   checkblock.cpp
   checkblockindex.cpp

--- a/src/bench/cadence.cpp
+++ b/src/bench/cadence.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or https://opensource.org/license/mit.
+
+#include <bench/bench.h>
+
+#include <chain.h>
+#include <chainparams.h>
+#include <common/args.h>
+#include <headerssync.h>
+#include <pow.h>
+#include <primitives/block.h>
+#include <util/chaintype.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+
+namespace {
+class CadenceBenchChain
+{
+public:
+    explicit CadenceBenchChain(const Consensus::Params& consensus, const size_t starvation_distance)
+    {
+        const int32_t permissionless_version{MakeVersion(/*chain_id=*/0, /*auxpow=*/false, /*version_bits=*/0)};
+        const int32_t auxpow_version{MakeVersion(static_cast<uint16_t>(consensus.nAuxpowChainId), /*auxpow=*/true, /*version_bits=*/0)};
+
+        Append(permissionless_version,
+               consensus.asertAnchorParams.nBlockTime,
+               consensus.asertAnchorParams.nBitsLegacy);
+        Append(auxpow_version,
+               m_indexes.back().nTime + static_cast<uint32_t>(consensus.nPowTargetSpacingAuxPow),
+               consensus.asertAnchorParams.nBitsAuxPow);
+        for (size_t i = 0; i < starvation_distance; ++i) {
+            Append(permissionless_version,
+                   m_indexes.back().nTime + static_cast<uint32_t>(consensus.nPowTargetSpacingLegacy),
+                   consensus.asertAnchorParams.nBitsLegacy);
+        }
+
+        m_next_auxpow.nVersion = auxpow_version;
+        m_next_auxpow.hashPrevBlock = Tip().GetBlockHash();
+        m_next_auxpow.nTime = Tip().nTime + 1;
+        m_next_auxpow.nBits = GetNextWorkRequired(&Tip(), &m_next_auxpow, consensus);
+    }
+
+    const CBlockIndex& Tip() const { return m_indexes.back(); }
+    const CBlockHeader& NextAuxpow() const { return m_next_auxpow; }
+
+private:
+    void Append(const int32_t version, const uint32_t time, const uint32_t bits)
+    {
+        CBlockHeader header;
+        header.nVersion = version;
+        header.hashPrevBlock = m_indexes.empty() ? uint256{} : m_indexes.back().GetBlockHash();
+        header.nTime = time;
+        header.nBits = bits;
+
+        m_indexes.emplace_back(header);
+        m_hashes.emplace_back(header.GetHash());
+        CBlockIndex& index{m_indexes.back()};
+        index.phashBlock = &m_hashes.back();
+        index.pprev = m_indexes.size() == 1 ? nullptr : &m_indexes[m_indexes.size() - 2];
+        index.nHeight = index.pprev == nullptr ? 0 : index.pprev->nHeight + 1;
+        index.nAuxPow = (index.pprev == nullptr ? 0 : index.pprev->nAuxPow) + (header.SignalsAuxpow() ? 1 : 0);
+        index.nChainWork = (index.pprev == nullptr ? arith_uint256{} : index.pprev->nChainWork) + GetBlockProof(index);
+        index.BuildSkip();
+        index.BuildCadenceLaneLinks();
+    }
+
+    std::deque<CBlockIndex> m_indexes;
+    std::deque<uint256> m_hashes;
+    CBlockHeader m_next_auxpow;
+};
+
+size_t StarvationDistance(const benchmark::Bench& bench)
+{
+    return std::max<size_t>(1, static_cast<size_t>(bench.complexityN()));
+}
+
+void CadenceLaneLookup(benchmark::Bench& bench)
+{
+    ArgsManager args;
+    const auto chain_params{CreateChainParams(args, ChainType::MAIN)};
+    const auto& consensus{chain_params->GetConsensus()};
+    CadenceBenchChain chain{consensus, StarvationDistance(bench)};
+
+    bench.run([&] {
+        ankerl::nanobench::doNotOptimizeAway(GetNextWorkRequired(&chain.Tip(), &chain.NextAuxpow(), consensus));
+    });
+}
+
+void CadenceHeadersSyncInit(benchmark::Bench& bench)
+{
+    ArgsManager args;
+    const auto chain_params{CreateChainParams(args, ChainType::MAIN)};
+    const auto& consensus{chain_params->GetConsensus()};
+    CadenceBenchChain chain{consensus, StarvationDistance(bench)};
+    const arith_uint256 minimum_work{chain.Tip().nChainWork + GetBlockProof(CBlockIndex{chain.NextAuxpow()})};
+
+    bench.run([&] {
+        HeadersSyncState state{/*id=*/0, consensus, &chain.Tip(), minimum_work};
+        ankerl::nanobench::doNotOptimizeAway(state.GetState());
+    });
+}
+} // namespace
+
+BENCHMARK(CadenceLaneLookup, benchmark::PriorityLevel::HIGH);
+BENCHMARK(CadenceHeadersSyncInit, benchmark::PriorityLevel::HIGH);

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -123,6 +123,29 @@ void CBlockIndex::BuildSkip()
         pskip = pprev->GetAncestor(GetSkipHeight(nHeight));
 }
 
+void CBlockIndex::BuildCadenceLaneLinks()
+{
+    pprev_permissionless = nullptr;
+    pprev_auxpow = nullptr;
+    if (!pprev) return;
+
+    if (pprev->SignalsAuxpow()) {
+        pprev_auxpow = pprev;
+        pprev_permissionless = pprev->pprev_permissionless;
+    } else {
+        pprev_permissionless = pprev;
+        pprev_auxpow = pprev->pprev_auxpow;
+    }
+}
+
+const CBlockIndex* CBlockIndex::GetPreviousBlockForLane(const bool auxpow, const int min_height) const noexcept
+{
+    if (SignalsAuxpow() == auxpow) return this;
+
+    const CBlockIndex* candidate = auxpow ? pprev_auxpow : pprev_permissionless;
+    return candidate != nullptr && candidate->nHeight >= min_height ? candidate : nullptr;
+}
+
 arith_uint256 GetBlockProof(const CBlockIndex& block)
 {
     arith_uint256 bnTarget;

--- a/src/chain.h
+++ b/src/chain.h
@@ -155,6 +155,12 @@ public:
     //! pointer to the index of some further predecessor of this block
     CBlockIndex* pskip{nullptr};
 
+    //! nearest strict permissionless ancestor (memory only)
+    CBlockIndex* pprev_permissionless{nullptr};
+
+    //! nearest strict AuxPoW ancestor (memory only)
+    CBlockIndex* pprev_auxpow{nullptr};
+
     //! height of the entry in the chain. The genesis block has height 0
     int nHeight{0};
 
@@ -341,6 +347,16 @@ public:
 
     //! Build the skiplist pointer for this entry.
     void BuildSkip();
+
+    //! Build branch-local Cadence lane predecessor pointers for this entry.
+    void BuildCadenceLaneLinks();
+
+    /**
+     * Return the most recent block in the requested Cadence lane, including
+     * this entry when it matches. An opposite-lane ancestor below min_height
+     * is excluded to preserve the ASERT anchor boundary.
+     */
+    const CBlockIndex* GetPreviousBlockForLane(bool auxpow, int min_height) const noexcept;
 
     //! Efficiently find an ancestor of this block.
     CBlockIndex* GetAncestor(int height);

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -76,18 +76,15 @@ HeadersSyncState::HeaderDifficultyState HeadersSyncState::MakeHeaderDifficultySt
     state.height = m_chain_start->nHeight;
     state.auxpow_count = m_chain_start->nAuxPow;
 
-    const CBlockIndex* pindex = m_chain_start;
-    while (pindex != nullptr) {
-        const ASERTHeaderState header_state{pindex->nHeight, pindex->GetBlockTime(), pindex->nAuxPow};
-        if (pindex->SignalsAuxpow()) {
-            if (!state.previous_auxpow) state.previous_auxpow = header_state;
-        } else {
-            if (!state.previous_permissionless) state.previous_permissionless = header_state;
-        }
-
-        if (state.previous_permissionless && state.previous_auxpow) break;
-        if (pindex->nHeight <= m_consensus_params.asertAnchorParams.nHeight) break;
-        pindex = pindex->pprev;
+    const int anchor_height{m_consensus_params.asertAnchorParams.nHeight};
+    const auto to_header_state = [](const CBlockIndex& pindex) {
+        return ASERTHeaderState{pindex.nHeight, pindex.GetBlockTime(), pindex.nAuxPow};
+    };
+    if (const CBlockIndex* permissionless = m_chain_start->GetPreviousBlockForLane(/*auxpow=*/false, anchor_height)) {
+        state.previous_permissionless = to_header_state(*permissionless);
+    }
+    if (const CBlockIndex* auxpow = m_chain_start->GetPreviousBlockForLane(/*auxpow=*/true, anchor_height)) {
+        state.previous_auxpow = to_header_state(*auxpow);
     }
 
     return state;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -252,6 +252,7 @@ CBlockIndex* BlockManager::AddToBlockIndex(const CBlockHeader& block, CBlockInde
         pindexNew->nHeight = pindexNew->pprev->nHeight + 1;
         pindexNew->BuildSkip();
     }
+    pindexNew->BuildCadenceLaneLinks();
     pindexNew->nTimeMax = (pindexNew->pprev ? std::max(pindexNew->pprev->nTimeMax, pindexNew->nTime) : pindexNew->nTime);
     pindexNew->nAuxPow = (pindexNew->pprev ? pindexNew->pprev->nAuxPow : 0) + (pindexNew->SignalsAuxpow() ? 1 : 0);
     pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
@@ -468,6 +469,7 @@ bool BlockManager::LoadBlockIndex(const std::optional<uint256>& snapshot_blockha
             return false;
         }
         previous_index = pindex;
+        pindex->BuildCadenceLaneLinks();
         pindex->nAuxPow = (pindex->pprev ? pindex->pprev->nAuxPow : 0) + (pindex->SignalsAuxpow() ? 1 : 0);
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         pindex->nTimeMax = (pindex->pprev ? std::max(pindex->pprev->nTimeMax, pindex->nTime) : pindex->nTime);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -217,19 +217,6 @@ uint32_t GetASERTAnchorBits(const Consensus::Params& params, const bool auxpow) 
     return anchor.nBits;
 }
 
-const CBlockIndex* GetPreviousSameTypeBlock(const CBlockIndex* pindexLast,
-                                            const bool next_block_is_auxpow,
-                                            const Consensus::Params& params) noexcept
-{
-    const auto& anchor = params.asertAnchorParams;
-    const CBlockIndex* pindexPrev = pindexLast;
-    while (pindexPrev != nullptr && IsAuxpowBlock(pindexPrev) != next_block_is_auxpow) {
-        if (pindexPrev->nHeight <= anchor.nHeight) return nullptr;
-        pindexPrev = pindexPrev->pprev;
-    }
-    return pindexPrev;
-}
-
 ASERTHeaderState GetASERTHeaderState(const CBlockIndex& pindex) noexcept
 {
     return ASERTHeaderState{pindex.nHeight, pindex.GetBlockTime(), pindex.nAuxPow};
@@ -351,7 +338,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         return GetNextASERTWorkRequired(pindexLast, params);
     }
 
-    const CBlockIndex* pindexPrevSameType = GetPreviousSameTypeBlock(pindexLast, next_block_is_auxpow, params);
+    const CBlockIndex* pindexPrevSameType = pindexLast->GetPreviousBlockForLane(next_block_is_auxpow, params.asertAnchorParams.nHeight);
     return GetNextASERTWorkRequired(pindexPrevSameType, next_block_is_auxpow, params);
 }
 

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <deque>
 #include <limits>
 #include <memory>
 #include <string>
@@ -778,6 +779,101 @@ BOOST_AUTO_TEST_CASE(auxpow_disk_block_index_reload_preserves_payload)
     BOOST_REQUIRE(decoded_header.HasAuxpow());
     BOOST_CHECK_EQUAL(decoded_header.GetHash(), hash);
     BOOST_CHECK_EQUAL(decoded_header.auxpow->GetParentBlockHash(), header.auxpow->GetParentBlockHash());
+}
+
+BOOST_AUTO_TEST_CASE(cadence_lane_links_rebuild_on_block_index_load)
+{
+    const auto& params = Params();
+    const auto& consensus = params.GetConsensus();
+    const uint32_t pow_limit_bits{UintToArith256(consensus.powLimit).GetCompact()};
+
+    std::deque<CBlockIndex> indexes;
+    std::deque<uint256> hashes;
+    const auto add_index = [&](CBlockHeader header, CBlockIndex* parent) -> CBlockIndex& {
+        if (header.SignalsAuxpow()) {
+            header.auxpow = MakeAuxpowPayload(header.GetHash(), consensus, header.nBits, header.nTime);
+        } else {
+            while (!CheckProofOfWork(header.GetHash(), header.nBits, consensus))
+                ++header.nNonce;
+        }
+        indexes.emplace_back(header);
+        hashes.emplace_back(header.GetHash());
+        CBlockIndex& index{indexes.back()};
+        index.phashBlock = &hashes.back();
+        index.pprev = parent;
+        index.nHeight = parent == nullptr ? 0 : parent->nHeight + 1;
+        index.nAuxPow = (parent == nullptr ? 0 : parent->nAuxPow) + (header.SignalsAuxpow() ? 1 : 0);
+        return index;
+    };
+
+    CBlockHeader root_header;
+    root_header.nVersion = MakeVersion(/*chain_id=*/0, /*auxpow=*/false, /*version_bits=*/0);
+    root_header.hashMerkleRoot = uint256{101};
+    root_header.nTime = 1'738'713'700;
+    root_header.nBits = pow_limit_bits;
+    CBlockIndex& root{add_index(root_header, nullptr)};
+
+    CBlockHeader auxpow_header;
+    auxpow_header.nVersion = MakeVersion(static_cast<uint16_t>(consensus.nAuxpowChainId), /*auxpow=*/true, /*version_bits=*/0);
+    auxpow_header.hashPrevBlock = root.GetBlockHash();
+    auxpow_header.hashMerkleRoot = uint256{102};
+    auxpow_header.nTime = root.nTime + 1;
+    auxpow_header.nBits = pow_limit_bits;
+    CBlockIndex& auxpow{add_index(auxpow_header, &root)};
+
+    CBlockHeader permissionless_header;
+    permissionless_header.nVersion = MakeVersion(/*chain_id=*/0, /*auxpow=*/false, /*version_bits=*/0);
+    permissionless_header.hashPrevBlock = auxpow.GetBlockHash();
+    permissionless_header.hashMerkleRoot = uint256{103};
+    permissionless_header.nTime = auxpow.nTime + 1;
+    permissionless_header.nBits = pow_limit_bits;
+    CBlockIndex& permissionless{add_index(permissionless_header, &auxpow)};
+
+    CBlockHeader fork_header{auxpow_header};
+    fork_header.hashPrevBlock = root.GetBlockHash();
+    fork_header.hashMerkleRoot = uint256{104};
+    fork_header.nTime = root.nTime + 2;
+    fork_header.auxpow.reset();
+    CBlockIndex& fork_auxpow{add_index(fork_header, &root)};
+
+    node::KernelNotifications notifications{Assert(m_node.shutdown_request), m_node.exit_status, *Assert(m_node.warnings)};
+    node::BlockManager::Options blockman_opts{
+        .chainparams = params,
+        .use_xor = false,
+        .blocks_dir = m_args.GetBlocksDirPath(),
+        .notifications = notifications,
+        .block_tree_db_params = DBParams{
+            .path = "",
+            .cache_bytes = 1 << 20,
+            .memory_only = true,
+        },
+    };
+    node::BlockManager blockman{*Assert(m_node.shutdown_signal), blockman_opts};
+
+    {
+        LOCK(::cs_main);
+        BOOST_REQUIRE(blockman.m_block_tree_db->WriteBatchSync(
+            {}, /*nLastFile=*/0, {&root, &auxpow, &permissionless, &fork_auxpow}));
+        BOOST_REQUIRE(blockman.LoadBlockIndexDB(std::nullopt) == node::BlockIndexLoadResult::SUCCESS);
+
+        const CBlockIndex* loaded_root{blockman.LookupBlockIndex(root.GetBlockHash())};
+        const CBlockIndex* loaded_auxpow{blockman.LookupBlockIndex(auxpow.GetBlockHash())};
+        const CBlockIndex* loaded_permissionless{blockman.LookupBlockIndex(permissionless.GetBlockHash())};
+        const CBlockIndex* loaded_fork_auxpow{blockman.LookupBlockIndex(fork_auxpow.GetBlockHash())};
+        BOOST_REQUIRE(loaded_root);
+        BOOST_REQUIRE(loaded_auxpow);
+        BOOST_REQUIRE(loaded_permissionless);
+        BOOST_REQUIRE(loaded_fork_auxpow);
+
+        BOOST_CHECK(loaded_root->pprev_permissionless == nullptr);
+        BOOST_CHECK(loaded_root->pprev_auxpow == nullptr);
+        BOOST_CHECK(loaded_auxpow->pprev_permissionless == loaded_root);
+        BOOST_CHECK(loaded_auxpow->pprev_auxpow == nullptr);
+        BOOST_CHECK(loaded_permissionless->pprev_permissionless == loaded_root);
+        BOOST_CHECK(loaded_permissionless->pprev_auxpow == loaded_auxpow);
+        BOOST_CHECK(loaded_fork_auxpow->pprev_permissionless == loaded_root);
+        BOOST_CHECK(loaded_fork_auxpow->pprev_auxpow == nullptr);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(auxpow_legacy_disk_block_index_entry_without_payload_still_deserializes)

--- a/src/test/cadence_tests.cpp
+++ b/src/test/cadence_tests.cpp
@@ -90,12 +90,43 @@ CBlockIndex& AppendBlock(std::deque<CBlockIndex>& chain, const int32_t version, 
         index.nAuxPow = index.pprev->nAuxPow;
         index.BuildSkip();
     }
+    index.BuildCadenceLaneLinks();
 
     if (IsAuxpowVersion(version)) {
         ++index.nAuxPow;
     }
 
     return index;
+}
+
+CBlockIndex& AppendChild(std::deque<CBlockIndex>& storage,
+                         CBlockIndex* parent,
+                         const int32_t version,
+                         const uint32_t time,
+                         const uint32_t bits)
+{
+    storage.emplace_back();
+    CBlockIndex& index = storage.back();
+    index.pprev = parent;
+    index.nHeight = parent == nullptr ? 0 : parent->nHeight + 1;
+    index.nVersion = version;
+    index.nTime = time;
+    index.nBits = bits;
+    index.nAuxPow = (parent == nullptr ? 0 : parent->nAuxPow) + (IsAuxpowVersion(version) ? 1 : 0);
+    index.BuildSkip();
+    index.BuildCadenceLaneLinks();
+    return index;
+}
+
+const CBlockIndex* LinearPreviousBlockForLane(const CBlockIndex* pindex,
+                                              const bool auxpow,
+                                              const int anchor_height)
+{
+    while (pindex != nullptr && pindex->SignalsAuxpow() != auxpow) {
+        if (pindex->nHeight <= anchor_height) return nullptr;
+        pindex = pindex->pprev;
+    }
+    return pindex;
 }
 
 CBlockHeader MakeNextHeader(const int32_t version, const uint32_t time)
@@ -201,6 +232,62 @@ BOOST_AUTO_TEST_CASE(cadence_same_type_predecessor_lookup)
 
     const CBlockHeader next_merged = MakeNextHeader(merged_version, anchor_time + 300);
     BOOST_CHECK_EQUAL(GetNextWorkRequired(tip, &next_merged, consensus), ExpectedCadenceBits(consensus, *merged_1, /*auxpow=*/true));
+}
+
+BOOST_AUTO_TEST_CASE(cadence_lane_links_match_linear_reference_on_forks_and_anchors)
+{
+    const auto consensus = GetConsensusParams(*m_node.args);
+    const int32_t permissionless_version = PermissionlessVersion();
+    const int32_t merged_version = MergedVersion(consensus);
+    const uint32_t legacy_bits = LegacyAnchorBits(consensus);
+    const uint32_t merged_bits = AuxPowAnchorBits(consensus);
+    const uint32_t anchor_time = consensus.asertAnchorParams.nBlockTime;
+
+    std::deque<CBlockIndex> common;
+    CBlockIndex* genesis = &AppendChild(common, nullptr, permissionless_version, anchor_time, legacy_bits);
+    CBlockIndex* first_auxpow = &AppendChild(common, genesis, merged_version, anchor_time + 60, merged_bits);
+    CBlockIndex* fork = &AppendChild(common, first_auxpow, permissionless_version, anchor_time + 120, legacy_bits);
+
+    std::deque<CBlockIndex> permissionless_branch;
+    CBlockIndex* permissionless_tip = fork;
+    for (int i = 1; i <= 1000; ++i) {
+        permissionless_tip = &AppendChild(permissionless_branch,
+                                          permissionless_tip,
+                                          permissionless_version,
+                                          anchor_time + 120 + i * 60,
+                                          legacy_bits);
+    }
+
+    std::deque<CBlockIndex> auxpow_branch;
+    CBlockIndex* auxpow_tip = fork;
+    for (int i = 1; i <= 1000; ++i) {
+        auxpow_tip = &AppendChild(auxpow_branch,
+                                  auxpow_tip,
+                                  merged_version,
+                                  anchor_time + 120 + i * 60,
+                                  merged_bits);
+    }
+
+    for (const CBlockIndex* tip : {permissionless_tip, auxpow_tip}) {
+        for (const bool auxpow : {false, true}) {
+            const CBlockIndex* linear = LinearPreviousBlockForLane(tip, auxpow, /*anchor_height=*/0);
+            BOOST_CHECK(tip->GetPreviousBlockForLane(auxpow, /*min_height=*/0) == linear);
+
+            const CBlockHeader next = MakeNextHeader(auxpow ? merged_version : permissionless_version, tip->nTime + 1);
+            const uint32_t expected_bits = linear != nullptr ? ExpectedCadenceBits(consensus, *linear, auxpow) : (auxpow ? merged_bits : legacy_bits);
+            BOOST_CHECK_EQUAL(GetNextWorkRequired(tip, &next, consensus), expected_bits);
+        }
+    }
+
+    BOOST_CHECK(permissionless_tip->GetPreviousBlockForLane(/*auxpow=*/true, fork->nHeight) == nullptr);
+    BOOST_CHECK(permissionless_tip->GetPreviousBlockForLane(/*auxpow=*/true, first_auxpow->nHeight) == first_auxpow);
+    BOOST_CHECK(auxpow_tip->GetPreviousBlockForLane(/*auxpow=*/false, fork->nHeight) == fork);
+
+    CChain active_chain;
+    active_chain.SetTip(*permissionless_tip);
+    BOOST_CHECK(active_chain.Tip()->GetPreviousBlockForLane(/*auxpow=*/true, /*min_height=*/0) == first_auxpow);
+    active_chain.SetTip(*auxpow_tip);
+    BOOST_CHECK(active_chain.Tip()->GetPreviousBlockForLane(/*auxpow=*/false, /*min_height=*/0) == fork);
 }
 
 BOOST_AUTO_TEST_CASE(cadence_pre_activation_uses_single_track_asert_history)

--- a/src/test/confirmation_target_tests.cpp
+++ b/src/test/confirmation_target_tests.cpp
@@ -81,6 +81,7 @@ struct HashrateTestChain {
         block->index.nChainWork = (block->index.pprev ? block->index.pprev->nChainWork : arith_uint256{}) + GetBlockProof(block->index);
         block->index.phashBlock = &block->hash;
         block->index.BuildSkip();
+        block->index.BuildCadenceLaneLinks();
         blocks.push_back(std::move(block));
         chain.SetTip(blocks.back()->index);
     }

--- a/src/test/fuzz/asert.cpp
+++ b/src/test/fuzz/asert.cpp
@@ -71,6 +71,7 @@ FUZZ_TARGET(asert_chain_transition, .init = initialize_asert)
     anchor_index->nHeight = consensus_params.asertAnchorParams.nHeight;
     anchor_index->nTime = anchor_header.nTime;
     anchor_index->nBits = anchor_header.nBits;
+    anchor_index->BuildCadenceLaneLinks();
 
     std::vector<std::unique_ptr<CBlockIndex>> chain;
     chain.emplace_back(std::move(anchor_index));
@@ -97,6 +98,7 @@ FUZZ_TARGET(asert_chain_transition, .init = initialize_asert)
         next_index->nHeight = prev->nHeight + 1;
         next_index->nTime = next_header.nTime;
         next_index->nBits = next_bits;
+        next_index->BuildCadenceLaneLinks();
         chain.emplace_back(std::move(next_index));
     }
 }

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -60,6 +60,7 @@ FUZZ_TARGET(pow, .init = initialize_pow)
             } else {
                 current_block.nChainWork = ConsumeArithUInt256(fuzzed_data_provider);
             }
+            current_block.BuildCadenceLaneLinks();
         }
         {
             (void)GetBlockProof(current_block);
@@ -144,6 +145,7 @@ FUZZ_TARGET(pow_transition, .init = initialize_pow)
             auto current_block{std::make_unique<CBlockIndex>(header)};
             current_block->pprev = blocks.empty() ? nullptr : blocks.back().get();
             current_block->nHeight = height;
+            current_block->BuildCadenceLaneLinks();
             blocks.emplace_back(std::move(current_block));
         }
         last_block = blocks.back().get();

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -13,6 +13,8 @@
 #include <test/util/setup_common.h>
 #include <util/chaintype.h>
 #include <validation.h>
+
+#include <deque>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -93,6 +95,7 @@ void HeadersGeneratorSetup::FinalizeIndex(CBlockIndex& index, const uint256& has
     index.nAuxPow = auxpow_count;
     index.nChainWork = chain_work;
     index.BuildSkip();
+    index.BuildCadenceLaneLinks();
 }
 
 void HeadersGeneratorSetup::AssertHeadersSyncAccepts(const Consensus::Params& consensus, const CBlockIndex& chain_start, const std::vector<CBlockHeader>& headers)
@@ -172,6 +175,7 @@ BOOST_AUTO_TEST_CASE(recent_chainwork_uses_mixed_lane_window)
             block.nAuxPow = auxpow_count;
             block.nChainWork = (block.pprev ? block.pprev->nChainWork : arith_uint256{}) + GetBlockProof(block);
             block.BuildSkip();
+            block.BuildCadenceLaneLinks();
         }
     };
     build_chain(auxpow_tip_chain, /*auxpow_tip=*/true);
@@ -340,6 +344,59 @@ BOOST_AUTO_TEST_CASE(headers_sync_accepts_signet_permissionless_to_auxpow_anchor
                                            permissionless_header.nTime + consensus.nPowTargetSpacing,
                                            consensus.asertAnchorParams.nBitsAuxPow);
     AssertHeadersSyncAccepts(consensus, permissionless, {auxpow});
+}
+
+BOOST_AUTO_TEST_CASE(headers_sync_uses_cached_starved_lane_history)
+{
+    const auto chain_params = CreateChainParams(*m_node.args, ChainType::MAIN);
+    const auto& consensus = chain_params->GetConsensus();
+    const int32_t permissionless_version{MakeVersion(/*chain_id=*/0, /*auxpow=*/false, /*version_bits=*/0)};
+    const int32_t auxpow_version{MakeVersion(static_cast<uint16_t>(consensus.nAuxpowChainId), /*auxpow=*/true, /*version_bits=*/0)};
+    const uint32_t permissionless_bits{consensus.asertAnchorParams.nBitsLegacy};
+    const uint32_t auxpow_bits{consensus.asertAnchorParams.nBitsAuxPow};
+
+    for (const bool starve_auxpow : {false, true}) {
+        std::deque<CBlockIndex> chain;
+        std::deque<uint256> hashes;
+        const auto append = [&](const int32_t version, const uint32_t time, const uint32_t bits) {
+            CBlockHeader header = MakeHeader(chain.empty() ? uint256{} : chain.back().GetBlockHash(), version, time, bits);
+            chain.emplace_back(header);
+            hashes.emplace_back(header.GetHash());
+            CBlockIndex& index{chain.back()};
+            CBlockIndex* parent{chain.size() == 1 ? nullptr : &chain[chain.size() - 2]};
+            FinalizeIndex(index,
+                          hashes.back(),
+                          parent,
+                          parent == nullptr ? 0 : parent->nHeight + 1,
+                          (parent == nullptr ? 0 : parent->nAuxPow) + (header.SignalsAuxpow() ? 1 : 0),
+                          (parent == nullptr ? arith_uint256{} : parent->nChainWork) + GetBlockProof(index));
+        };
+
+        append(permissionless_version,
+               consensus.asertAnchorParams.nBlockTime,
+               permissionless_bits);
+        if (starve_auxpow) {
+            append(auxpow_version,
+                   consensus.asertAnchorParams.nBlockTime + consensus.nPowTargetSpacingAuxPow,
+                   auxpow_bits);
+        }
+
+        const int32_t repeated_version{starve_auxpow ? permissionless_version : auxpow_version};
+        const uint32_t repeated_bits{starve_auxpow ? permissionless_bits : auxpow_bits};
+        for (int i = 1; i <= 1000; ++i) {
+            append(repeated_version,
+                   chain.back().nTime + static_cast<uint32_t>(starve_auxpow ? consensus.nPowTargetSpacingLegacy : consensus.nPowTargetSpacingAuxPow),
+                   repeated_bits);
+        }
+
+        const int32_t resumed_version{starve_auxpow ? auxpow_version : permissionless_version};
+        CBlockHeader resumed = MakeHeader(chain.back().GetBlockHash(),
+                                          resumed_version,
+                                          chain.back().nTime + 1,
+                                          /*n_bits=*/0);
+        resumed.nBits = GetNextWorkRequired(&chain.back(), &resumed, consensus);
+        AssertHeadersSyncAccepts(consensus, chain.back(), {resumed});
+    }
 }
 
 BOOST_AUTO_TEST_CASE(headers_sync_redownload_preserves_auxpow_payload)

--- a/src/test/peerman_tests.cpp
+++ b/src/test/peerman_tests.cpp
@@ -75,6 +75,7 @@ static std::vector<CBlockHeader> BuildHeaders(const CBlockIndex& base_index, con
         current_index.pprev = const_cast<CBlockIndex*>(prev_index);
         current_index.nHeight = prev_index->nHeight + 1;
         current_index.BuildSkip();
+        current_index.BuildCadenceLaneLinks();
 
         prev_header = headers.back();
         prev_index = &current_index;
@@ -98,6 +99,7 @@ static CBlockIndex& InsertTestBlockIndex(ChainstateManager& chainman, const uint
     index.m_chain_tx_count = prev ? prev->m_chain_tx_count + 1 : 1;
     index.nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
     index.BuildSkip();
+    index.BuildCadenceLaneLinks();
     return index;
 }
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -438,6 +438,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_legacy_retarget_clamps_powlimit_regression)
         chain[i].nTime = (i == interval - 1) ? first_time + extreme_gap : first_time + i * consensus.nPowTargetSpacing;
         chain[i].pprev = (i > 0) ? &chain[i - 1] : nullptr;
         chain[i].BuildSkip();
+        chain[i].BuildCadenceLaneLinks();
     }
 
     CBlockHeader next_block{};

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -90,6 +90,7 @@ static CBlockIndex& InsertTestBlockIndex(ChainstateManager& chainman, const uint
     index.m_chain_tx_count = prev ? prev->m_chain_tx_count + 1 : 1;
     index.nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
     index.BuildSkip();
+    index.BuildCadenceLaneLinks();
     return index;
 }
 
@@ -546,6 +547,7 @@ BOOST_FIXTURE_TEST_CASE(activatebestchainstep_schedules_recovery_for_witness_pru
         candidate.m_chain_tx_count = active_tip->m_chain_tx_count + 1;
         candidate.nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA | BLOCK_OPT_WITNESS_PRUNED;
         candidate.BuildSkip();
+        candidate.BuildCadenceLaneLinks();
 
         BOOST_REQUIRE(candidate_ptr != nullptr);
         BOOST_CHECK(chainman.NeedsWitnessForValidation(*candidate_ptr));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5848,6 +5848,10 @@ void ChainstateManager::CheckBlockIndex() const
         }
         const uint64_t expected_auxpow_count = (pindex->pprev ? pindex->pprev->nAuxPow : 0) + (pindex->SignalsAuxpow() ? 1 : 0);
         assert(pindex->nAuxPow == expected_auxpow_count);
+        const CBlockIndex* expected_permissionless = pindex->pprev ? (pindex->pprev->SignalsAuxpow() ? pindex->pprev->pprev_permissionless : pindex->pprev) : nullptr;
+        const CBlockIndex* expected_auxpow = pindex->pprev ? (pindex->pprev->SignalsAuxpow() ? pindex->pprev : pindex->pprev->pprev_auxpow) : nullptr;
+        assert(pindex->pprev_permissionless == expected_permissionless);
+        assert(pindex->pprev_auxpow == expected_auxpow);
         // There should be no block with more work than m_best_header, unless it's known to be invalid
         assert((pindex->nStatus & BLOCK_FAILED_MASK) || pindex->nChainWork <= m_best_header->nChainWork);
 


### PR DESCRIPTION
## Summary

- Cache the nearest permissionless and AuxPoW ancestors on each `CBlockIndex` and rebuild the memory-only links deterministically during block-index load.
- Use the cached links for Cadence ASERT validation and headers-sync difficulty initialization, removing starvation-dependent `pprev` walks from both paths.
- Add branch, reorg, anchor-boundary, reload, headers-sync, and exact-difficulty regression coverage, plus asymptotic benchmarks for both affected paths.

Fixes #103.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands and results:

- `cmake -B build -DBUILD_BENCH=ON -DBUILD_GUI=OFF`
- `cmake --build build --target test_bitcoin bench_bitcoin -j4`
- `test_qbit --run_test=cadence_tests` — passed
- `test_qbit --run_test=headers_sync_chainwork_tests` — passed
- `test_qbit --run_test=auxpow_tests/cadence_lane_links_rebuild_on_block_index_load` — passed
- `test_qbit --run_test=pow_tests` — passed
- `test_qbit --run_test=asert_tests` — passed
- `test_qbit --run_test=confirmation_target_tests` — passed
- `test_qbit --run_test=peerman_tests` — passed
- `test_qbit --run_test=validation_chainstatemanager_tests` — passed
- `test_qbit --run_test=validation_chainstate_tests` — passed
- `test_qbit --run_test=miner_tests` — passed
- `test_qbit --run_test=skiplist_tests` — passed
- Docker lint image — passed
- Clang-format changed-line and `git diff --check` validation — passed
- `bench_qbit -filter='Cadence.*' -asymptote=1,1000,100000 -min-time=50 -p2mronly=0` — both benchmarks classified O(1): lane lookup remained about 34 ns and headers-sync initialization about 775 ns.

The complete local unit binary is blocked by unrelated harness failures: `i2p_tests` fails on its persistent SAM-session log assertion, and `net_peer_connection_tests` exits 139 even when run independently. The relevant and adjacent suites above pass individually.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: This is consensus-adjacent because the lookup feeds contextual ASERT difficulty validation. It is intended to preserve byte-for-byte difficulty results. The new fields are memory-only, add no block-index serialization, and are checked against their parent-derived invariant in `CheckBlockIndex()`.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: This is an internal validation-performance hardening change with no user-visible behavior or configuration change.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786387944&installation_id=141183937&pr_number=108&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F108&signature=2ba0c67392ce51d4109ddae45de03b86096340b9038117a7dbada9ba82efdaf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consensus-adjacent difficulty validation (ASERT/Cadence); behavior is intended to be identical to the prior linear walk, with added invariant checks on the block index.
> 
> **Overview**
> Adds **memory-only** `pprev_permissionless` and `pprev_auxpow` on each `CBlockIndex`, rebuilt via `BuildCadenceLaneLinks()` when blocks are added and when the index is loaded from disk, so Cadence ASERT can find the correct same-lane predecessor in **O(1)** instead of walking `pprev`.
> 
> **`GetPreviousBlockForLane(auxpow, min_height)`** replaces the removed `GetPreviousSameTypeBlock` loop; **`GetNextWorkRequired`** and **`HeadersSyncState::MakeHeaderDifficultyState`** now use it (with ASERT anchor height as the floor). **`CheckBlockIndex`** asserts the lane pointers match their parent-derived values.
> 
> New **`bench/cadence.cpp`** benchmarks lane lookup and headers-sync init; tests cover forks, reorgs, anchor boundaries, DB reload, and long “starved lane” header sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ad804ce0a99debc1e7662b2505c2380f1162742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->