### PR TITLE
test: reap node before Windows cleanup

### DIFF
--- a/test/functional/feature_framework_startup_failures.py
+++ b/test/functional/feature_framework_startup_failures.py
@@ -142,7 +142,13 @@ class TestStartStopStartupFailure(InternalTestMixin, BitcoinTestFramework):
     def setup_network(self):
         self.add_nodes(self.num_nodes, self.extra_args)
         self.nodes[0].start()
-        self.nodes[0].stop_node()
+        try:
+            self.nodes[0].stop_node()
+        finally:
+            # stop_node() is expected to raise before stopping the process. Wait
+            # for the forced shutdown so Windows releases debug.log before the
+            # parent test removes this child test's temporary directory.
+            self.nodes[0].kill_process()
         assert False, "stop_node() should raise an exception when we haven't called wait_for_rpc_connection()"
 
     def run_test(self):


### PR DESCRIPTION
## Summary

Ensure the intentional start/stop startup-failure test fully reaps its qbitd process before the parent functional test removes the child temporary directory. This prevents Windows from racing directory cleanup against an open debug.log handle while preserving the expected stop_node() assertion.

## Testing

- [ ] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [x] Not run. Reason: The full functional test was not run because the workspace has no configured build or qbitd binary. A focused control-flow regression check passed, Docker lint passed, and git diff --check passed.

## Target Branch

- [x] This PR targets main or a maintainer-requested release branch such as 0.1.x.

## Risk / Review Notes

- [ ] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [x] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: The change only affects cleanup in an intentional functional-test failure path.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: This is an internal functional-test cleanup fix with no user-visible behavior change.

## libbitcoinpqc Subtree Checklist (if src/libbitcoinpqc changed)

- [ ] Source commit is reachable from an immutable release tag in Qbit-Org/qbit-libbitcoinpqc.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with contrib/devtools/update-libbitcoinpqc-subtree.sh.
- [ ] test/lint/libbitcoinpqc-subtree-check.sh passes locally.
- [ ] Any default tag change in contrib/devtools/update-libbitcoinpqc-subtree.sh is intentional and matches doc/subtrees/libbitcoinpqc.md.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786389203&installation_id=141183937&pr_number=111&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F111&signature=54d0c090d186bd232ab0ec52b3fe44c4065a0f64ce6e52f8a7475b802c6f9d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup on an intentional failure path; no production, consensus, or wallet behavior changes.
> 
> **Overview**
> Fixes flaky Windows cleanup in the **start-then-stop without RPC** startup-failure child test (`TestStartStopStartupFailure`).
> 
> That test deliberately calls `stop_node()` before `wait_for_rpc_connection()`, so `stop_node()` **asserts and never shuts down** the node. The change wraps that call in `try`/`finally` and always runs **`kill_process()`** in `finally`, so the child `qbitd`/`bitcoind` is reaped and **`debug.log` is closed** before the parent removes the child’s temp directory.
> 
> The expected assertion behavior is unchanged; only teardown on this intentional failure path is hardened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d852f2c7d4dab915aca222881e7e560adf5e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->