### PR TITLE
fix: resolve finalized mainnet CI failures

### DIFF
--- a/.github/workflows/core-checks.yml
+++ b/.github/workflows/core-checks.yml
@@ -231,6 +231,7 @@ jobs:
           suites=(
             pqc_tests
             asert_tests
+            auxpow_tests
             pow_tests
             subsidy_tests
             script_p2mr_tests

--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -64,7 +64,12 @@ HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus
     // could try again, if necessary, to sync a longer chain).
     // Header sync must admit histories produced under the legacy two-hour
     // future-time rule, even when the v2 rule is active at the current tip.
-    m_max_commitments = 6*(Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start->GetMedianTimePast()}}) + MAX_FUTURE_BLOCK_TIME_LEGACY) / HEADER_COMMITMENT_PERIOD;
+    const int64_t commitment_time{
+        Ticks<std::chrono::seconds>(NodeClock::now() - NodeSeconds{std::chrono::seconds{chain_start->GetMedianTimePast()}}) +
+        MAX_FUTURE_BLOCK_TIME_LEGACY};
+    if (commitment_time > 0) {
+        m_max_commitments = 6 * static_cast<uint64_t>(commitment_time) / HEADER_COMMITMENT_PERIOD;
+    }
     m_presync_difficulty = MakeHeaderDifficultyState();
     m_redownload_difficulty = MakeHeaderDifficultyState();
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -348,6 +348,11 @@ void BitcoinApplication::requestShutdown()
     // Request node shutdown, which can interrupt long operations, like
     // rescanning a wallet.
     node().startShutdown();
+#ifdef ENABLE_WALLET
+    // Request cancellation for every wallet send worker before teardown can
+    // block on a worker owned by a later wallet view.
+    window->prepareWalletsForShutdown();
+#endif // ENABLE_WALLET
     // Prior to unsetting the client model, stop listening backend signals
     if (clientModel) {
         clientModel->stop();
@@ -361,7 +366,8 @@ void BitcoinApplication::requestShutdown()
 #ifdef ENABLE_WALLET
     // Wallet views own background send workers and temporary unlock contexts
     // which reference WalletModel objects parented to the wallet controller.
-    // Destroy the views and join their workers before deleting those models.
+    // Destroy the views and join the already-cancelled workers before deleting
+    // those models.
     window->removeAllWallets();
 
     // Delete wallet controller here manually, instead of relying on Qt object

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -844,6 +844,11 @@ void BitcoinGUI::setCurrentWalletBySelectorIndex(int index)
     if (wallet_model) setCurrentWallet(wallet_model);
 }
 
+void BitcoinGUI::prepareWalletsForShutdown()
+{
+    if (walletFrame) walletFrame->prepareForShutdown();
+}
+
 void BitcoinGUI::removeAllWallets()
 {
     if (!walletFrame) return;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -90,6 +90,7 @@ public:
     */
     void addWallet(WalletModel* walletModel);
     void removeWallet(WalletModel* walletModel);
+    void prepareWalletsForShutdown();
     void removeAllWallets();
 #endif // ENABLE_WALLET
     bool enableWallet = false;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -358,8 +358,7 @@ void SendCoinsDialog::setModel(WalletModel *_model)
 
 SendCoinsDialog::~SendCoinsDialog()
 {
-    m_prepare_cancel_requested = true;
-    clearPrepareProgressDialog();
+    prepareForShutdown();
     if (m_prepare_thread) {
         QThread* thread = m_prepare_thread;
         m_prepare_thread = nullptr;
@@ -376,6 +375,12 @@ SendCoinsDialog::~SendCoinsDialog()
     settings.setValue("nTransactionFee", (qint64)ui->customFee->value());
 
     delete ui;
+}
+
+void SendCoinsDialog::prepareForShutdown()
+{
+    m_prepare_cancel_requested = true;
+    clearPrepareProgressDialog();
 }
 
 bool SendCoinsDialog::PrepareSendText(QString& question_string, QString& informative_text, QString& detailed_text)

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -61,6 +61,7 @@ public:
     void setAddress(const QString &address);
     void pasteEntry(const SendCoinsRecipient &rv);
     bool handlePaymentRequest(const SendCoinsRecipient &recipient);
+    void prepareForShutdown();
 
     // Only used for testing-purposes
     wallet::CCoinControl* getCoinControl() { return m_coin_control.get(); }

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -211,18 +211,29 @@ void AppTests::appTests()
         QVERIFY(!widget->inherits("SendConfirmationDialog"));
     }
 #endif // ENABLE_WALLET
+}
 
