### PR TITLE
Enforce immutable local release publication

### DIFF
--- a/ci/checks/classify_merge_profile.py
+++ b/ci/checks/classify_merge_profile.py
@@ -116,8 +116,7 @@ def normalize_path(path: str) -> str | None:
 
 def is_release_policy_path(path: str) -> bool:
     return (
-        path == ".github/workflows/release-publish.yml"
-        or path == "contrib/release-process/publish-local-release.sh"
+        path == "contrib/release-process/publish-local-release.sh"
         or path.startswith("ci/release/")
         or path.startswith("contrib/keys/operator-keys/")
         or RELEASE_TRUST_DOC_RE.fullmatch(path) is not None
@@ -205,8 +204,7 @@ def github_outputs(classification: Classification) -> dict[str, str]:
             any(path.startswith("contrib/keys/operator-keys/") for path in paths)
         ),
         "touched_release_publish": bool_output(
-            ".github/workflows/release-publish.yml" in paths
-            or "contrib/release-process/publish-local-release.sh" in paths
+            "contrib/release-process/publish-local-release.sh" in paths
         ),
         "touched_release_validators": bool_output(
             any(path.startswith("ci/release/") for path in paths)

--- a/ci/checks/test_classify_merge_profile.py
+++ b/ci/checks/test_classify_merge_profile.py
@@ -66,7 +66,6 @@ class ClassifyMergeProfileTest(unittest.TestCase):
     def test_release_policy_allowlist_covers_release_paths(self) -> None:
         classification = self.classify(
             [
-                ".github/workflows/release-publish.yml",
                 "contrib/release-process/publish-local-release.sh",
                 "ci/release/validate_key_metadata.py",
                 "contrib/keys/operator-keys/public-keys/operator-01-release.asc",
@@ -93,6 +92,15 @@ class ClassifyMergeProfileTest(unittest.TestCase):
                 self.assertEqual(outputs["release_policy_only"], "true")
                 self.assertEqual(outputs["source_validation_required"], "false")
                 self.assertEqual(outputs["touched_release_validators"], "true")
+
+    def test_retired_release_workflow_requires_source_validation(self) -> None:
+        path = ".github/workflows/release-publish.yml"
+        classification = self.classify([path])
+        outputs = classify_merge_profile.github_outputs(classification)
+
+        self.assertEqual(classification.profile, classify_merge_profile.SOURCE_PROFILE)
+        self.assertEqual(classification.outside_paths, (path,))
+        self.assertEqual(outputs["touched_release_publish"], "false")
 
     def test_rpc_docs_paths_are_rpc_docs_only(self) -> None:
         classification = self.classify(RPC_DOCS_PATHS)

--- a/ci/release/test_publish_local_release.py
+++ b/ci/release/test_publish_local_release.py
@@ -188,6 +188,10 @@ if args[:2] == ["release", "create"]:
     (state / "release-body").write_text(
         notes_file.read_text(encoding="utf8"), encoding="utf8"
     )
+    prerelease = "true" if "--prerelease" in args else "false"
+    latest = "true" if "--latest" in args else "false"
+    (state / "prerelease-state").write_text(prerelease, encoding="utf8")
+    (state / "latest-state").write_text(latest, encoding="utf8")
     raise SystemExit(0)
 
 if args[:2] == ["release", "upload"]:
@@ -208,6 +212,14 @@ if args[:2] == ["release", "edit"]:
         )
     if "--draft=false" in args:
         (state / "release-state").write_text("published\n", encoding="utf8")
+    if "--prerelease" in args:
+        (state / "prerelease-state").write_text("true", encoding="utf8")
+    elif "--prerelease=false" in args:
+        (state / "prerelease-state").write_text("false", encoding="utf8")
+    if "--latest" in args:
+        (state / "latest-state").write_text("true", encoding="utf8")
+    elif "--latest=false" in args:
+        (state / "latest-state").write_text("false", encoding="utf8")
     raise SystemExit(0)
 
 print("unsupported fake gh command: " + " ".join(args), file=sys.stderr)
@@ -500,6 +512,49 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Verified draft release", result.stdout)
         self.assertFalse((self.gh_state / "immutable-view-count").exists())
+
+    def test_resumed_draft_preserves_omitted_release_metadata(self) -> None:
+        (self.gh_state / "release-state").write_text("draft\n", encoding="utf8")
+        (self.gh_state / "assets.tsv").write_text("", encoding="utf8")
+        (self.gh_state / "prerelease-state").write_text("true", encoding="utf8")
+        (self.gh_state / "latest-state").write_text("true", encoding="utf8")
+
+        result = self.run_publisher("--publish")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            (self.gh_state / "prerelease-state").read_text(encoding="utf8"), "true"
+        )
+        self.assertEqual(
+            (self.gh_state / "latest-state").read_text(encoding="utf8"), "true"
+        )
+        edit_args = next(
+            line.split()
+            for line in self.gh_log.read_text(encoding="utf8").splitlines()
+            if line.startswith("release edit")
+        )
+        self.assertNotIn("--prerelease", edit_args)
+        self.assertNotIn("--prerelease=false", edit_args)
+        self.assertNotIn("--latest", edit_args)
+        self.assertNotIn("--latest=false", edit_args)
+
+    def test_resumed_draft_metadata_can_be_explicitly_cleared(self) -> None:
+        (self.gh_state / "release-state").write_text("draft\n", encoding="utf8")
+        (self.gh_state / "assets.tsv").write_text("", encoding="utf8")
+        (self.gh_state / "prerelease-state").write_text("true", encoding="utf8")
+        (self.gh_state / "latest-state").write_text("true", encoding="utf8")
+
+        result = self.run_publisher(
+            "--create-draft", "--no-prerelease", "--make-latest", "false"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            (self.gh_state / "prerelease-state").read_text(encoding="utf8"), "false"
+        )
+        self.assertEqual(
+            (self.gh_state / "latest-state").read_text(encoding="utf8"), "false"
+        )
 
     def test_draft_asset_digest_mismatch_fails_without_replacement(self) -> None:
         artifact = next(

--- a/ci/release/test_publish_local_release.py
+++ b/ci/release/test_publish_local_release.py
@@ -102,7 +102,7 @@ if args[:2] == ["auth", "status"]:
     raise SystemExit(0)
 
 if args and args[0] == "api":
-    endpoint = args[1]
+    endpoint = next(value for value in args[1:] if value.startswith("repos/"))
     if "/git/ref/tags/" in endpoint:
         print("tag " + os.environ["FAKE_GH_TAG_OBJECT"])
     elif "/git/tags/" in endpoint:
@@ -130,9 +130,62 @@ if args and args[0] == "api":
                 }
             )
         )
