### PR TITLE
Re-pin signed tags during immutable release publication

### DIFF
--- a/ci/release/test_publish_local_release.py
+++ b/ci/release/test_publish_local_release.py
@@ -98,21 +98,64 @@ log = Path(os.environ["FAKE_GH_LOG"])
 with log.open("a", encoding="utf8") as output:
     output.write(" ".join(args) + "\n")
 
+
+def sequence_value(name, fallback, index):
+    values = os.environ.get(name, fallback).split(",")
+    return values[min(index, len(values) - 1)]
+
+
+def next_counter(name):
+    path = state / name
+    value = int(path.read_text(encoding="utf8")) if path.exists() else 0
+    path.write_text(str(value + 1), encoding="utf8")
+    return value
+
+
+def api_fields():
+    fields = {}
+    for index, value in enumerate(args[:-1]):
+        if value in {"-f", "-F", "--raw-field", "--field"}:
+            key, field_value = args[index + 1].split("=", 1)
+            fields[key] = field_value
+    return fields
+
+
 if args[:2] == ["auth", "status"]:
     raise SystemExit(0)
 
 if args and args[0] == "api":
     endpoint = next(value for value in args[1:] if value.startswith("repos/"))
     if "/git/ref/tags/" in endpoint:
-        print("tag " + os.environ["FAKE_GH_TAG_OBJECT"])
+        index = next_counter("tag-ref-read-count")
+        moved_tag_path = state / "moved-tag-object"
+        if moved_tag_path.exists():
+            tag_object = moved_tag_path.read_text(encoding="utf8")
+        else:
+            tag_object = sequence_value(
+                "FAKE_GH_TAG_OBJECT_SEQUENCE",
+                os.environ["FAKE_GH_TAG_OBJECT"],
+                index,
+            )
+        print("tag " + tag_object)
     elif "/git/tags/" in endpoint:
+        index = next_counter("tag-object-read-count")
         print(
             "\t".join(
                 [
-                    os.environ["FAKE_GH_TAG_TARGET"],
+                    sequence_value(
+                        "FAKE_GH_TAG_TARGET_SEQUENCE",
+                        os.environ["FAKE_GH_TAG_TARGET"],
+                        index,
+                    ),
                     "commit",
-                    os.environ.get("FAKE_GH_VERIFIED", "true"),
-                    "valid",
+                    sequence_value(
+                        "FAKE_GH_VERIFIED_SEQUENCE",
+                        os.environ.get("FAKE_GH_VERIFIED", "true"),
+                        index,
+                    ),
+                    sequence_value(
+                        "FAKE_GH_VERIFICATION_REASON_SEQUENCE", "valid", index
+                    ),
                     "2026-01-01T00:00:00Z",
                 ]
             )
@@ -142,6 +185,13 @@ if args and args[0] == "api":
             if draft:
                 immutable = os.environ.get("FAKE_GH_DRAFT_IMMUTABLE", "false")
             else:
+                moved_tag_object = os.environ.get(
+                    "FAKE_GH_TAG_OBJECT_DURING_IMMUTABLE_POLL", ""
+                )
+                if moved_tag_object:
+                    (state / "moved-tag-object").write_text(
+                        moved_tag_object, encoding="utf8"
+                    )
                 sequence = os.environ.get("FAKE_GH_IMMUTABLE_SEQUENCE", "true").split(",")
                 counter_path = state / "immutable-view-count"
                 counter = int(counter_path.read_text(encoding="utf8")) if counter_path.exists() else 0
@@ -193,10 +243,24 @@ if args and args[0] == "api":
                     print(line.split("\t", 1)[0] + "\t")
             else:
                 print(asset_text, end="")
+    elif endpoint.endswith("/releases/1") and "PATCH" in args:
+        fields = api_fields()
+        if fields.get("draft") == "false":
+            (state / "release-state").write_text("published\n", encoding="utf8")
+        if "make_latest" in fields:
+            (state / "latest-mode").write_text(
+                fields["make_latest"], encoding="utf8"
+            )
+            (state / "latest-state").write_text(
+                fields["make_latest"], encoding="utf8"
+            )
+        print(json.dumps({"id": 1, "draft": fields.get("draft") != "false"}))
     elif endpoint.endswith("/releases/1"):
         body_path = state / "release-body"
         body = body_path.read_text(encoding="utf8") if body_path.exists() else ""
-        print(json.dumps({"body": body}))
+        title_path = state / "release-title"
+        title = title_path.read_text(encoding="utf8") if title_path.exists() else ""
+        print(json.dumps({"body": body, "name": title}))
     else:
         print("unsupported fake gh api endpoint: " + endpoint, file=sys.stderr)
         raise SystemExit(2)
@@ -209,6 +273,8 @@ if args[:2] == ["release", "create"]:
     (state / "release-body").write_text(
         notes_file.read_text(encoding="utf8"), encoding="utf8"
     )
+    title = args[args.index("--title") + 1]
+    (state / "release-title").write_text(title, encoding="utf8")
     prerelease = "true" if "--prerelease" in args else "false"
     latest = "true" if "--latest" in args else "false"
     (state / "prerelease-state").write_text(prerelease, encoding="utf8")
@@ -231,6 +297,9 @@ if args[:2] == ["release", "edit"]:
         (state / "release-body").write_text(
             notes_file.read_text(encoding="utf8"), encoding="utf8"
         )
+    if "--title" in args:
+        title = args[args.index("--title") + 1]
+        (state / "release-title").write_text(title, encoding="utf8")
     if "--draft=false" in args:
         (state / "release-state").write_text("published\n", encoding="utf8")
     if "--prerelease" in args:
@@ -279,6 +348,9 @@ def option(name):
 
 artifacts = Path(option("--artifacts-dir"))
 output_path = Path(option("--github-output"))
+notes_to_mutate = os.environ.get("FAKE_MUTATE_NOTES_FILE")
+if notes_to_mutate:
+    Path(notes_to_mutate).write_text("mutated after snapshot\n", encoding="utf8")
 files = sorted(path.resolve() for path in artifacts.iterdir() if path.is_file())
 with output_path.open("a", encoding="utf8") as output:
     output.write(f"file_count={len(files)}\n")
@@ -375,6 +447,12 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         release_lookup_error: bool = False,
         published_asset_lag: int = 0,
         can_push: bool = True,
+        tag_object_sequence: tuple[str, ...] | None = None,
+        tag_target_sequence: tuple[str, ...] | None = None,
+        verified_sequence: tuple[bool, ...] | None = None,
+        verification_reason_sequence: tuple[str, ...] | None = None,
+        tag_object_during_immutable_poll: str | None = None,
+        mutate_notes_file: Path | None = None,
     ) -> subprocess.CompletedProcess[str]:
         env = dict(os.environ)
         env["PATH"] = f"{self.bin_dir}{os.pathsep}{env['PATH']}"