+void AppTests::cleanup()
+{
 #ifdef ENABLE_WALLET
-    // WalletLoader::createWallet persists startup entries. Remove test-only
-    // entries so later options tests see their original settings fixture.
-    gArgs.LockSettings([](common::Settings& settings) {
-        settings.rw_settings.erase("wallet");
-    });
-    QVERIFY(gArgs.WriteSettingsFile());
+    bool settings_written{true};
+    if (m_remove_test_wallet_settings) {
+        // WalletLoader::createWallet persists startup entries. Remove
+        // test-only entries so later options tests see their original fixture.
+        gArgs.LockSettings([](common::Settings& settings) {
+            settings.rw_settings.erase("wallet");
+        });
+        settings_written = gArgs.WriteSettingsFile();
+        m_remove_test_wallet_settings = false;
+    }
 #endif // ENABLE_WALLET
 
-    // Reset global state to avoid interfering with later tests.
+    // Reset global state even when a QVERIFY returns early from appTests().
     LogInstance().DisconnectTestLogger();
+
+#ifdef ENABLE_WALLET
+    QVERIFY(settings_written);
+#endif // ENABLE_WALLET
 }
 
 //! Entry point for BitcoinGUI tests.
@@ -234,6 +245,7 @@ void AppTests::guiTests(BitcoinGUI* window)
     WalletController* const controller{window->getWalletController()};
     QVERIFY(controller);
 
+    m_remove_test_wallet_settings = true;
     for (const std::string name : {"qt-shutdown-lifetime-1", "qt-shutdown-lifetime-2"}) {
         QSignalSpy wallet_added_spy(controller, &WalletController::walletAdded);
         QVERIFY(wallet_added_spy.isValid());

--- a/src/qt/test/apptests.h
+++ b/src/qt/test/apptests.h
@@ -32,6 +32,7 @@ public:
 
 private Q_SLOTS:
     void appTests();
+    void cleanup();
     void guiTests(BitcoinGUI* window);
     void consoleTests(RPCConsole* console);
 
@@ -63,6 +64,7 @@ private:
     int64_t m_shutdown_elapsed_ms{-1};
     int m_shutdown_coins_sent{0};
     bool m_wallet_dependents_destroyed_before_model{false};
+    bool m_remove_test_wallet_settings{false};
 };
 
 #endif // QBIT_QT_TEST_APPTESTS_H

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -4,6 +4,7 @@
 
 #include <qt/test/rpcnestedtests.h>
 
+#include <chainparams.h>
 #include <common/system.h>
 #include <interfaces/node.h>
 #include <qt/rpcconsole.h>
@@ -82,7 +83,7 @@ void RPCNestedTests::rpcNestedTests()
     QVERIFY(result == result2);
 
     RPCConsole::RPCExecuteCommandLine(m_node, result, "getblock(getbestblockhash())[tx][0]", &filtered);
-    QVERIFY(result == "773941c57f540b7e0f841db6de90bf4f29d305d8233224c2581025c684387313");
+    QVERIFY(result == Params().GenesisBlock().vtx[0]->GetHash().GetHex());
     QVERIFY(filtered == "getblock(getbestblockhash())[tx][0]");
 
     RPCConsole::RPCParseCommandLine(nullptr, result, "signmessagewithprivkey abc", false, &filtered);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -57,6 +57,13 @@ WalletFrame::WalletFrame(const PlatformStyle* _platformStyle, QWidget* parent)
 
 WalletFrame::~WalletFrame() = default;
 