+    elif "/releases/tags/" in endpoint:
+        if os.environ.get("FAKE_GH_RELEASE_LOOKUP_ERROR") == "true":
+            print("simulated release lookup failure", file=sys.stderr)
+            raise SystemExit(1)
+        release_state = state / "release-state"
+        if not release_state.exists():
+            print("HTTP/2.0 404 Not Found")
+            print()
+            print('{"message":"Not Found"}')
+            print("release not found", file=sys.stderr)
+            raise SystemExit(1)
+        draft = release_state.read_text(encoding="utf8").strip() == "draft"
+        if draft:
+            immutable = os.environ.get("FAKE_GH_DRAFT_IMMUTABLE", "false")
+        else:
+            sequence = os.environ.get("FAKE_GH_IMMUTABLE_SEQUENCE", "true").split(",")
+            counter_path = state / "immutable-view-count"
+            counter = int(counter_path.read_text(encoding="utf8")) if counter_path.exists() else 0
+            immutable = sequence[min(counter, len(sequence) - 1)]
+            counter_path.write_text(str(counter + 1), encoding="utf8")
+        print("HTTP/2.0 200 OK")
+        print()
+        print(
+            "\t".join(
+                [
+                    "1",
+                    str(draft).lower(),
+                    immutable,
+                    os.environ["FAKE_GH_TAG"],
+                    "https://example.invalid/release/" + os.environ["FAKE_GH_TAG"],
+                ]
+            )
+        )
     elif "/releases/1/assets" in endpoint:
         assets = state / "assets.tsv"
         if assets.exists():
+            asset_text = assets.read_text(encoding="utf8")
+            release_state = state / "release-state"
+            published = (
+                release_state.exists()
+                and release_state.read_text(encoding="utf8").strip() == "published"
+            )
+            if published:
+                lag = int(os.environ.get("FAKE_GH_PUBLISHED_ASSET_LAG", "0"))
+                counter_path = state / "published-asset-view-count"
+                counter = (
+                    int(counter_path.read_text(encoding="utf8"))
+                    if counter_path.exists()
+                    else 0
+                )
+                counter_path.write_text(str(counter + 1), encoding="utf8")
+                if counter < lag:
+                    for line in asset_text.splitlines():
+                        if line:
+                            print(line.split("\t", 1)[0] + "\t")
+                    raise SystemExit(0)
             asset_reads = state / "asset-reads"
             read_count = (
                 int(asset_reads.read_text(encoding="utf8"))
@@ -140,7 +193,6 @@ if args and args[0] == "api":
                 else 0
             )
             asset_reads.write_text(str(read_count + 1), encoding="utf8")
-            asset_text = assets.read_text(encoding="utf8")
             if read_count < int(os.environ["FAKE_GH_EMPTY_DIGEST_READS"]):
                 for line in asset_text.splitlines():
                     print(line.split("\t", 1)[0] + "\t")
@@ -153,32 +205,6 @@ if args and args[0] == "api":
     else:
         print("unsupported fake gh api endpoint: " + endpoint, file=sys.stderr)
         raise SystemExit(2)
-    raise SystemExit(0)
-
-if args[:2] == ["release", "view"]:
-    release_state = state / "release-state"
-    if not release_state.exists():
-        raise SystemExit(1)
-    draft = release_state.read_text(encoding="utf8").strip() == "draft"
-    if draft:
-        immutable = os.environ.get("FAKE_GH_DRAFT_IMMUTABLE", "false")
-    else:
-        sequence = os.environ.get("FAKE_GH_IMMUTABLE_SEQUENCE", "true").split(",")
-        counter_path = state / "immutable-view-count"
-        counter = int(counter_path.read_text(encoding="utf8")) if counter_path.exists() else 0
-        immutable = sequence[min(counter, len(sequence) - 1)]
-        counter_path.write_text(str(counter + 1), encoding="utf8")
-    print(
-        "\t".join(
-            [
-                "1",
-                str(draft).lower(),
-                immutable,
-                os.environ["FAKE_GH_TAG"],
-                "https://example.invalid/release/" + os.environ["FAKE_GH_TAG"],
-            ]
-        )
-    )
     raise SystemExit(0)
 
 if args[:2] == ["release", "create"]:
@@ -351,6 +377,8 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         release_line: str = "testnet",
         immutable_sequence: tuple[str, ...] = ("true",),
         draft_immutable: str = "false",
+        release_lookup_error: bool = False,
+        published_asset_lag: int = 0,
     ) -> subprocess.CompletedProcess[str]:
         env = dict(os.environ)
         env["PATH"] = f"{self.bin_dir}{os.pathsep}{env['PATH']}"
@@ -367,6 +395,8 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
                 "FAKE_GH_EMPTY_DIGEST_READS": str(empty_digest_reads),
                 "FAKE_GH_IMMUTABLE_SEQUENCE": ",".join(immutable_sequence),
                 "FAKE_GH_DRAFT_IMMUTABLE": draft_immutable,
+                "FAKE_GH_RELEASE_LOOKUP_ERROR": str(release_lookup_error).lower(),
+                "FAKE_GH_PUBLISHED_ASSET_LAG": str(published_asset_lag),
                 "FAKE_VALIDATOR_LOG": str(self.validator_log),
             }
         )
@@ -443,6 +473,17 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("P2MR_V1_ORACLE_REPORT is required", result.stderr)
         self.assertFalse(self.validator_log.exists())
+
+    def test_validation_only_fails_when_release_lookup_is_inconclusive(self) -> None:
+        result = self.run_publisher(release_lookup_error=True)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("simulated release lookup failure", result.stderr)
+        self.assertIn("Could not inspect GitHub Release", result.stderr)
+        gh_log = self.gh_log.read_text(encoding="utf8")
+        self.assertNotIn("release create", gh_log)
+        self.assertNotIn("release upload", gh_log)
+        self.assertNotIn("release edit", gh_log)
 
     def test_wrong_trusted_ref_fails_closed(self) -> None:
         result = self.run_publisher(trusted_ref="1" * 40)