@@ -386,6 +464,22 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
                 "FAKE_GH_TAG_OBJECT": self.tag_object,
                 "FAKE_GH_TAG_TARGET": self.tag_target,
                 "FAKE_GH_VERIFIED": str(verified).lower(),
+                "FAKE_GH_TAG_OBJECT_SEQUENCE": ",".join(
+                    tag_object_sequence or (self.tag_object,)
+                ),
+                "FAKE_GH_TAG_TARGET_SEQUENCE": ",".join(
+                    tag_target_sequence or (self.tag_target,)
+                ),
+                "FAKE_GH_VERIFIED_SEQUENCE": ",".join(
+                    str(value).lower()
+                    for value in (verified_sequence or (verified,))
+                ),
+                "FAKE_GH_VERIFICATION_REASON_SEQUENCE": ",".join(
+                    verification_reason_sequence or ("valid",)
+                ),
+                "FAKE_GH_TAG_OBJECT_DURING_IMMUTABLE_POLL": (
+                    tag_object_during_immutable_poll or ""
+                ),
                 "FAKE_GH_GENERATED_NOTES": GENERATED_NOTES,
                 "FAKE_GH_IGNORE_NOTES_EDIT": str(ignore_notes_edit).lower(),
                 "FAKE_GH_EMPTY_DIGEST_READS": str(empty_digest_reads),
@@ -395,6 +489,7 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
                 "FAKE_GH_PUBLISHED_ASSET_LAG": str(published_asset_lag),
                 "FAKE_GH_CAN_PUSH": str(can_push).lower(),
                 "FAKE_VALIDATOR_LOG": str(self.validator_log),
