### PR TITLE
Require potential resolutions in PR review findings

### DIFF
--- a/.agents/skills/qbit-single-pr-review/SKILL.md
+++ b/.agents/skills/qbit-single-pr-review/SKILL.md
@@ -195,13 +195,13 @@ Lead with actionable findings. Use these severities:
 - `medium`: plausible bug, incomplete edge coverage, unclear behavior, or documentation/runbook gap that should be addressed.
 - `low`: small maintainability, clarity, or test-quality issue that does not block correctness.
 
-Each finding should include:
+Each finding must include:
 
 - A severity.
 - File and line reference when possible.
 - The observed behavior.
 - Why it matters in qbit or Bitcoin Core terms.
-- The concrete fix or evidence needed.
+- A separate `Potential resolution:` line directly beneath the finding that states the concrete fix or evidence needed. Do not leave the resolution implicit in the finding explanation.
 
 Do not pad the comment with speculative findings. If no actionable issues are found, say that and list remaining residual risks or validation gaps.
 
@@ -238,7 +238,8 @@ The proposed GitHub comment should use this structure:
 ## PR Review
 
 ### Findings
-- [severity] `path:line` - Finding title. Explanation and requested change.
+- [severity] `path:line` - Finding title. Explanation of the observed behavior and why it matters.
+  - **Potential resolution:** Concrete fix or evidence needed.
 
 If there are no findings:
 No blocking findings from this review pass.


### PR DESCRIPTION
## Summary

- Require every PR review finding to include a separate `Potential resolution:` line.
- Update the proposed-comment template to place the resolution directly beneath each finding.

## Testing

- [ ] Built locally.
- [ ] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [x] Not run. Reason: Build and unit/functional tests are not applicable to this skill-only Markdown change.

Validation performed:

- Full repository lint suite using the documented Docker lint image.
- Skill metadata and structure validation with the skill-creator validator.
- `git diff --check`.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

## Risk / Review Notes

- [ ] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [x] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: This only tightens the required format of drafted review findings.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: The in-repo review skill is the process guidance being updated; no separate public documentation describes this output format.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786547829&installation_id=141183937&pr_number=120&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F120&signature=f40dd72e9df3a51b304466d702dd900ca295394ff4f809d7fb82e5dc621c279d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only process guidance for review comment formatting; no runtime, consensus, or security behavior changes.
> 
> **Overview**
> Tightens the **qbit-single-pr-review** skill so every drafted finding must carry an explicit fix or evidence ask, not only severity and explanation.
> 
> **Finding rules** now require a separate **`Potential resolution:`** line directly under each finding; resolutions must not be buried in the finding text. The proposed GitHub comment template matches that shape: one bullet for the finding, a nested bullet for **Potential resolution**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700fbccd827a6444d91496a18112247f62d3fda6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->