@@ -677,6 +718,31 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertEqual(gh_log.count("release upload"), len(uploaded))
         self.assertIn("release edit", gh_log)
         self.assertIn("--draft=false", gh_log)
+        log_lines = gh_log.splitlines()
+        final_view = max(i for i, line in enumerate(log_lines) if "/releases/tags/" in line)
+        final_assets = max(i for i, line in enumerate(log_lines) if "/releases/1/assets" in line)
+        self.assertGreater(final_assets, final_view)
+
+    def test_publish_polls_final_asset_digests(self) -> None:
+        result = self.run_publisher("--publish", published_asset_lag=2)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Published immutable release", result.stdout)
+        self.assertEqual(
+            (self.gh_state / "published-asset-view-count").read_text(encoding="utf8"),
+            "3",
+        )
+
+    def test_publish_fails_after_bounded_final_asset_poll(self) -> None:
+        result = self.run_publisher("--publish", published_asset_lag=5)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("digest_mismatch", result.stderr)
+        self.assertIn("Published immutable release assets do not exactly match", result.stderr)
+        self.assertEqual(
+            (self.gh_state / "published-asset-view-count").read_text(encoding="utf8"),
+            "5",
+        )
 
     def test_publish_polls_until_release_becomes_immutable(self) -> None:
         result = self.run_publisher(

--- a/ci/release/test_publish_local_release.py
+++ b/ci/release/test_publish_local_release.py
@@ -121,6 +121,8 @@ if args and args[0] == "api":
         print("behind")
     elif "/commits/" in endpoint:
         print(endpoint.rsplit("/", 1)[1])
+    elif endpoint.count("/") == 2:
+        print(os.environ.get("FAKE_GH_CAN_PUSH", "true"))
     elif endpoint.endswith("/releases/generate-notes"):
         print(
             json.dumps(
@@ -130,39 +132,32 @@ if args and args[0] == "api":
                 }
             )
         )
-    elif "/releases/tags/" in endpoint:
+    elif endpoint.endswith("/releases?per_page=100"):
         if os.environ.get("FAKE_GH_RELEASE_LOOKUP_ERROR") == "true":
             print("simulated release lookup failure", file=sys.stderr)
             raise SystemExit(1)
         release_state = state / "release-state"
-        if not release_state.exists():
-            print("HTTP/2.0 404 Not Found")
-            print()
-            print('{"message":"Not Found"}')
-            print("release not found", file=sys.stderr)
-            raise SystemExit(1)
-        draft = release_state.read_text(encoding="utf8").strip() == "draft"
-        if draft:
-            immutable = os.environ.get("FAKE_GH_DRAFT_IMMUTABLE", "false")
-        else:
-            sequence = os.environ.get("FAKE_GH_IMMUTABLE_SEQUENCE", "true").split(",")
-            counter_path = state / "immutable-view-count"
-            counter = int(counter_path.read_text(encoding="utf8")) if counter_path.exists() else 0
-            immutable = sequence[min(counter, len(sequence) - 1)]
-            counter_path.write_text(str(counter + 1), encoding="utf8")
-        print("HTTP/2.0 200 OK")
-        print()
-        print(
-            "\t".join(
-                [
-                    "1",
-                    str(draft).lower(),
-                    immutable,
-                    os.environ["FAKE_GH_TAG"],
-                    "https://example.invalid/release/" + os.environ["FAKE_GH_TAG"],
-                ]
+        if release_state.exists():
+            draft = release_state.read_text(encoding="utf8").strip() == "draft"
+            if draft:
+                immutable = os.environ.get("FAKE_GH_DRAFT_IMMUTABLE", "false")
+            else:
+                sequence = os.environ.get("FAKE_GH_IMMUTABLE_SEQUENCE", "true").split(",")
+                counter_path = state / "immutable-view-count"
+                counter = int(counter_path.read_text(encoding="utf8")) if counter_path.exists() else 0
+                immutable = sequence[min(counter, len(sequence) - 1)]
+                counter_path.write_text(str(counter + 1), encoding="utf8")
+            print(
+                "\t".join(
+                    [
+                        "1",
+                        str(draft).lower(),
+                        immutable,
+                        os.environ["FAKE_GH_TAG"],
+                        "https://example.invalid/release/" + os.environ["FAKE_GH_TAG"],
+                    ]
+                )
             )
-        )
     elif "/releases/1/assets" in endpoint:
         assets = state / "assets.tsv"
         if assets.exists():
@@ -379,6 +374,7 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         draft_immutable: str = "false",
         release_lookup_error: bool = False,
         published_asset_lag: int = 0,
+        can_push: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         env = dict(os.environ)
         env["PATH"] = f"{self.bin_dir}{os.pathsep}{env['PATH']}"
@@ -397,6 +393,7 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
                 "FAKE_GH_DRAFT_IMMUTABLE": draft_immutable,
                 "FAKE_GH_RELEASE_LOOKUP_ERROR": str(release_lookup_error).lower(),
                 "FAKE_GH_PUBLISHED_ASSET_LAG": str(published_asset_lag),
+                "FAKE_GH_CAN_PUSH": str(can_push).lower(),
                 "FAKE_VALIDATOR_LOG": str(self.validator_log),
             }
         )
@@ -484,6 +481,13 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertNotIn("release create", gh_log)
         self.assertNotIn("release upload", gh_log)
         self.assertNotIn("release edit", gh_log)