+                "FAKE_MUTATE_NOTES_FILE": str(mutate_notes_file or ""),
             }
         )
         args = [
@@ -563,6 +658,9 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         (self.gh_state / "assets.tsv").write_text("", encoding="utf8")
         (self.gh_state / "prerelease-state").write_text("true", encoding="utf8")
         (self.gh_state / "latest-state").write_text("true", encoding="utf8")
+        (self.gh_state / "release-title").write_text(
+            "Custom coordinator title", encoding="utf8"
+        )
 
         result = self.run_publisher("--publish")
 
@@ -573,6 +671,10 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertEqual(
             (self.gh_state / "latest-state").read_text(encoding="utf8"), "true"
         )
+        self.assertEqual(
+            (self.gh_state / "release-title").read_text(encoding="utf8"),
+            "Custom coordinator title",
+        )
         edit_args = next(
             line.split()
             for line in self.gh_log.read_text(encoding="utf8").splitlines()
@@ -582,10 +684,40 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertNotIn("--prerelease=false", edit_args)
         self.assertNotIn("--latest", edit_args)
         self.assertNotIn("--latest=false", edit_args)
+        self.assertNotIn("--title", edit_args)
         gh_log = self.gh_log.read_text(encoding="utf8")
         self.assertIn("/releases?per_page=100", gh_log)
         self.assertNotIn("/releases/tags/", gh_log)
         self.assertNotIn("release create", gh_log)
+        publish_call = next(
+            line
+            for line in gh_log.splitlines()
+            if "/releases/1 --method PATCH" in line and "draft=false" in line
+        )
+        self.assertNotIn("make_latest=", publish_call)
+
+    def test_resumed_draft_replaces_title_only_when_explicit(self) -> None:
+        (self.gh_state / "release-state").write_text("draft\n", encoding="utf8")
+        (self.gh_state / "assets.tsv").write_text("", encoding="utf8")
+        (self.gh_state / "release-title").write_text(
+            "Custom coordinator title", encoding="utf8"
+        )
+
+        result = self.run_publisher(
+            "--publish", "--release-name", "Approved release title"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            (self.gh_state / "release-title").read_text(encoding="utf8"),
+            "Approved release title",
+        )
+        edit_call = next(
+            line
+            for line in self.gh_log.read_text(encoding="utf8").splitlines()
+            if line.startswith("release edit ")
+        )
+        self.assertIn("--title Approved release title", edit_call)
 
     def test_resumed_draft_metadata_can_be_explicitly_cleared(self) -> None:
         (self.gh_state / "release-state").write_text("draft\n", encoding="utf8")
@@ -664,10 +796,17 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
             for line in self.gh_log.read_text(encoding="utf8").splitlines()
             if line.startswith("release edit ")
         ]
-        self.assertEqual(len(edit_commands), 2)
+        self.assertEqual(len(edit_commands), 1)
         self.assertIn("--draft", edit_commands[0].split())
         self.assertNotIn("--draft=false", edit_commands[0].split())
-        self.assertIn("--draft=false", edit_commands[1].split())
+        self.assertIn(
+            "draft=false",
+            next(
+                line
+                for line in self.gh_log.read_text(encoding="utf8").splitlines()
+                if "/releases/1 --method PATCH" in line
+            ),
+        )
 
     def test_publish_replaces_stale_draft_body_with_explicit_notes(self) -> None:
         notes = self.root / "release-notes.md"
@@ -686,6 +825,25 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertNotIn(
             "releases/generate-notes",
             self.gh_log.read_text(encoding="utf8"),
+        )
+
+    def test_publish_uses_snapshot_when_explicit_notes_change_during_validation(self) -> None:
+        notes = self.root / "release-notes.md"
+        approved_notes = "Approved notes\n\nExact coordinator contents"
+        notes.write_text(approved_notes, encoding="utf8")
+
+        result = self.run_publisher(
+            "--publish",
+            "--notes-file",
+            str(notes),
+            mutate_notes_file=notes,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(notes.read_text(encoding="utf8"), "mutated after snapshot\n")
+        self.assertEqual(
+            (self.gh_state / "release-body").read_text(encoding="utf8"),
+            approved_notes,
         )
 
     def test_publish_fails_closed_when_draft_body_cannot_be_corrected(self) -> None:
@@ -725,7 +883,7 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertEqual(gh_log.count("release create"), 1)
         self.assertEqual(gh_log.count("release upload"), len(uploaded))
         self.assertIn("release edit", gh_log)
-        self.assertIn("--draft=false", gh_log)
+        self.assertIn("--method PATCH -F draft=false -f make_latest=false", gh_log)
         log_lines = gh_log.splitlines()
         final_view = max(
             i
@@ -766,6 +924,101 @@ with open(os.environ["FAKE_VALIDATOR_LOG"], "a", encoding="utf8") as log:
         self.assertEqual(
             (self.gh_state / "immutable-view-count").read_text(encoding="utf8"), "3"
         )
+
+    def test_publish_maps_make_latest_auto_to_github_legacy_mode(self) -> None:
+        (self.gh_state / "release-state").write_text("draft\n", encoding="utf8")
+        (self.gh_state / "assets.tsv").write_text("", encoding="utf8")
+        (self.gh_state / "latest-state").write_text("true", encoding="utf8")
+
+        result = self.run_publisher("--publish", "--make-latest", "auto")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual(
+            (self.gh_state / "latest-mode").read_text(encoding="utf8"), "legacy"
+        )
+        publish_call = next(
+            line
+            for line in self.gh_log.read_text(encoding="utf8").splitlines()
+            if "/releases/1 --method PATCH" in line and "draft=false" in line
+        )
+        self.assertIn("make_latest=legacy", publish_call)
+
+    def test_tag_move_before_publication_leaves_release_as_draft(self) -> None:
+        moved_tag_object = "f" * 40
+
+        result = self.run_publisher(
+            "--publish",
+            tag_object_sequence=(self.tag_object, moved_tag_object),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("during pre-publication verification", result.stderr)
+        self.assertEqual(
+            (self.gh_state / "release-state").read_text(encoding="utf8").strip(),
+            "draft",
+        )
+        self.assertNotIn("draft=false", self.gh_log.read_text(encoding="utf8"))
+
+    def test_tag_target_change_before_publication_leaves_release_as_draft(self) -> None:
+        moved_tag_target = "e" * 40
+
+        result = self.run_publisher(
+            "--publish",
+            tag_target_sequence=(self.tag_target, moved_tag_target),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match pinned tag target", result.stderr)
+        self.assertIn("during pre-publication verification", result.stderr)
+        self.assertEqual(
+            (self.gh_state / "release-state").read_text(encoding="utf8").strip(),
+            "draft",
+        )
+
+    def test_tag_signature_change_before_publication_leaves_release_as_draft(self) -> None:
+        result = self.run_publisher(
+            "--publish",
+            verified_sequence=(True, False),
+            verification_reason_sequence=("valid", "invalid"),
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("exact valid status", result.stderr)
+        self.assertIn("during pre-publication verification", result.stderr)
+        self.assertEqual(
+            (self.gh_state / "release-state").read_text(encoding="utf8").strip(),
+            "draft",
+        )
+
+    def test_tag_move_during_immutable_polling_fails_after_publication(self) -> None:
+        moved_tag_object = "d" * 40
+
+        result = self.run_publisher(
+            "--publish",
+            immutable_sequence=("false", "true"),
+            tag_object_during_immutable_poll=moved_tag_object,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("during post-publication verification", result.stderr)
+        self.assertIn("may already be immutable", result.stderr)
+        self.assertIn("Stop distribution", result.stderr)
+        self.assertEqual(
+            (self.gh_state / "release-state").read_text(encoding="utf8").strip(),
+            "published",
+        )
+        log_lines = self.gh_log.read_text(encoding="utf8").splitlines()
+        publish_index = next(
+            index
+            for index, line in enumerate(log_lines)
+            if "/releases/1 --method PATCH" in line and "draft=false" in line
+        )
+        final_tag_index = max(
+            index
+            for index, line in enumerate(log_lines)
+            if "/git/ref/tags/" in line
+        )
+        self.assertGreater(final_tag_index, publish_index)
 
     def test_publish_fails_when_release_remains_mutable(self) -> None:
         result = self.run_publisher("--publish", immutable_sequence=("false",))

--- a/ci/release/test_validate_release_artifacts.py
+++ b/ci/release/test_validate_release_artifacts.py
@@ -646,7 +646,10 @@ class ReleasePublisherBoundaryTest(unittest.TestCase):
 
         self.assertIn(".verification.verified", publisher)
         self.assertIn("not a GitHub-verified signed tag", publisher)
-        self.assertIn('"$REMOTE_TARGET_TYPE" = commit', publisher)
+        self.assertIn('"$remote_target_type" = commit', publisher)
+        self.assertIn('"$remote_verification_reason" = valid', publisher)
+        self.assertIn("verify_remote_tag_pin pre-publication", publisher)
+        self.assertIn("verify_remote_tag_pin post-publication", publisher)
         self.assertIn("merge-base --is-ancestor", publisher)
         self.assertIn("ci/release/validate_release_artifacts.py", publisher)
         self.assertIn("ci/release/verify_testnet_release_posture.py", publisher)

--- a/contrib/release-process/publish-local-release.sh
+++ b/contrib/release-process/publish-local-release.sh
@@ -50,13 +50,14 @@ Release policy:
 
 Release metadata:
   --notes-file FILE                 Release notes; otherwise generate notes.
-  --release-name NAME               Default: qbit <TAG>.
+  --release-name NAME               Default for a new draft: qbit <TAG>.
   --prerelease                      Mark the release as a prerelease.
   --no-prerelease                   Explicitly clear the prerelease flag.
-  --make-latest MODE                true, false, or auto.
+  --make-latest MODE                true, false, or auto (GitHub legacy mode).
 
 For a new draft, prerelease and make-latest default to false. When resuming a
-draft, omitted metadata options preserve its current prerelease and latest state.
+draft, omitted metadata options preserve its current title, prerelease, and
+latest state.
 
 Publication mode (mutually exclusive):
   --create-draft                    Upload and verify assets, then leave a draft.
@@ -201,6 +202,70 @@ remote_commit_on_branch() {
     esac
 }
 
+remote_tag_pin_failure() {
+    local phase="$1"
+    shift
+    if [ "$phase" = post-publication ]; then
+        die "$*" "Release $TAG may already be immutable. Stop distribution," \
+            "preserve the publisher transcript and observed tag values, and follow" \
+            "the immutable-publication recovery procedure in doc/release/release-process.md."
+    fi
+    die "$*"
+}
+
+verify_remote_tag_pin() {
+    local phase="$1"
+    local remote_ref
+    local remote_tag_type
+    local remote_tag_sha
+    local remote_tag_query
+    local remote_tag_info
+    local remote_tag_target
+    local remote_target_type
+    local remote_verified
+    local remote_verification_reason
+    local remote_verified_at
+
+    remote_ref="$(
+        gh api "repos/$GH_REPO_PATH/git/ref/tags/$TAG" \
+            --jq '.object.type + " " + .object.sha'
+    )" || remote_tag_pin_failure "$phase" \
+        "Could not resolve remote tag $TAG during $phase verification"
+    remote_tag_type="${remote_ref%% *}"
+    remote_tag_sha="${remote_ref#* }"
+    [ "$remote_tag_type" = tag ] \
+        || remote_tag_pin_failure "$phase" \
+            "Remote tag $TAG must be annotated during $phase verification, got $remote_tag_type"
+    [ "$(lowercase "$remote_tag_sha")" = "$(lowercase "$TAG_OBJECT")" ] \
+        || remote_tag_pin_failure "$phase" \
+            "Remote tag object $remote_tag_sha does not match pinned tag object $TAG_OBJECT during $phase verification"
+
+    remote_tag_query='[.object.sha, .object.type, '
+    remote_tag_query+='((.verification.verified // false) | tostring), '
+    remote_tag_query+='(.verification.reason // "unknown"), '
+    remote_tag_query+='(.verification.verified_at // "")] | @tsv'
+    remote_tag_info="$(
+        gh api "repos/$GH_REPO_PATH/git/tags/$TAG_OBJECT" \
+            --jq "$remote_tag_query"
+    )" || remote_tag_pin_failure "$phase" \
+        "Could not inspect pinned remote tag object $TAG_OBJECT during $phase verification"
+    IFS=$'\t' read -r remote_tag_target remote_target_type remote_verified \
+        remote_verification_reason remote_verified_at <<< "$remote_tag_info"
+    [ "$remote_target_type" = commit ] \
+        || remote_tag_pin_failure "$phase" \
+            "Remote tag $TAG must directly target a commit during $phase verification, got $remote_target_type"
+    [ "$(lowercase "$remote_tag_target")" = "$(lowercase "$TAG_TARGET")" ] \
+        || remote_tag_pin_failure "$phase" \
+            "Remote tag target $remote_tag_target does not match pinned tag target" \
+            "$TAG_TARGET during $phase verification"
+    [ "$remote_verified" = true ] && [ "$remote_verification_reason" = valid ] \
+        || remote_tag_pin_failure "$phase" \
+            "Remote tag $TAG is not a GitHub-verified signed tag with exact valid" \
+            "status during $phase verification (verified=$remote_verified" \
+            "reason=$remote_verification_reason)"
+    msg "Remote tag pin verified during $phase${remote_verified_at:+ at $remote_verified_at}"
+}
+
 release_view() {
     local errors="$WORK_DIR/release-view-errors"
     local response
@@ -284,8 +349,21 @@ wait_for_published_immutable_release() {
 
 prepare_release_notes() {
     if [ -n "$NOTES_FILE" ]; then
-        EFFECTIVE_NOTES_FILE="$NOTES_FILE"
-        msg "Using explicit release notes from $NOTES_FILE"
+        EFFECTIVE_NOTES_FILE="$WORK_DIR/explicit-release-notes.md"
+        python3 - "$NOTES_FILE" "$EFFECTIVE_NOTES_FILE" <<'PY'
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+content = source.read_bytes()
+try:
+    content.decode("utf8")
+except UnicodeDecodeError as error:
+    raise SystemExit(f"Explicit release notes are not valid UTF-8: {error}") from error
+destination.write_bytes(content)
+PY
+        msg "Snapshotted explicit release notes from $NOTES_FILE"
         return
     fi
 
@@ -435,6 +513,8 @@ P2MR_V1_ORACLE_REPORT=""
 P2MR_V1_INTEGRATION_MATRIX=""
 NOTES_FILE=""
 RELEASE_NAME=""
+RELEASE_NAME_EXPLICIT=0
+RELEASE_CREATED_THIS_RUN=0
 REQUIRE_PHOTON=0
 ALLOW_UNSIGNED_PLATFORM_ARTIFACTS=0
 ALLOW_CODESIGNING_ARTIFACTS=0
@@ -505,6 +585,7 @@ while [ "$#" -gt 0 ]; do
         --release-name)
             require_value "$1" "${2:-}"
             RELEASE_NAME="$2"
+            RELEASE_NAME_EXPLICIT=1
             shift 2
             ;;
         --require-photon) REQUIRE_PHOTON=1; shift ;;
@@ -677,31 +758,7 @@ remote_commit "$GUIX_SIGS_GH_REPO_PATH" "$GUIX_SIGS_REF" "qbit-guix.sigs commit"
 remote_commit_on_branch "$GUIX_SIGS_GH_REPO_PATH" "$GUIX_SIGS_REF" \
     "$GUIX_SIGS_BRANCH" "qbit-guix.sigs commit"
 
-REMOTE_REF="$(gh api "repos/$GH_REPO_PATH/git/ref/tags/$TAG" --jq '.object.type + " " + .object.sha')" \
-    || die "Could not resolve remote tag $TAG"
-REMOTE_TAG_TYPE="${REMOTE_REF%% *}"
-REMOTE_TAG_SHA="${REMOTE_REF#* }"
-[ "$REMOTE_TAG_TYPE" = tag ] \
-    || die "Remote tag $TAG must be annotated, got $REMOTE_TAG_TYPE"
-[ "$(lowercase "$REMOTE_TAG_SHA")" = "$(lowercase "$TAG_OBJECT")" ] \
-    || die "Remote tag object $REMOTE_TAG_SHA does not match local tag object $TAG_OBJECT"
-REMOTE_TAG_QUERY='[.object.sha, .object.type, '
-REMOTE_TAG_QUERY+='((.verification.verified // false) | tostring), '
-REMOTE_TAG_QUERY+='(.verification.reason // "unknown"), '
-REMOTE_TAG_QUERY+='(.verification.verified_at // "")] | @tsv'
-REMOTE_TAG_INFO="$(
-    gh api "repos/$GH_REPO_PATH/git/tags/$REMOTE_TAG_SHA" \
-        --jq "$REMOTE_TAG_QUERY"
-)" || die "Could not inspect remote tag $TAG"
-IFS=$'\t' read -r REMOTE_TAG_TARGET REMOTE_TARGET_TYPE REMOTE_VERIFIED \
-    REMOTE_VERIFICATION_REASON REMOTE_VERIFIED_AT <<< "$REMOTE_TAG_INFO"
-[ "$REMOTE_TARGET_TYPE" = commit ] \
-    || die "Remote tag $TAG must directly target a commit, got $REMOTE_TARGET_TYPE"
-[ "$REMOTE_VERIFIED" = true ] \
-    || die "Remote tag $TAG is not a GitHub-verified signed tag (reason: $REMOTE_VERIFICATION_REASON)"
-[ "$(lowercase "$REMOTE_TAG_TARGET")" = "$(lowercase "$TAG_TARGET")" ] \
-    || die "Remote tag target $REMOTE_TAG_TARGET does not match local tag target $TAG_TARGET"
-msg "Remote tag is GitHub-verified${REMOTE_VERIFIED_AT:+ at $REMOTE_VERIFIED_AT}"
+verify_remote_tag_pin initial
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/qbit-release-publish.XXXXXX")"
 trap 'rm -rf "$WORK_DIR"' EXIT
@@ -709,6 +766,7 @@ VALIDATION_OUTPUT="$WORK_DIR/validation-output.env"
 LOCAL_ASSET_MANIFEST="$WORK_DIR/local-assets.tsv"
 REMOTE_ASSET_MANIFEST="$WORK_DIR/remote-assets.tsv"
 : > "$VALIDATION_OUTPUT"
+[ -z "$NOTES_FILE" ] || prepare_release_notes
 
 if [ "$P2MR_CONFORMANCE_REQUESTED" -eq 1 ]; then
     msg "Validating qbit P2MR v1 release conformance"
@@ -896,6 +954,7 @@ if RELEASE_VIEW_OUTPUT="$(release_view)"; then
         require_immutable_release
         write_remote_asset_manifest "$REMOTE_ASSET_MANIFEST"
         compare_asset_manifests exact "$REMOTE_ASSET_MANIFEST"
+        verify_remote_tag_pin post-publication
         msg "Published release assets exactly match local names and SHA256 digests"
         msg "Validation-only mode complete: $RELEASE_URL (immutable=true)"
         exit 0
@@ -913,7 +972,7 @@ else
     fi
 fi
 
-prepare_release_notes
+[ -n "${EFFECTIVE_NOTES_FILE:-}" ] || prepare_release_notes
 
 create_args=(
     gh release create "$TAG"
@@ -951,6 +1010,7 @@ if [ "$MODE" = validate ]; then
 fi
 
 if [ -z "$RELEASE_ID" ]; then
+    RELEASE_CREATED_THIS_RUN=1
     msg "Creating draft release $TAG"
     "${create_args[@]}"
     require_release_view
@@ -976,33 +1036,54 @@ msg "Draft release assets exactly match local names and SHA256 digests"
 edit_args=(
     gh release edit "$TAG"
     --repo "$GH_REPO"
-    --verify-tag
-    --title "$RELEASE_NAME"
     --notes-file "$EFFECTIVE_NOTES_FILE"
 )
+[ "$RELEASE_NAME_EXPLICIT" -eq 0 ] || edit_args+=(--title "$RELEASE_NAME")
 case "$PRERELEASE" in
     true) edit_args+=(--prerelease) ;;
     false) edit_args+=(--prerelease=false) ;;
     preserve) ;;
 esac
-case "$MAKE_LATEST" in
-    true) edit_args+=(--latest) ;;
-    false) edit_args+=(--latest=false) ;;
-    preserve|auto) ;;
-esac
-
+if [ "$MODE" = draft ]; then
+    case "$MAKE_LATEST" in
+        true) edit_args+=(--latest) ;;
+        false) edit_args+=(--latest=false) ;;
+        preserve|auto) ;;
+    esac
+fi
 msg "Updating verified draft metadata for $TAG"
 "${edit_args[@]}" --draft