+void WalletFrame::prepareForShutdown()
+{
+    for (WalletView* wallet_view : mapWalletViews) {
+        wallet_view->prepareForShutdown();
+    }
+}
+
 void WalletFrame::setClientModel(ClientModel *_clientModel)
 {
     this->clientModel = _clientModel;

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -38,6 +38,7 @@ public:
 
     bool addView(WalletView* walletView);
     void setCurrentWallet(WalletModel* wallet_model);
+    void prepareForShutdown();
     void removeWallet(WalletModel* wallet_model);
     QList<WalletModel*> getWalletModels() const;
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -113,6 +113,11 @@ WalletView::WalletView(WalletModel* wallet_model, const PlatformStyle* _platform
 
 WalletView::~WalletView() = default;
 
+void WalletView::prepareForShutdown()
+{
+    sendCoinsPage->prepareForShutdown();
+}
+
 void WalletView::setClientModel(ClientModel *_clientModel)
 {
     this->clientModel = _clientModel;

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -44,6 +44,7 @@ public:
     */
     void setClientModel(ClientModel *clientModel);
     WalletModel* getWalletModel() const noexcept { return walletModel; }
+    void prepareForShutdown();
 
     bool handlePaymentRequest(const SendCoinsRecipient& recipient);
 

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -397,13 +397,13 @@ BOOST_AUTO_TEST_CASE(auxpow_expected_index_vectors_document_qbit_slot_math)
     // used by Namecoin, so these vectors pin qbit's slot assignment.
     BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(/*nonce=*/0, /*chain_id=*/1, /*merkle_height=*/0), 0);
     BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(/*nonce=*/0, /*chain_id=*/1, /*merkle_height=*/1), 1);
-    BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(/*nonce=*/0, consensus.nAuxpowChainId, /*merkle_height=*/4), 12);
-    BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(/*nonce=*/0x12345678, consensus.nAuxpowChainId, /*merkle_height=*/4), 4);
-    BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(/*nonce=*/0, consensus.nAuxpowChainId, /*merkle_height=*/32), 882684108);
+    BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(/*nonce=*/0, consensus.nAuxpowChainId, /*merkle_height=*/4), 1);
+    BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(/*nonce=*/0x12345678, consensus.nAuxpowChainId, /*merkle_height=*/4), 9);
+    BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(/*nonce=*/0, consensus.nAuxpowChainId, /*merkle_height=*/32), -414942079);
     BOOST_CHECK_EQUAL(auxpow::GetExpectedIndex(std::numeric_limits<uint32_t>::max(),
                                                consensus.nAuxpowChainId,
                                                auxpow::MAX_CHAIN_MERKLE_BRANCH_LENGTH),
-                      838473315);
+                      614588952);
 }
 
 BOOST_AUTO_TEST_CASE(auxpow_merkle_branch_respects_left_and_right_positions)

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/params.h>
 #include <headerssync.h>
 #include <net.h>
+#include <net_processing.h>
 #include <pow.h>
 #include <primitives/pureheader.h>
 #include <serialize.h>
@@ -312,15 +313,26 @@ BOOST_AUTO_TEST_CASE(headers_sync_state)
 
 BOOST_AUTO_TEST_CASE(headers_sync_future_chain_start_does_not_wrap_commitment_limit)
 {
-    const auto chain_params = CreateChainParams(*m_node.args, ChainType::MAIN);
-    const auto& consensus = chain_params->GetConsensus();
-    CBlockIndex genesis{chain_params->GenesisBlock()};
-    const uint256 genesis_hash{chain_params->GenesisBlock().GetHash()};
-    FinalizeIndex(genesis, genesis_hash, /*pprev=*/nullptr, /*height=*/0, /*auxpow_count=*/0, GetBlockProof(genesis));
+    const CBlockIndex* chain_start = WITH_LOCK(::cs_main, return m_node.chainman->m_blockman.LookupBlockIndex(Params().GenesisBlock().GetHash()));
+    BOOST_REQUIRE(chain_start);
 
-    const ScopedMockTime mock_time{std::chrono::seconds{genesis.GetMedianTimePast() - MAX_FUTURE_BLOCK_TIME_LEGACY - 1}};
-    HeadersSyncState hss{/*id=*/0, consensus, &genesis, genesis.nChainWork};
-    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::PRESYNC);
+    std::vector<CBlockHeader> headers;
+    GenerateHeaders(headers,
+                    MAX_HEADERS_RESULTS,
+                    chain_start->GetBlockHash(),
+                    chain_start->nVersion,
+                    chain_start->GetBlockTime(),
+                    ArithToUint256(0),
+                    chain_start->nBits);
+
+    // Make the signed commitment window negative enough that the old formula
+    // produced a negative quotient before converting it to uint64_t. A full
+    // headers batch is guaranteed to encounter a stored commitment, so a zero
+    // limit must abort presync instead of admitting an effectively unbounded
+    // number of commitments.
+    const ScopedMockTime mock_time{std::chrono::seconds{
+        chain_start->GetMedianTimePast() - MAX_FUTURE_BLOCK_TIME_LEGACY - MAX_HEADERS_RESULTS}};
+    AssertHeadersSyncRejects(Params().GetConsensus(), *chain_start, headers);
 }
 
 BOOST_AUTO_TEST_CASE(headers_sync_accepts_genesis_to_permissionless_anchor_jumps)

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -12,6 +12,7 @@
 #include <serialize.h>
 #include <test/util/setup_common.h>
 #include <util/chaintype.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <deque>