+
+    def test_release_discovery_requires_push_access(self) -> None:
+        result = self.run_publisher(can_push=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("requires push access", result.stderr)
+        self.assertFalse(self.validator_log.exists())
 
     def test_wrong_trusted_ref_fails_closed(self) -> None:
         result = self.run_publisher(trusted_ref="1" * 40)
@@ -578,6 +582,10 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertNotIn("--prerelease=false", edit_args)
         self.assertNotIn("--latest", edit_args)
         self.assertNotIn("--latest=false", edit_args)
+        gh_log = self.gh_log.read_text(encoding="utf8")
+        self.assertIn("/releases?per_page=100", gh_log)
+        self.assertNotIn("/releases/tags/", gh_log)
+        self.assertNotIn("release create", gh_log)
 
     def test_resumed_draft_metadata_can_be_explicitly_cleared(self) -> None:
         (self.gh_state / "release-state").write_text("draft\n", encoding="utf8")
@@ -719,7 +727,11 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertIn("release edit", gh_log)
         self.assertIn("--draft=false", gh_log)
         log_lines = gh_log.splitlines()
-        final_view = max(i for i, line in enumerate(log_lines) if "/releases/tags/" in line)
+        final_view = max(
+            i
+            for i, line in enumerate(log_lines)
+            if "/releases?per_page=100" in line
+        )
         final_assets = max(i for i, line in enumerate(log_lines) if "/releases/1/assets" in line)
         self.assertGreater(final_assets, final_view)
 

--- a/ci/release/test_publish_local_release.py
+++ b/ci/release/test_publish_local_release.py
@@ -160,13 +160,20 @@ if args[:2] == ["release", "view"]:
     if not release_state.exists():
         raise SystemExit(1)
     draft = release_state.read_text(encoding="utf8").strip() == "draft"
-    immutable = not draft
+    if draft:
+        immutable = os.environ.get("FAKE_GH_DRAFT_IMMUTABLE", "false")
+    else:
+        sequence = os.environ.get("FAKE_GH_IMMUTABLE_SEQUENCE", "true").split(",")
+        counter_path = state / "immutable-view-count"
+        counter = int(counter_path.read_text(encoding="utf8")) if counter_path.exists() else 0
+        immutable = sequence[min(counter, len(sequence) - 1)]
+        counter_path.write_text(str(counter + 1), encoding="utf8")
     print(
         "\t".join(
             [
                 "1",
                 str(draft).lower(),
-                str(immutable).lower(),
+                immutable,
                 os.environ["FAKE_GH_TAG"],
                 "https://example.invalid/release/" + os.environ["FAKE_GH_TAG"],
             ]
@@ -330,6 +337,8 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         ignore_notes_edit: bool = False,
         empty_digest_reads: int = 0,
         release_line: str = "testnet",
+        immutable_sequence: tuple[str, ...] = ("true",),
+        draft_immutable: str = "false",
     ) -> subprocess.CompletedProcess[str]:
         env = dict(os.environ)
         env["PATH"] = f"{self.bin_dir}{os.pathsep}{env['PATH']}"
@@ -344,6 +353,8 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
                 "FAKE_GH_GENERATED_NOTES": GENERATED_NOTES,
                 "FAKE_GH_IGNORE_NOTES_EDIT": str(ignore_notes_edit).lower(),
                 "FAKE_GH_EMPTY_DIGEST_READS": str(empty_digest_reads),
+                "FAKE_GH_IMMUTABLE_SEQUENCE": ",".join(immutable_sequence),
+                "FAKE_GH_DRAFT_IMMUTABLE": draft_immutable,
                 "FAKE_VALIDATOR_LOG": str(self.validator_log),
             }
         )
@@ -440,7 +451,7 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertNotIn("release upload", gh_log)
         self.assertNotIn("release edit", gh_log)
 
-    def test_validation_only_accepts_matching_published_release(self) -> None:
+    def test_validation_only_accepts_matching_immutable_published_release(self) -> None:
         (self.gh_state / "release-state").write_text("published\n", encoding="utf8")
         remote_assets = []
         for path in sorted(self.artifacts.iterdir()):
@@ -459,6 +470,36 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertNotIn("release create", gh_log)
         self.assertNotIn("release upload", gh_log)
         self.assertNotIn("release edit", gh_log)