+if [ "$MODE" = draft ] && [ "$MAKE_LATEST" = auto ]; then
+    gh api "repos/$GH_REPO_PATH/releases/$RELEASE_ID" \
+        --method PATCH -f make_latest=legacy >/dev/null \
+        || die "Could not apply automatic latest-release policy to draft $TAG"
+fi
 verify_release_notes \
     || die "Draft release notes do not match the expected notes"
 msg "Draft release notes exactly match the expected notes"
 
 if [ "$MODE" = publish ]; then
+    publish_args=(
+        gh api "repos/$GH_REPO_PATH/releases/$RELEASE_ID"
+        --method PATCH
+        -F draft=false
+    )
+    case "$MAKE_LATEST" in
+        true|false) publish_args+=(-f "make_latest=$MAKE_LATEST") ;;
+        auto) publish_args+=(-f make_latest=legacy) ;;
+        preserve)
+            [ "$RELEASE_CREATED_THIS_RUN" -eq 0 ] \
+                || publish_args+=(-f make_latest=false)
+            ;;
+    esac
     msg "Publishing release $TAG"
-    "${edit_args[@]}" --draft=false
+    verify_remote_tag_pin pre-publication
+    "${publish_args[@]}" >/dev/null \
+        || die "Could not publish release $TAG"
     wait_for_published_immutable_release
     wait_for_exact_assets \
         || die "Published immutable release assets do not exactly match the validated upload set"