@@ -290,6 +291,19 @@ BOOST_AUTO_TEST_CASE(headers_sync_state)
     BOOST_CHECK(result.success);
 }
 
+BOOST_AUTO_TEST_CASE(headers_sync_future_chain_start_does_not_wrap_commitment_limit)
+{
+    const auto chain_params = CreateChainParams(*m_node.args, ChainType::MAIN);
+    const auto& consensus = chain_params->GetConsensus();
+    CBlockIndex genesis{chain_params->GenesisBlock()};
+    const uint256 genesis_hash{chain_params->GenesisBlock().GetHash()};
+    FinalizeIndex(genesis, genesis_hash, /*pprev=*/nullptr, /*height=*/0, /*auxpow_count=*/0, GetBlockProof(genesis));
+
+    SetMockTime(genesis.GetMedianTimePast() - MAX_FUTURE_BLOCK_TIME_LEGACY - 1);
+    HeadersSyncState hss{/*id=*/0, consensus, &genesis, genesis.nChainWork};
+    BOOST_CHECK(hss.GetState() == HeadersSyncState::State::PRESYNC);
+}
+
 BOOST_AUTO_TEST_CASE(headers_sync_accepts_genesis_to_permissionless_anchor_jumps)
 {
     // These shipped networks fail on current develop because presync compares
@@ -395,6 +409,7 @@ BOOST_AUTO_TEST_CASE(headers_sync_uses_cached_starved_lane_history)
                                           chain.back().nTime + 1,
                                           /*n_bits=*/0);
         resumed.nBits = GetNextWorkRequired(&chain.back(), &resumed, consensus);
+        SetMockTime(chain.back().GetMedianTimePast() + 1);
         AssertHeadersSyncAccepts(consensus, chain.back(), {resumed});
     }
 }

--- a/src/test/headers_sync_chainwork_tests.cpp
+++ b/src/test/headers_sync_chainwork_tests.cpp
@@ -20,6 +20,25 @@
 
 #include <boost/test/unit_test.hpp>
 
+namespace {
+class ScopedMockTime
+{
+public:
+    explicit ScopedMockTime(std::chrono::seconds mock_time) : m_previous{GetMockTime()}
+    {
+        SetMockTime(mock_time);
+    }
+
+    ~ScopedMockTime()
+    {
+        SetMockTime(m_previous);
+    }
+
+private:
+    const std::chrono::seconds m_previous;
+};
+} // namespace
+
 struct HeadersGeneratorSetup : public RegTestingSetup {
     /** Search for a nonce to meet (regtest) proof of work */
     void FindProofOfWork(CBlockHeader& starting_header);
@@ -299,7 +318,7 @@ BOOST_AUTO_TEST_CASE(headers_sync_future_chain_start_does_not_wrap_commitment_li
     const uint256 genesis_hash{chain_params->GenesisBlock().GetHash()};
     FinalizeIndex(genesis, genesis_hash, /*pprev=*/nullptr, /*height=*/0, /*auxpow_count=*/0, GetBlockProof(genesis));
 
-    SetMockTime(genesis.GetMedianTimePast() - MAX_FUTURE_BLOCK_TIME_LEGACY - 1);
+    const ScopedMockTime mock_time{std::chrono::seconds{genesis.GetMedianTimePast() - MAX_FUTURE_BLOCK_TIME_LEGACY - 1}};
     HeadersSyncState hss{/*id=*/0, consensus, &genesis, genesis.nChainWork};
     BOOST_CHECK(hss.GetState() == HeadersSyncState::State::PRESYNC);
 }
@@ -409,7 +428,7 @@ BOOST_AUTO_TEST_CASE(headers_sync_uses_cached_starved_lane_history)
                                           chain.back().nTime + 1,
                                           /*n_bits=*/0);
         resumed.nBits = GetNextWorkRequired(&chain.back(), &resumed, consensus);