+
+    def test_validation_only_rejects_matching_mutable_published_release(self) -> None:
+        (self.gh_state / "release-state").write_text("published\n", encoding="utf8")
+
+        result = self.run_publisher(
+            "--repo", "Example-Org/release-target", immutable_sequence=("false",)
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("did not confirm it as immutable", result.stderr)
+        self.assertIn("Example-Org/release-target", result.stderr)
+        self.assertIn("Settings > Releases", result.stderr)
+        gh_log = self.gh_log.read_text(encoding="utf8")
+        self.assertNotIn("release upload", gh_log)
+        self.assertNotIn("release edit", gh_log)
+
+    def test_validation_only_rejects_missing_published_immutable_state(self) -> None:
+        (self.gh_state / "release-state").write_text("published\n", encoding="utf8")
+
+        result = self.run_publisher(immutable_sequence=("null",))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("isImmutable=null", result.stderr)
+
+    def test_create_draft_does_not_require_immutable_state(self) -> None:
+        result = self.run_publisher("--create-draft", draft_immutable="null")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Verified draft release", result.stdout)
+        self.assertFalse((self.gh_state / "immutable-view-count").exists())
 
     def test_draft_asset_digest_mismatch_fails_without_replacement(self) -> None:
         artifact = next(
@@ -564,7 +605,7 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Draft release assets exactly match", result.stdout)
-        self.assertIn("Published release", result.stdout)
+        self.assertIn("Published immutable release", result.stdout)
         self.assertEqual(
             (self.gh_state / "release-state").read_text(encoding="utf8").strip(),
             "published",
@@ -581,6 +622,26 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertEqual(gh_log.count("release upload"), len(uploaded))
         self.assertIn("release edit", gh_log)
         self.assertIn("--draft=false", gh_log)
+
+    def test_publish_polls_until_release_becomes_immutable(self) -> None:
+        result = self.run_publisher(
+            "--publish", immutable_sequence=("false", "null", "true")
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("Published immutable release", result.stdout)
+        self.assertEqual(
+            (self.gh_state / "immutable-view-count").read_text(encoding="utf8"), "3"
+        )
+
+    def test_publish_fails_when_release_remains_mutable(self) -> None:
+        result = self.run_publisher("--publish", immutable_sequence=("false",))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("did not confirm it as immutable", result.stderr)
+        self.assertEqual(
+            (self.gh_state / "immutable-view-count").read_text(encoding="utf8"), "5"
+        )
 
 
 if __name__ == "__main__":

--- a/contrib/release-process/publish-local-release.sh
+++ b/contrib/release-process/publish-local-release.sh
@@ -203,21 +203,27 @@ remote_commit_on_branch() {
 
 release_view() {
     local errors="$WORK_DIR/release-view-errors"
-    local http_status
     local response
-    if response="$(
-        gh api --include "repos/$GH_REPO_PATH/releases/tags/$TAG" \
-            --jq '[.id, (.draft | tostring), (.immutable | tostring), .tag_name, .html_url] | @tsv' \
+    local release_id
+    local is_draft
+    local is_immutable
+    local release_tag
+    local release_url
+    if ! response="$(
+        gh api --paginate "repos/$GH_REPO_PATH/releases?per_page=100" \
+            --jq '.[] | [.id, (.draft | tostring), (.immutable | tostring), .tag_name, .html_url] | @tsv' \
             2> "$errors"
     )"; then
-        http_status="$(printf '%s\n' "$response" | awk 'NR == 1 { print $2 }')"
-    else
-        http_status="$(printf '%s\n' "$response" | awk 'NR == 1 { print $2 }')"
-        [ "$http_status" != 404 ] || return 3
         return 2
     fi
-    [ "$http_status" = 200 ] || return 2
-    printf '%s\n' "$response" | awk 'NF { line=$0 } END { print line }'
+    while IFS=$'\t' read -r release_id is_draft is_immutable \
+            release_tag release_url; do
+        [ "$release_tag" = "$TAG" ] || continue
+        printf '%s\t%s\t%s\t%s\t%s\n' \
+            "$release_id" "$is_draft" "$is_immutable" "$release_tag" "$release_url"
+        return 0
+    done <<< "$response"
+    return 3
 }
 
 load_release_view() {
@@ -659,6 +665,11 @@ git -C "$TRUSTED_ROOT" merge-base --is-ancestor "$TAG_TARGET" "$TRUSTED_RELEASE_
 
 GH_REPO_PATH="$(github_repo_path "$GH_REPO")"
 GUIX_SIGS_GH_REPO_PATH="$(github_repo_path "$GUIX_SIGS_GH_REPO")"
+REPO_CAN_PUSH="$(
+    gh api "repos/$GH_REPO_PATH" --jq '(.permissions.push // false) | tostring'
+)" || die "Could not verify authenticated access to $GH_REPO"
+[ "$REPO_CAN_PUSH" = true ] \
+    || die "Authenticated GitHub account requires push access to $GH_REPO to discover draft releases"
 msg "Verifying trusted release ref is public"
 remote_commit "$GH_REPO_PATH" "$TRUSTED_RELEASE_REF" "Trusted release ref"
 msg "Verifying qbit-guix.sigs commit is public and merged"

--- a/contrib/release-process/publish-local-release.sh
+++ b/contrib/release-process/publish-local-release.sh
@@ -67,6 +67,9 @@ Repository overrides:
 Existing published releases are never changed. A matching draft can be safely
 resumed: its notes are replaced and verified, and existing assets must be a
 digest-matching subset of the validated set.
+Published releases are accepted only when GitHub reports them as immutable. The
+target of --repo must enable repository release immutability or be covered by an
+organization immutable-release policy before publication.
 EOF
 }
 
@@ -206,6 +209,44 @@ load_release_view() {
         RELEASE_TAG RELEASE_URL <<< "$release_view_output"
     [ "$RELEASE_TAG" = "$TAG" ] \
         || die "GitHub Release tag $RELEASE_TAG does not match $TAG"
+}
+
+immutable_release_error() {
+    local observed="${RELEASE_IS_IMMUTABLE:-missing}"
+    die "Release $TAG in $GH_REPO is published but GitHub did not confirm it as immutable" \
+        "(isImmutable=$observed). Enable release immutability under the target" \
+        "repository's Settings > Releases or enforce the organization immutable-release" \
+        "policy before publishing. GitHub applies this setting only to future releases;" \
+        "this release requires manual remediation."
+}
+
+require_immutable_release() {
+    [ "$RELEASE_IS_IMMUTABLE" = true ] || immutable_release_error
+}
+
+wait_for_published_immutable_release() {
+    local attempt
+    local metadata_observed=0
+    local output
+    local errors="$WORK_DIR/release-view-errors"
+    for attempt in 1 2 3 4 5; do
+        if output="$(release_view 2> "$errors")"; then
+            metadata_observed=1
+            load_release_view "$output"
+            if [ "$RELEASE_IS_DRAFT" = false ] && \
+                    [ "$RELEASE_IS_IMMUTABLE" = true ]; then
+                return 0
+            fi
+        fi
+        [ "$attempt" -eq 5 ] || sleep 2
+    done
+    if [ "$metadata_observed" -eq 0 ]; then
+        cat "$errors" >&2
+        die "Could not confirm the final published state of release $TAG in $GH_REPO"
+    fi
+    [ "$RELEASE_IS_DRAFT" = false ] \
+        || die "Release $TAG in $GH_REPO did not reach the published state"
+    immutable_release_error
 }
 
 prepare_release_notes() {
@@ -803,10 +844,11 @@ if RELEASE_VIEW_OUTPUT="$(release_view 2>/dev/null)"; then
     if [ "$RELEASE_IS_DRAFT" != true ]; then
         [ "$MODE" = validate ] \
             || die "Release $TAG already exists and is published; refusing to modify it"
+        require_immutable_release
         write_remote_asset_manifest "$REMOTE_ASSET_MANIFEST"
         compare_asset_manifests exact "$REMOTE_ASSET_MANIFEST"
         msg "Published release assets exactly match local names and SHA256 digests"
-        msg "Validation-only mode complete: $RELEASE_URL (immutable=$RELEASE_IS_IMMUTABLE)"
+        msg "Validation-only mode complete: $RELEASE_URL (immutable=true)"
         exit 0
     fi
     wait_for_subset_assets \
@@ -907,14 +949,14 @@ msg "Draft release notes exactly match the expected notes"
 if [ "$MODE" = publish ]; then
     msg "Publishing release $TAG"
     "${edit_args[@]}" --draft=false
-fi
-
-RELEASE_VIEW_OUTPUT="$(release_view)"
-load_release_view "$RELEASE_VIEW_OUTPUT"
-if [ "$MODE" = publish ]; then
-    [ "$RELEASE_IS_DRAFT" = false ] || die "Release $TAG remained a draft"
-    msg "Published release: $RELEASE_URL (immutable=$RELEASE_IS_IMMUTABLE)"
+    wait_for_published_immutable_release
+    write_remote_asset_manifest "$REMOTE_ASSET_MANIFEST"
+    compare_asset_manifests exact "$REMOTE_ASSET_MANIFEST"
+    msg "Published immutable release assets exactly match local names and SHA256 digests"
+    msg "Published immutable release: $RELEASE_URL"
 else
+    RELEASE_VIEW_OUTPUT="$(release_view)"
+    load_release_view "$RELEASE_VIEW_OUTPUT"
     [ "$RELEASE_IS_DRAFT" = true ] || die "Release $TAG did not remain a draft"
     msg "Verified draft release: $RELEASE_URL"
 fi

--- a/contrib/release-process/publish-local-release.sh
+++ b/contrib/release-process/publish-local-release.sh
@@ -52,7 +52,11 @@ Release metadata:
   --notes-file FILE                 Release notes; otherwise generate notes.
   --release-name NAME               Default: qbit <TAG>.
   --prerelease                      Mark the release as a prerelease.
-  --make-latest MODE                true, false, or auto. Default: false.
+  --no-prerelease                   Explicitly clear the prerelease flag.
+  --make-latest MODE                true, false, or auto.
+
+For a new draft, prerelease and make-latest default to false. When resuming a
+draft, omitted metadata options preserve its current prerelease and latest state.
 
 Publication mode (mutually exclusive):
   --create-draft                    Upload and verify assets, then leave a draft.
@@ -405,8 +409,8 @@ RELEASE_NAME=""
 REQUIRE_PHOTON=0
 ALLOW_UNSIGNED_PLATFORM_ARTIFACTS=0
 ALLOW_CODESIGNING_ARTIFACTS=0
-PRERELEASE=0
-MAKE_LATEST=false
+PRERELEASE=preserve
+MAKE_LATEST=preserve
 MODE=validate
 GH_REPO=Qbit-Org/qbit
 GUIX_SIGS_GH_REPO=Qbit-Org/qbit-guix.sigs
@@ -483,7 +487,18 @@ while [ "$#" -gt 0 ]; do
             ALLOW_CODESIGNING_ARTIFACTS=1
             shift
             ;;
-        --prerelease) PRERELEASE=1; shift ;;
+        --prerelease)
+            [ "$PRERELEASE" != false ] \
+                || die "--prerelease and --no-prerelease are mutually exclusive"
+            PRERELEASE=true
+            shift
+            ;;
+        --no-prerelease)
+            [ "$PRERELEASE" != true ] \
+                || die "--prerelease and --no-prerelease are mutually exclusive"
+            PRERELEASE=false
+            shift
+            ;;
         --make-latest)
             require_value "$1" "${2:-}"
             MAKE_LATEST="$(lowercase "$2")"