+    verify_remote_tag_pin post-publication
     msg "Published immutable release assets exactly match local names and SHA256 digests"
     msg "Published immutable release: $RELEASE_URL"
 else

--- a/doc/release/release-process.md
+++ b/doc/release/release-process.md
@@ -61,7 +61,9 @@ coordinator-held artifacts; GitHub Actions does not publish releases.
 
 The publisher validates:
 
-- the release tag is a signed annotated tag that GitHub verifies
+- the release tag ref resolves to the exact locally pinned annotated-tag object,
+  that object directly targets the pinned commit, and GitHub reports its
+  signature verification as exactly `verified=true` and `reason=valid`
 - the tag signer is accepted by the qbit release key policy
 - `trusted_release_ref` is a full public commit SHA and is not the tag object or
   tag target commit, and the tag target is its ancestor
@@ -79,6 +81,8 @@ The publisher validates:
   the validator-approved upload set before publication
 - the final published release is immutable, and its locked asset names and
   GitHub-computed SHA256 digests still exactly match the validated upload set
+- the immutable release locked the same signed tag object and target checked
+  before validation and immediately before publication
 
 Testnet posture evidence is mandatory for `release_line=testnet`; the publisher
 fails closed when `--testnet-posture-evidence` is missing.
@@ -191,27 +195,36 @@ the publisher never uses replacement uploads and never modifies an existing
 published release.
 
 Release notes follow the same policy for new and resumed drafts. When