-        SetMockTime(chain.back().GetMedianTimePast() + 1);
+        const ScopedMockTime mock_time{std::chrono::seconds{chain.back().GetMedianTimePast() + 1}};
         AssertHeadersSyncAccepts(consensus, chain.back(), {resumed});
     }
 }


### PR DESCRIPTION
## Summary

- Refresh the AuxPoW slot-index vectors for finalized mainnet chain ID 47, derive the nested RPC genesis transaction hash from selected chain parameters, and keep these expectations in focused CI.
- Cancel every active Qt wallet send worker before wallet-view teardown, then join already-cancelled workers during destruction.
- Move AppTests settings and logger restoration into failure-safe QtTest cleanup so an early assertion cannot contaminate later tests.
- Clamp negative header-sync commitment windows before unsigned conversion and make future-chain test clocks deterministic.

## Root Cause

The finalized mainnet parameters exposed stale AuxPoW and RPC test expectations. Separately, wallet views were destroyed in a single pass, so a send worker in a later view could remain blocked until the test watchdog fired. The resulting early Qt assertion skipped settings and logger cleanup, which cascaded into OptionTests and RPCNestedTests failures. The header-sync test also constructed a chain ahead of wall time, causing a negative signed commitment window to convert to an enormous unsigned value under UBSan.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands run:

- `ninja -C .context/build-ci-fix test_qbit test_qbit-qt`
- `ulimit -n 1024 && .context/build-ci-fix/bin/test_qbit --run_test=auxpow_tests`
- `ulimit -n 1024 && .context/build-ci-fix/bin/test_qbit --run_test=headers_sync_chainwork_tests`
- `ulimit -n 1024 && QT_QPA_PLATFORM=cocoa .context/build-ci-fix/bin/test_qbit-qt`
- `DOCKER_BUILDKIT=1 docker build -t qbit-ci-lint-local --file ./ci/lint_imagefile ./`
- `docker run --rm ... qbit-ci-lint-local` with the worktree and Git metadata mounted into the container
- `git diff --check`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.x.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: Wallet shutdown ordering and the P2P header-sync memory bound change. Consensus validation rules do not change. Future chain anchors now receive a zero commitment allowance instead of wrapping to an effectively unbounded value.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: the changes repair shutdown behavior, defensive bounds, tests, and CI without changing documented user workflows.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Header-sync memory bounding and Qt shutdown ordering affect P2P presync and wallet GUI teardown; consensus rules are unchanged but behavior at edge cases (future MTP, multi-wallet shutdown) changes.
> 
> **Overview**
> Fixes **finalized mainnet CI** by aligning **AuxPoW** slot-index expectations with qbit’s slot math, deriving the nested RPC genesis tx hash from **chain params**, and running **`auxpow_tests`** in focused CI.
> 
> **Qt shutdown:** Cancels in-flight **send prepare** workers across all wallet views via **`prepareWalletsForShutdown()`** before teardown, then joins those workers during destruction so shutdown does not block on a later wallet’s background thread.
> 
> **P2P headers sync:** **`m_max_commitments`** is only computed when the commitment time window is positive, avoiding a negative signed value wrapping to a huge unsigned cap under UBSan; tests use **mock time** and add coverage for “future” chain starts.
> 
> **Qt tests:** **`AppTests::cleanup()`** restores settings and logging even when **`appTests()`** fails early, preventing follow-on test pollution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f69bdd52a1093133de2e727f919db8bc1cf9f80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->