@@ -536,7 +551,7 @@ case "$RELEASE_LINE" in
     *) die "--release-line must be testnet or mainnet: $RELEASE_LINE" ;;
 esac
 case "$MAKE_LATEST" in
-    true|false|auto) ;;
+    preserve|true|false|auto) ;;
     *) die "--make-latest must be true, false, or auto: $MAKE_LATEST" ;;
 esac
 if [ "$RELEASE_LINE" = testnet ] && [ -z "$TESTNET_POSTURE_EVIDENCE" ]; then
@@ -868,16 +883,13 @@ create_args=(
     --title "$RELEASE_NAME"
 )
 create_args+=(--notes-file "$EFFECTIVE_NOTES_FILE")
-if [ "$PRERELEASE" -ne 0 ]; then
-    create_args+=(--prerelease)
-fi
+case "$PRERELEASE" in
+    true) create_args+=(--prerelease) ;;
+    preserve|false) ;;
+esac
 case "$MAKE_LATEST" in
-    true)
-        create_args+=(--latest)
-        ;;
-    false)
-        create_args+=(--latest=false)
-        ;;
+    true) create_args+=(--latest) ;;
+    preserve|false) create_args+=(--latest=false) ;;
     auto) ;;
 esac
 
@@ -929,15 +941,15 @@ edit_args=(
     --title "$RELEASE_NAME"
     --notes-file "$EFFECTIVE_NOTES_FILE"
 )
-if [ "$PRERELEASE" -eq 1 ]; then
-    edit_args+=(--prerelease)
-else
-    edit_args+=(--prerelease=false)
-fi
+case "$PRERELEASE" in
+    true) edit_args+=(--prerelease) ;;
+    false) edit_args+=(--prerelease=false) ;;
+    preserve) ;;
+esac
 case "$MAKE_LATEST" in
     true) edit_args+=(--latest) ;;
     false) edit_args+=(--latest=false) ;;
-    auto) ;;
+    preserve|auto) ;;
 esac
 
 msg "Updating verified draft metadata for $TAG"