-`--notes-file` is provided, its exact UTF-8 contents are authoritative. When it
-is omitted, the publisher obtains a body from GitHub's generate-release-notes
-API and uses that body as the authoritative notes for the invocation. The
-publisher replaces any existing draft body, fetches it back, and requires an
-exact match before publication. A draft body that cannot be corrected and
-verified remains unpublished. Manual changes to a resumed draft are therefore
-not preserved; record curated notes in a file and pass `--notes-file`.
+`--notes-file` is provided, the publisher validates its UTF-8 encoding and
+snapshots its exact bytes into the invocation work directory before the
+long-running validators execute. Later changes to the source file cannot alter
+the release body. When the option is omitted, the publisher obtains a body from
+GitHub's generate-release-notes API and snapshots that generated body for the
+invocation. The publisher replaces any existing draft body, fetches it back,
+and requires an exact match before publication. A draft body that cannot be
+corrected and verified remains unpublished. Manual changes to a resumed draft
+are therefore not preserved; record curated notes in a file and pass
+`--notes-file`.
 
-New drafts default to non-prerelease and `make-latest=false`. When resuming a
-draft, omitted metadata options preserve its existing prerelease and latest
-state. Use `--prerelease` or `--no-prerelease` and an explicit `--make-latest`
-mode to change those values during a resumed operation.
+New drafts default to the title `qbit <TAG>`, non-prerelease, and
+`make-latest=false`. When resuming a draft, omitting `--release-name` preserves
+its current title, and omitted prerelease and latest options preserve their
+current state. Use `--release-name`, `--prerelease` or `--no-prerelease`, and an
+explicit `--make-latest` mode to change those values. `--make-latest auto` maps
+to GitHub's `make_latest=legacy` behavior, which selects the latest release by
+creation date and semantic version rather than preserving the prior setting.
 
 Draft releases are expected to remain mutable while their assets are assembled.
 The publisher does not require `isImmutable=true` until `--publish` transitions
-the draft to a published release. It then polls the final release metadata for a
-bounded period and fails unless GitHub reports both `isDraft=false` and
-`isImmutable=true`, then polls the locked asset inventory and digests for a
-bounded period to tolerate GitHub API propagation. Validation-only mode likewise
-rejects an existing published release that is not immutable or whose immutable
-state is missing. Release discovery uses a fully paginated listing so matching
+the draft to a published release. The exact remote tag ref, annotated-tag object,
+commit target, and GitHub signature verification are checked before validation
+and again immediately before that transition. The publisher then polls the
+final release metadata for a bounded period and fails unless GitHub reports both
+`isDraft=false` and `isImmutable=true`, polls the locked asset inventory and
+digests for API propagation, and performs the exact tag check a final time before
+reporting success. Validation-only mode likewise rejects an existing published
+release that is not immutable, whose immutable state is missing, or whose final
+tag pin differs. Release discovery uses a fully paginated listing so matching
 drafts remain resumable. A release is considered absent only after that listing
 succeeds without a matching tag; authentication, API, and other lookup failures
 stop validation rather than skipping the remote release checks.
@@ -223,6 +236,21 @@ release immutable. When `--repo OWNER/REPO` overrides the default repository,
 that target repository must independently satisfy the same policy. A publisher
 failure after a mutable publication requires manual release remediation; rerunning
 the publisher does not retrofit immutability or modify the published release.