--- a/contrib/release-process/publish-local-release.sh
+++ b/contrib/release-process/publish-local-release.sh
@@ -202,9 +202,22 @@ remote_commit_on_branch() {
 }
 
 release_view() {
-    gh release view "$TAG" --repo "$GH_REPO" \
-        --json databaseId,isDraft,isImmutable,tagName,url \
-        --jq '[.databaseId, (.isDraft | tostring), (.isImmutable | tostring), .tagName, .url] | @tsv'
+    local errors="$WORK_DIR/release-view-errors"
+    local http_status
+    local response
+    if response="$(
+        gh api --include "repos/$GH_REPO_PATH/releases/tags/$TAG" \
+            --jq '[.id, (.draft | tostring), (.immutable | tostring), .tag_name, .html_url] | @tsv' \
+            2> "$errors"
+    )"; then
+        http_status="$(printf '%s\n' "$response" | awk 'NR == 1 { print $2 }')"
+    else
+        http_status="$(printf '%s\n' "$response" | awk 'NR == 1 { print $2 }')"
+        [ "$http_status" != 404 ] || return 3
+        return 2
+    fi
+    [ "$http_status" = 200 ] || return 2
+    printf '%s\n' "$response" | awk 'NF { line=$0 } END { print line }'
 }
 
 load_release_view() {
@@ -213,6 +226,16 @@ load_release_view() {
         RELEASE_TAG RELEASE_URL <<< "$release_view_output"
     [ "$RELEASE_TAG" = "$TAG" ] \
         || die "GitHub Release tag $RELEASE_TAG does not match $TAG"
+}
+
+require_release_view() {
+    local output
+    if output="$(release_view)"; then
+        load_release_view "$output"
+        return
+    fi
+    cat "$WORK_DIR/release-view-errors" >&2
+    die "Could not inspect GitHub Release $TAG in $GH_REPO"
 }
 
 immutable_release_error() {
@@ -234,7 +257,7 @@ wait_for_published_immutable_release() {
     local output
     local errors="$WORK_DIR/release-view-errors"
     for attempt in 1 2 3 4 5; do
-        if output="$(release_view 2> "$errors")"; then
+        if output="$(release_view)"; then
             metadata_observed=1
             load_release_view "$output"
             if [ "$RELEASE_IS_DRAFT" = false ] && \
@@ -854,7 +877,7 @@ RELEASE_IS_DRAFT=""
 RELEASE_IS_IMMUTABLE=""
 RELEASE_TAG=""
 RELEASE_URL=""
-if RELEASE_VIEW_OUTPUT="$(release_view 2>/dev/null)"; then
+if RELEASE_VIEW_OUTPUT="$(release_view)"; then
     load_release_view "$RELEASE_VIEW_OUTPUT"
     if [ "$RELEASE_IS_DRAFT" != true ]; then
         [ "$MODE" = validate ] \
@@ -870,7 +893,13 @@ if RELEASE_VIEW_OUTPUT="$(release_view 2>/dev/null)"; then
         || die "Draft release assets are not a digest-matching subset of the validated upload set"
     msg "Found matching draft release; missing assets will be resumed"
 else
-    : > "$REMOTE_ASSET_MANIFEST"
+    view_status=$?
+    if [ "$view_status" -eq 3 ]; then
+        : > "$REMOTE_ASSET_MANIFEST"
+    else
+        cat "$WORK_DIR/release-view-errors" >&2
+        die "Could not inspect GitHub Release $TAG in $GH_REPO"
+    fi
 fi
 
 prepare_release_notes
@@ -913,8 +942,7 @@ fi
 if [ -z "$RELEASE_ID" ]; then
     msg "Creating draft release $TAG"
     "${create_args[@]}"
-    RELEASE_VIEW_OUTPUT="$(release_view)"
-    load_release_view "$RELEASE_VIEW_OUTPUT"
+    require_release_view
     [ "$RELEASE_IS_DRAFT" = true ] || die "New release $TAG is not a draft"
 fi
 
@@ -962,13 +990,12 @@ if [ "$MODE" = publish ]; then
     msg "Publishing release $TAG"
     "${edit_args[@]}" --draft=false
     wait_for_published_immutable_release
-    write_remote_asset_manifest "$REMOTE_ASSET_MANIFEST"
-    compare_asset_manifests exact "$REMOTE_ASSET_MANIFEST"
+    wait_for_exact_assets \
+        || die "Published immutable release assets do not exactly match the validated upload set"
     msg "Published immutable release assets exactly match local names and SHA256 digests"
     msg "Published immutable release: $RELEASE_URL"
 else
-    RELEASE_VIEW_OUTPUT="$(release_view)"
-    load_release_view "$RELEASE_VIEW_OUTPUT"
+    require_release_view
     [ "$RELEASE_IS_DRAFT" = true ] || die "Release $TAG did not remain a draft"
     msg "Verified draft release: $RELEASE_URL"
 fi

--- a/doc/release/release-process.md
+++ b/doc/release/release-process.md
@@ -197,6 +197,11 @@ exact match before publication. A draft body that cannot be corrected and
 verified remains unpublished. Manual changes to a resumed draft are therefore
 not preserved; record curated notes in a file and pass `--notes-file`.
 
+New drafts default to non-prerelease and `make-latest=false`. When resuming a
+draft, omitted metadata options preserve its existing prerelease and latest
+state. Use `--prerelease` or `--no-prerelease` and an explicit `--make-latest`
+mode to change those values during a resumed operation.
+
 Draft releases are expected to remain mutable while their assets are assembled.
 The publisher does not require `isImmutable=true` until `--publish` transitions
 the draft to a published release. It then polls the final release metadata for a

--- a/doc/release/release-process.md
+++ b/doc/release/release-process.md
@@ -206,8 +206,12 @@ Draft releases are expected to remain mutable while their assets are assembled.
 The publisher does not require `isImmutable=true` until `--publish` transitions
 the draft to a published release. It then polls the final release metadata for a
 bounded period and fails unless GitHub reports both `isDraft=false` and
-`isImmutable=true`. Validation-only mode likewise rejects an existing published
-release that is not immutable or whose immutable state is missing.
+`isImmutable=true`, then polls the locked asset inventory and digests for a
+bounded period to tolerate GitHub API propagation. Validation-only mode likewise
+rejects an existing published release that is not immutable or whose immutable
+state is missing. A release lookup is considered absent only when GitHub
+explicitly returns HTTP 404; authentication, API, and other lookup failures stop
+validation rather than skipping the remote release checks.
 
 Release immutability must be enabled under the target repository's release
 settings or enforced by its organization before publication. GitHub applies the

--- a/doc/release/release-process.md
+++ b/doc/release/release-process.md
@@ -77,6 +77,8 @@ The publisher validates:
   selected by the publisher
 - the draft release asset names and GitHub-computed SHA256 digests exactly match
   the validator-approved upload set before publication
+- the final published release is immutable, and its locked asset names and
+  GitHub-computed SHA256 digests still exactly match the validated upload set
 
 Testnet posture evidence is mandatory for `release_line=testnet`; the publisher
 fails closed when `--testnet-posture-evidence` is missing.
@@ -194,6 +196,21 @@ publisher replaces any existing draft body, fetches it back, and requires an
 exact match before publication. A draft body that cannot be corrected and
 verified remains unpublished. Manual changes to a resumed draft are therefore
 not preserved; record curated notes in a file and pass `--notes-file`.
+
+Draft releases are expected to remain mutable while their assets are assembled.
+The publisher does not require `isImmutable=true` until `--publish` transitions
+the draft to a published release. It then polls the final release metadata for a
+bounded period and fails unless GitHub reports both `isDraft=false` and
+`isImmutable=true`. Validation-only mode likewise rejects an existing published
+release that is not immutable or whose immutable state is missing.
+
+Release immutability must be enabled under the target repository's release
+settings or enforced by its organization before publication. GitHub applies the
+setting only to future releases; enabling it does not make an existing mutable
+release immutable. When `--repo OWNER/REPO` overrides the default repository,
+that target repository must independently satisfy the same policy. A publisher
+failure after a mutable publication requires manual release remediation; rerunning
+the publisher does not retrofit immutability or modify the published release.
 
 Unsigned platform or public codesigning payload waivers require the explicit
 `--allow-unsigned-platform-artifacts` or `--allow-codesigning-artifacts` flags.

--- a/doc/release/release-process.md
+++ b/doc/release/release-process.md
@@ -163,7 +163,9 @@ Public validators live under `ci/release/`. Release key metadata lives under
 
 ## Publishing
 
-The publisher requires `gh`, `git`, `gpg`, and `python3`. Run it from the
+The publisher requires `gh`, `git`, `gpg`, `python3`, and an authenticated GitHub
+account with push access to the target repository. Push access is required even
+in validation-only mode so the release listing includes drafts. Run it from the
 repository root at the selected trusted release ref. A command with no
 publication mode performs all local and remote validation without changing a
 GitHub Release:
@@ -209,9 +211,10 @@ bounded period and fails unless GitHub reports both `isDraft=false` and
 `isImmutable=true`, then polls the locked asset inventory and digests for a
 bounded period to tolerate GitHub API propagation. Validation-only mode likewise
 rejects an existing published release that is not immutable or whose immutable
-state is missing. A release lookup is considered absent only when GitHub
-explicitly returns HTTP 404; authentication, API, and other lookup failures stop
-validation rather than skipping the remote release checks.
+state is missing. Release discovery uses a fully paginated listing so matching
+drafts remain resumable. A release is considered absent only after that listing
+succeeds without a matching tag; authentication, API, and other lookup failures
+stop validation rather than skipping the remote release checks.
 
 Release immutability must be enabled under the target repository's release
 settings or enforced by its organization before publication. GitHub applies the


### PR DESCRIPTION
## Summary

- extend the script-only local release publisher now present on `1.0.0` through PR #116 while preserving its deterministic release-note checks and PR #118's P2MR v1 conformance gates
- require every accepted published release to report `isImmutable=true`, with bounded post-publication polling for delayed GitHub metadata and asset-digest propagation
- fail closed for false or missing immutability, require push access for draft visibility, and treat a release as absent only after a successful fully paginated listing finds no matching tag
- preserve omitted prerelease/latest metadata on resumed drafts and document the repository or organization immutability policy required for repositories selected with `--repo`

Fixes #100.

### PR #91 replay provenance after rebase

The original version of this PR explicitly replayed these two commits authored for PR #91, **Add script-only release publisher**:

- `be61f6902fe950e6e140c7af5c00ad1b1fb7024e` — `release: publish artifacts from local coordinator`
- `5c19300d7aaa24ec1f54c48341efb5ecfec44cdf` — `release: validate existing published assets`

PR #91 targeted the temporary `bind-builder-source-attestations` branch and merged there as `8e24755eb8b1563c89105ffe9786a45f1b6e40a5`. PR #84 had already squash-merged that branch into `1.0.0` one minute earlier, so the later PR #91 merge and its two commits initially missed `1.0.0`.

The latest `1.0.0` contains the local-publisher foundation through PR #116 (`398c21d1731e715af544d622cf8a41fd6822c77f`), which independently incorporated and hardened that work, and the P2MR v1 release-conformance framework through PR #118 (`4af778aedc6b77b25f377051a288a098192c9767`). After rebasing, this PR no longer re-adds the foundation. It preserves #116's deterministic draft-note behavior and #118's P2MR validation inputs and ordering, then layers issue #100 immutability enforcement, metadata preservation, fail-closed lookup handling, bounded asset polling, and tests on top. The two hashes above remain the provenance of the originally replayed changes.

## Testing

- [ ] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [x] Not run. Reason: no C++ product build was run because this changes release tooling, tests, merge classification, and documentation only.

Focused validation:

```sh
python3 -m unittest ci.release.test_publish_local_release
python3 -m unittest ci.release.test_publish_local_release ci.release.test_validate_builder_attestations ci.release.test_validate_key_metadata ci.release.test_validate_release_artifacts ci.release.test_verify_testnet_release_posture
python3 -m unittest ci.checks.test_classify_merge_profile
bash -n contrib/release-process/publish-local-release.sh
git diff --check origin/1.0.0...HEAD
```

The publisher suite passed all 25 tests, the expanded release suite (including P2MR v1 conformance) passed all 186 tests, and the merge-profile suite passed all 23 tests. The complete Docker lint suite also passed, including Ruff and ShellCheck coverage for the changed files.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`. The branch is rebased onto `27bdaa920ec7daf075423b698c7cfa38220a8065`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- Publication remains validation-only unless `--create-draft` or `--publish` is explicit.
- Draft notes retain PR #116's deterministic replacement and exact verification before publication.
- PR #118's mainnet-required and testnet all-or-none P2MR v1 conformance evidence remains validated before artifact publication checks.
- Draft assets remain mutable and must exactly match the validated set before publication.
- After `--publish`, the publisher polls release metadata up to five times and succeeds only after observing `isDraft=false` and `isImmutable=true`.
- Once immutability is confirmed, it polls the locked asset inventory up to five times and verifies exact names and GitHub-computed SHA256 digests.
- Validation-only mode accepts an existing published release only when it is immutable and digest-identical; a release is treated as absent only after an authenticated, fully paginated listing that can include drafts finds no matching tag.
- The publisher never enables repository settings itself and never modifies an existing published release.

## Docs / Process Impact

Choose exactly one:

- [x] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [ ] No public docs update needed. Reason:

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; the subtree was not changed.

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes gate public release publication and validation (immutability, asset digests, GitHub API behavior); mistakes could block legitimate releases or accept unsafe mutable publications.
> 
> **Overview**
> Hardens **`publish-local-release.sh`** so published releases are accepted only when GitHub reports **`isImmutable=true`**, with bounded polling after **`--publish`** for immutability metadata and locked asset digests. Release discovery moves to a **paginated releases API** listing (drafts need **push access**); inconclusive lookups **fail closed** instead of behaving like “no release.”
> 
> **Resumed drafts** keep existing prerelease/latest flags unless **`--prerelease`**, **`--no-prerelease`**, or **`--make-latest`** are set explicitly; new drafts still default to non-prerelease / not latest.
> 
> **Merge classification** drops the retired **`.github/workflows/release-publish.yml`** from the release-policy allowlist, so changes there require full source validation. Tests and **`doc/release/release-process.md`** document immutability prerequisites, polling, and the updated publisher behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd260f5c82979ce8a51d7ba1784e50092cf103a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->