+
+### Immutable-publication recovery
+
+A final tag-pin failure can occur after GitHub has already made the release
+immutable. The publisher exits unsuccessfully and identifies the expected and
+observed tag values; it cannot roll the publication back. Stop distributing the
+release and preserve the complete publisher transcript, release URL and ID,
+expected and observed tag object and target, and repository audit evidence. Do
+not rerun the publisher expecting it to repair or replace the immutable release.
+
+Handle the event through the release-integrity incident process. If policy calls
+for removing the incorrect immutable release, remember that GitHub does not
+allow its tag name to be reused afterward. Prepare a new version, create and
+sign a new annotated tag, repeat the complete validation and publication flow,
+and publish a correction notice that identifies the superseded release.
 
 Unsigned platform or public codesigning payload waivers require the explicit
 `--allow-unsigned-platform-artifacts` or `--allow-codesigning-artifacts` flags.


### PR DESCRIPTION
## Summary

- re-pin the exact GitHub-verified annotated tag object and commit target immediately before publication and again after immutable-state and asset polling
- preserve omitted resumed-draft titles, snapshot explicit release notes before long-running validation, and map `--make-latest auto` to GitHub's `make_latest=legacy` behavior
- extend the fake GitHub API for tag-move, signature, title, notes-snapshot, and latest-mode regressions, and document immutable-publication recovery

Fixes #126.

## Testing

- [ ] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [x] Not run. Reason: No C++ product build was run because this changes release tooling, behavioral tests, and release-process documentation only.

Focused and expanded validation:

```sh
GIT_CONFIG_GLOBAL=/dev/null python3 -m unittest \
  ci.release.test_publish_local_release \
  ci.release.test_validate_builder_attestations \
  ci.release.test_validate_key_metadata \
  ci.release.test_validate_release_artifacts \
  ci.release.test_verify_testnet_release_posture

(cd ci/checks && GIT_CONFIG_GLOBAL=/dev/null python3 -m unittest test_classify_merge_profile)

bash -n contrib/release-process/publish-local-release.sh
python3 -m py_compile \
  ci/release/test_publish_local_release.py \
  ci/release/test_validate_release_artifacts.py
git diff --check origin/1.0.0...HEAD
```

The expanded release suite passed all 162 tests, the merge-profile suite passed all 23 tests, and the final focused publisher/boundary suite passed all 33 tests. The complete Docker lint suite passed using `ci/lint_imagefile` and `ci/lint/06_script.sh`, including Ruff, ShellCheck, documentation, and subtree checks.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.0.0`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- This changes the security-critical release publication state machine but does not change node consensus behavior.
- Publication now fails before `draft=false` if the remote tag ref, annotated-tag object, commit target, or exact GitHub signature status differs from the locally pinned values.
- A final mismatch after GitHub reports the release immutable fails closed with incident-recovery guidance because the publication may already be locked.
- Draft metadata is finalized before publication; the final REST update carries only `draft=false` and the explicit latest-release policy.
- New releases still default to `make_latest=false`, resumed drafts still preserve an omitted latest policy, and explicit `auto` is sent as GitHub's `legacy` value.

## Docs / Process Impact

Choose exactly one:

- [x] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [ ] No public docs update needed. Reason:

The release-process guide now documents the repeated exact tag pin, metadata behavior, notes snapshot, and recovery steps when final verification fails after immutable publication.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; the subtree was not changed.

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786631551&installation_id=141183937&pr_number=130&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F130&signature=b437cb29de8514caa76fac2448c428db877397618ebeee4f73400540bccd46ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the security-critical local release publication state machine: publication aborts on remote tag/signature drift, and a post-immutable mismatch can leave a locked release requiring manual incident recovery.
> 
> **Overview**
> Hardens **`publish-local-release.sh`** so publication only proceeds when GitHub still reports the **same annotated tag object, commit target, and `verified=true` / `reason=valid`** signature status as the local pin—checked at startup, **immediately before** `draft=false`, and again after immutable/asset polling. Tag drift or signature changes **before** publish leave the release a draft; a mismatch **after** immutability fails closed with **immutable-publication recovery** guidance.
> 
> **Metadata and notes:** explicit `--notes-file` content is **UTF-8 snapshotted** into the workdir before long validators (so later file edits cannot change the body). Resumed drafts **keep title/prerelease/latest** unless overridden; publish uses **`gh api` PATCH** (`draft=false`, explicit `make_latest`, with **`auto` → `legacy`**). Draft edits no longer force title/latest on publish.
> 
> **Tests/docs:** the fake `gh` harness simulates tag moves, verification sequences, PATCH publish, titles, and post-snapshot note mutation; **`release-process.md`** documents the repeated pin, snapshot behavior, and recovery when verification fails after an immutable release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb64ece4c2cac7d2e35147cd6006fdbc713a845b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->