### PR TITLE
wallet: avoid deferred keypool unlock deadlock

### DIFF
--- a/src/qt/test/syntheticwallet.cpp
+++ b/src/qt/test/syntheticwallet.cpp
@@ -229,7 +229,20 @@ public:
     std::unique_ptr<interfaces::Handler> handleStatusChanged(StatusChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
     std::unique_ptr<interfaces::Handler> handleAddressBookChanged(AddressBookChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
     std::unique_ptr<interfaces::Handler> handleTransactionChanged(TransactionChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
-    std::unique_ptr<interfaces::Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn) override { return interfaces::MakeCleanupHandler([] {}); }
+    std::unique_ptr<interfaces::Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn fn) override
+    {
+        {
+            std::lock_guard lock{m_state->mutex};
+            m_state->can_get_addresses_changed = std::move(fn);
+        }
+        std::weak_ptr<SyntheticWalletState> weak_state{m_state};
+        return interfaces::MakeCleanupHandler([weak_state] {
+            if (auto state = weak_state.lock()) {
+                std::lock_guard lock{state->mutex};
+                state->can_get_addresses_changed = {};
+            }
+        });
+    }
 
 private:
     wallet::PQCUsageReport m_report;

--- a/src/qt/test/syntheticwallet.h
+++ b/src/qt/test/syntheticwallet.h
@@ -9,6 +9,7 @@
 #include <wallet/pqc_usage.h>
 
 #include <condition_variable>
+#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -29,6 +30,7 @@ struct SyntheticWalletState {
     bool locked{false};
     int lock_calls{0};
     int unlock_calls{0};
+    std::function<void()> can_get_addresses_changed;
 };
 
 std::unique_ptr<interfaces::Wallet> MakeSyntheticWallet(

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -1598,6 +1598,40 @@ void TestUnlockContextModelLifetime(interfaces::Node& node)
     QCOMPARE(lock_calls(), 1);
 }
 
+void TestCanGetAddressesNotificationIsQueued(interfaces::Node& node)
+{
+    TestChain100Setup test{ChainType::REGTEST, {.extra_args = {"-p2mronly=0"}}};
+    node.setContext(&test.m_node);
+
+    std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    OptionsModel options_model{node};
+    bilingual_str error;
+    QVERIFY(options_model.Init(error));
+    ClientModel client_model{node, &options_model};
+
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    WalletModel wallet_model{
+        qt_test::MakeSyntheticWallet(wallet::PQCUsageReport{}, state),
+        client_model,
+        platform_style.get()};
+    QSignalSpy notification_spy{&wallet_model, &WalletModel::canGetAddressesChanged};
+    QVERIFY(notification_spy.isValid());
+
+    std::function<void()> notify;
+    {
+        std::lock_guard lock{state->mutex};
+        notify = state->can_get_addresses_changed;
+    }
+    QVERIFY(notify);
+
+    notify();
+    QCOMPARE(notification_spy.count(), 0);
+
+    QCoreApplication::sendPostedEvents(&wallet_model, QEvent::MetaCall);
+    QCoreApplication::processEvents();
+    QCOMPARE(notification_spy.count(), 1);
+}
+
 void TestSendPQCWarningFormatting()
 {
     CPQCKey key;
@@ -1669,5 +1703,6 @@ void WalletTests::walletTests()
     TestSendPQCReportPropagation(m_node);
     TestSendCompletionAfterModelDestruction(m_node);
     TestUnlockContextModelLifetime(m_node);
+    TestCanGetAddressesNotificationIsQueued(m_node);
     TestSendPQCWarningFormatting();
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -503,7 +503,7 @@ static void ShowProgress(WalletModel *walletmodel, const std::string &title, int
 
 static void NotifyCanGetAddressesChanged(WalletModel* walletmodel)
 {
-    bool invoked = QMetaObject::invokeMethod(walletmodel, "canGetAddressesChanged");
+    bool invoked = QMetaObject::invokeMethod(walletmodel, "canGetAddressesChanged", Qt::QueuedConnection);
     assert(invoked);
 }
 

--- a/src/wallet/context.h
+++ b/src/wallet/context.h
@@ -56,6 +56,10 @@ struct WalletContext {
     // creation starts and keep unchanged until creation has completed.
     CreateWalletStageFn create_wallet_stage_fn;
 
+    // Optional deterministic scheduler hook for tests. Copied into deferred
+    // keypool workers when they are scheduled.
+    std::function<void()> deferred_keypool_top_up_step_finished_fn;
+
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the WalletContext struct doesn't need to #include class
     //! definitions for smart pointer and container members.

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -23,19 +23,21 @@ using common::PSBTError;
 namespace wallet {
 bool ExternalSignerScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, std::unique_ptr<Descriptor> desc)
 {
-    LOCK(cs_desc_man);
-    assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-    assert(m_storage.IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
+    {
+        LOCK(cs_desc_man);
+        assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
+        assert(m_storage.IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
 
-    int64_t creation_time = GetTime();
+        int64_t creation_time = GetTime();
 
-    // Make the descriptor
-    WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
-    m_wallet_descriptor = w_desc;
+        // Make the descriptor
+        WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
+        m_wallet_descriptor = w_desc;
 
-    // Store the descriptor
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+        // Store the descriptor
+        if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+            throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+        }
     }
 
     // TopUp

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -160,7 +160,14 @@ public:
     }
     bool isCrypted() override { return m_wallet->IsCrypted(); }
     bool lock() override { return m_wallet->Lock(); }
-    bool unlock(const SecureString& wallet_passphrase) override { return m_wallet->Unlock(wallet_passphrase); }
+    bool unlock(const SecureString& wallet_passphrase) override
+    {
+        if (!m_wallet->Unlock(wallet_passphrase, /*run_pending_initial_keypool_top_up=*/false)) {
+            return false;
+        }
+        MaybeSchedulePendingInitialKeyPoolTopUp(m_context, m_wallet);
+        return true;
+    }
     bool isLocked() override { return m_wallet->IsLocked(); }
     bool changeWalletPassphrase(const SecureString& old_wallet_passphrase,
         const SecureString& new_wallet_passphrase) override

--- a/src/wallet/pqc_usage.cpp
+++ b/src/wallet/pqc_usage.cpp
@@ -247,6 +247,7 @@ PQCUsageReport BuildSigningPQCUsageReport(const PQCUsageRecorder& recorder)
 
 PQCUsageReport BuildGetAddressInfoPQCUsageReport(const CWallet& wallet, const CScript& script_pubkey)
 {
+    LOCK(wallet.cs_wallet);
     PQCUsageReport report;
     CTxDestination destination;
     if (!ExtractDestination(script_pubkey, destination)) {

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -943,17 +943,16 @@ bool LegacyDataSPKM::DeleteRecordsWithDB(WalletBatch& batch)
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
     bool notify_can_get_addresses_changed{false};
+    std::set<CScript> committed_spks;
     util::Result<CTxDestination> result{[&] {
         LOCK(cs_desc_man);
-        return GetNewDestinationNoNotify(type, /*index=*/nullptr, notify_can_get_addresses_changed);
+        return GetNewDestinationNoNotify(type, /*index=*/nullptr, notify_can_get_addresses_changed, committed_spks);
     }()};
-    if (notify_can_get_addresses_changed) {
-        NotifyCanGetAddressesChanged();
-    }
+    PublishTopUp(committed_spks, notify_can_get_addresses_changed);
     return result;
 }
 
-util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestinationNoNotify(const OutputType type, int64_t* index, bool& notify_can_get_addresses_changed)
+util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestinationNoNotify(const OutputType type, int64_t* index, bool& notify_can_get_addresses_changed, std::set<CScript>& committed_spks)
 {
     AssertLockHeld(cs_desc_man);
     // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later
@@ -969,7 +968,7 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestinationNoNotif
     }
 
     if (!m_deferred_create_keypool_top_up && !IsRangedP2MRDescriptorNoLock()) {
-        if (TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/0)) {
+        if (TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/0, committed_spks)) {
             notify_can_get_addresses_changed = true;
         }
     }
@@ -978,7 +977,7 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestinationNoNotif
     FlatSigningProvider out_keys;
     std::vector<CScript> scripts_temp;
     if (m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end) {
-        auto top_up{TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/1)};
+        auto top_up{TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/1, committed_spks)};
         if (!top_up) {
             // We can't generate anymore keys
             return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
@@ -1108,16 +1107,15 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetReservedDestination(const OutputType type, bool internal, int64_t& index, bool allow_internal_p2mr_refill)
 {
     bool notify_can_get_addresses_changed{false};
+    std::set<CScript> committed_spks;
     util::Result<CTxDestination> result{[&] {
         LOCK(cs_desc_man);
-        if (internal && allow_internal_p2mr_refill && MaybeTopUpInternalP2MRKeyPoolNoNotify()) {
+        if (internal && allow_internal_p2mr_refill && MaybeTopUpInternalP2MRKeyPoolNoNotify(committed_spks)) {
             notify_can_get_addresses_changed = true;
         }
-        return GetNewDestinationNoNotify(type, &index, notify_can_get_addresses_changed);
+        return GetNewDestinationNoNotify(type, &index, notify_can_get_addresses_changed, committed_spks);
     }()};
-    if (notify_can_get_addresses_changed) {
-        NotifyCanGetAddressesChanged();
-    }
+    PublishTopUp(committed_spks, notify_can_get_addresses_changed);
     return result;
 }
 
@@ -1238,16 +1236,27 @@ DescriptorScriptPubKeyMan::TopUpPreparation DescriptorScriptPubKeyMan::PrepareTo
 util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResult(std::optional<bool> internal_hint, unsigned int size)
 {
     AssertLockNotHeld(cs_desc_man);
-    auto result{TopUpWithInternalHintResultNoNotify(internal_hint, size)};
-    if (result) {
-        NotifyCanGetAddressesChanged();
-    }
+    std::set<CScript> committed_spks;
+    auto result{TopUpWithInternalHintResultNoNotify(internal_hint, size, committed_spks)};
+    PublishTopUp(committed_spks, result.has_value());
     return result;
 }
 
-util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResultNoNotify(std::optional<bool> internal_hint, unsigned int size)
+void DescriptorScriptPubKeyMan::PublishTopUp(const std::set<CScript>& new_spks, bool notify_can_get_addresses_changed)
+{
+    AssertLockNotHeld(cs_desc_man);
+    if (!new_spks.empty()) {
+        m_storage.TopUpCallback(new_spks, this);
+    }
+    if (notify_can_get_addresses_changed) {
+        NotifyCanGetAddressesChanged();
+    }
+}
+
+util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResultNoNotify(std::optional<bool> internal_hint, unsigned int size, std::set<CScript>& committed_spks)
 {
     const TopUpPreparation prepared{PrepareTopUp(internal_hint)};
+    std::set<CScript> new_spks;
     {
         LOCK(cs_desc_man);
         // Keep descriptor and database lock ordering aligned with address reservation.
@@ -1255,7 +1264,7 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResultNoNotif
         if (!batch.TxnBegin()) {
             return util::Error{_("Error starting descriptors keypool top-up database transaction")};
         }
-        util::Result<void> res{TopUpWithDBPreparedResult(batch, size, prepared, /*throw_on_persistence_error=*/false, /*rollback_state_on_error=*/true)};
+        util::Result<void> res{TopUpWithDBPreparedResult(batch, size, prepared, /*throw_on_persistence_error=*/false, /*rollback_state_on_error=*/true, new_spks)};
         if (!res) {
             if (!batch.TxnAbort()) {
                 throw std::runtime_error(strprintf(
@@ -1266,20 +1275,24 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResultNoNotif
         }
         if (!batch.TxnCommit()) throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet [%s]", m_storage.LogName()));
     }
+    committed_spks.insert(new_spks.begin(), new_spks.end());
     return {};
 }
 
 bool DescriptorScriptPubKeyMan::TopUpWithDB(WalletBatch& batch, unsigned int size, std::optional<bool> internal_hint)
 {
+    AssertLockNotHeld(cs_desc_man);
     return TopUpWithDBResult(batch, size, internal_hint, /*throw_on_persistence_error=*/true, /*rollback_state_on_error=*/false).has_value();
 }
 
 util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBResult(WalletBatch& batch, unsigned int size, std::optional<bool> internal_hint, bool throw_on_persistence_error, bool rollback_state_on_error)
 {
+    AssertLockNotHeld(cs_desc_man);
     const TopUpPreparation prepared{PrepareTopUp(internal_hint)};
+    std::set<CScript> new_spks;
     util::Result<void> result{[&] {
         LOCK(cs_desc_man);
-        return TopUpWithDBPreparedResult(batch, size, prepared, throw_on_persistence_error, rollback_state_on_error);
+        return TopUpWithDBPreparedResult(batch, size, prepared, throw_on_persistence_error, rollback_state_on_error, new_spks);
     }()};
     if (!result) return result;
 
@@ -1287,16 +1300,16 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBResult(WalletBatch& bat
         // Caller-owned transactions publish address availability only after
         // their complete descriptor update is durable.
         batch.RegisterTxnListener({
-            .on_commit = [this] { NotifyCanGetAddressesChanged(); },
+            .on_commit = [this, new_spks = std::move(new_spks)] { PublishTopUp(new_spks, /*notify_can_get_addresses_changed=*/true); },
             .on_abort = [] {},
         });
     } else {
-        NotifyCanGetAddressesChanged();
+        PublishTopUp(new_spks, /*notify_can_get_addresses_changed=*/true);
     }
     return {};
 }
 
-util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error)
+util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error, std::set<CScript>& new_spks)
 {
     AssertLockHeld(cs_desc_man);
     const int32_t old_range_start{m_wallet_descriptor.range_start};
@@ -1382,7 +1395,7 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
         if (throw_on_persistence_error) throw std::runtime_error(error.original);
         return util::Error{std::move(error)};
     };
-    std::set<CScript> new_spks;
+    std::set<CScript> staged_spks;
     unsigned int target_size;
     if (size > 0) {
         target_size = size;
@@ -1516,7 +1529,7 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
             }
         }
         // Add all of the scriptPubKeys to the scriptPubKey set
-        new_spks.insert(scripts_temp.begin(), scripts_temp.end());
+        staged_spks.insert(scripts_temp.begin(), scripts_temp.end());
         for (const CScript& script : scripts_temp) {
             remember_script_pub_key(script);
             m_map_script_pub_keys[script] = i;
@@ -1555,7 +1568,7 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
     // By this point, the cache size should be the size of the entire range
     assert(m_wallet_descriptor.range_end - 1 == m_max_cached_index);
 
-    m_storage.TopUpCallback(new_spks, this);
+    new_spks.insert(staged_spks.begin(), staged_spks.end());
     return {};
 }
 
@@ -1736,29 +1749,32 @@ bool DescriptorScriptPubKeyMan::AddDescriptorPQCKeyWithDB(WalletBatch& batch, co
 
 bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal, unsigned int initial_keypool_size)
 {
-    LOCK(cs_desc_man);
-    assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
+    unsigned int top_up_size{0};
+    {
+        LOCK(cs_desc_man);
+        assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
 
-    // Ignore when there is already a descriptor
-    if (m_wallet_descriptor.descriptor) {
-        return false;
+        // Ignore when there is already a descriptor
+        if (m_wallet_descriptor.descriptor) {
+            return false;
+        }
+
+        m_wallet_descriptor = GenerateWalletDescriptor(master_key.Neuter(), addr_type, internal);
+
+        // Store the master private key, and descriptor
+        if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
+            throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
+        }
+        if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+            throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+        }
+
+        // Wallet creation on P2MR-only chains seeds a small synchronous pool first,
+        // then refills the remainder after create returns.
+        m_deferred_create_keypool_top_up = initial_keypool_size > 0 && initial_keypool_size < m_keypool_size;
+        m_wallet_descriptor.deferred_create_keypool_top_up = m_deferred_create_keypool_top_up;
+        top_up_size = m_deferred_create_keypool_top_up ? initial_keypool_size : 0;
     }
-
-    m_wallet_descriptor = GenerateWalletDescriptor(master_key.Neuter(), addr_type, internal);
-
-    // Store the master private key, and descriptor
-    if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
-    }
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
-    }
-
-    // Wallet creation on P2MR-only chains seeds a small synchronous pool first,
-    // then refills the remainder after create returns.
-    m_deferred_create_keypool_top_up = initial_keypool_size > 0 && initial_keypool_size < m_keypool_size;
-    m_wallet_descriptor.deferred_create_keypool_top_up = m_deferred_create_keypool_top_up;
-    const unsigned int top_up_size = m_deferred_create_keypool_top_up ? initial_keypool_size : 0;
     TopUpWithDB(batch, top_up_size, internal);
 
     m_storage.UnsetBlankWalletFlag(batch);
@@ -1807,7 +1823,7 @@ bool DescriptorScriptPubKeyMan::NeedsP2MRKeyPoolRefillNoLock() const
            GetKeyPoolSizeNoLock() <= GetP2MRReceiveKeyPoolLowWatermarkNoLock();
 }
 
-bool DescriptorScriptPubKeyMan::MaybeTopUpInternalP2MRKeyPoolNoNotify()
+bool DescriptorScriptPubKeyMan::MaybeTopUpInternalP2MRKeyPoolNoNotify(std::set<CScript>& committed_spks)
 {
     AssertLockHeld(cs_desc_man);
     if (m_storage.IsLocked() || !NeedsP2MRKeyPoolRefillNoLock()) return false;
@@ -1815,7 +1831,7 @@ bool DescriptorScriptPubKeyMan::MaybeTopUpInternalP2MRKeyPoolNoNotify()
     const unsigned int target{GetP2MRReceiveKeyPoolRefillStepTargetNoLock()};
     if (target == 0) return false;
     try {
-        util::Result<void> res{TopUpWithInternalHintResultNoNotify(/*internal_hint=*/true, target)};
+        util::Result<void> res{TopUpWithInternalHintResultNoNotify(/*internal_hint=*/true, target, committed_spks)};
         if (!res) {
             WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
                 GetID().ToString(), target, GetKeyPoolSizeNoLock(), util::ErrorString(res).original);
@@ -2839,33 +2855,35 @@ uint256 DescriptorScriptPubKeyMan::GetID() const
 
 void DescriptorScriptPubKeyMan::SetCache(const DescriptorCache& cache)
 {
-    LOCK(cs_desc_man);
     std::set<CScript> new_spks;
-    m_wallet_descriptor.cache = cache;
-    for (int32_t i = m_wallet_descriptor.range_start; i < m_wallet_descriptor.range_end; ++i) {
-        FlatSigningProvider out_keys;
-        std::vector<CScript> scripts_temp;
-        if (!m_wallet_descriptor.descriptor->ExpandFromCache(i, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
-            throw std::runtime_error("Error: Unable to expand wallet descriptor from cache");
-        }
-        // Add all of the scriptPubKeys to the scriptPubKey set
-        new_spks.insert(scripts_temp.begin(), scripts_temp.end());
-        for (const CScript& script : scripts_temp) {
-            if (m_map_script_pub_keys.count(script) != 0) {
-                throw std::runtime_error(strprintf("Error: Already loaded script at index %d as being at index %d", i, m_map_script_pub_keys[script]));
+    {
+        LOCK(cs_desc_man);
+        m_wallet_descriptor.cache = cache;
+        for (int32_t i = m_wallet_descriptor.range_start; i < m_wallet_descriptor.range_end; ++i) {
+            FlatSigningProvider out_keys;
+            std::vector<CScript> scripts_temp;
+            if (!m_wallet_descriptor.descriptor->ExpandFromCache(i, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
+                throw std::runtime_error("Error: Unable to expand wallet descriptor from cache");
             }
-            m_map_script_pub_keys[script] = i;
-        }
-        for (const auto& pk_pair : out_keys.pubkeys) {
-            const CPubKey& pubkey = pk_pair.second;
-            if (m_map_pubkeys.count(pubkey) != 0) {
-                // We don't need to give an error here.
-                // It doesn't matter which of many valid indexes the pubkey has, we just need an index where we can derive it and its private key
-                continue;
+            // Add all of the scriptPubKeys to the scriptPubKey set
+            new_spks.insert(scripts_temp.begin(), scripts_temp.end());
+            for (const CScript& script : scripts_temp) {
+                if (m_map_script_pub_keys.count(script) != 0) {
+                    throw std::runtime_error(strprintf("Error: Already loaded script at index %d as being at index %d", i, m_map_script_pub_keys[script]));
+                }
+                m_map_script_pub_keys[script] = i;
             }
-            m_map_pubkeys[pubkey] = i;
+            for (const auto& pk_pair : out_keys.pubkeys) {
+                const CPubKey& pubkey = pk_pair.second;
+                if (m_map_pubkeys.count(pubkey) != 0) {
+                    // We don't need to give an error here.
+                    // It doesn't matter which of many valid indexes the pubkey has, we just need an index where we can derive it and its private key
+                    continue;
+                }
+                m_map_pubkeys[pubkey] = i;
+            }
+            m_max_cached_index++;
         }
-        m_max_cached_index++;
     }
     // Make sure the wallet knows about our new spks
     m_storage.TopUpCallback(new_spks, this);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -942,11 +942,18 @@ bool LegacyDataSPKM::DeleteRecordsWithDB(WalletBatch& batch)
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
+    return GetNewDestinationInternal(type, /*index=*/nullptr);
+}
+
+util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestinationInternal(const OutputType type, int64_t* index)
+{
     // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later
     if (!CanGetAddresses()) {
         return util::Error{_("No addresses available")};
     }
-    {
+
+    bool notify_can_get_addresses_changed{false};
+    util::Result<CTxDestination> result{[&]() -> util::Result<CTxDestination> {
         LOCK(cs_desc_man);
         assert(m_wallet_descriptor.descriptor->IsSingleType()); // This is a combo descriptor which should not be an active descriptor
         std::optional<OutputType> desc_addr_type = m_wallet_descriptor.descriptor->GetOutputType();
@@ -956,15 +963,19 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
         }
 
         if (!m_deferred_create_keypool_top_up && !IsRangedP2MRDescriptorNoLock()) {
-            TopUp();
+            notify_can_get_addresses_changed = TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/0).has_value();
         }
 
         // Get the scriptPubKey from the descriptor
         FlatSigningProvider out_keys;
         std::vector<CScript> scripts_temp;
-        if (m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end && !TopUp(1)) {
-            // We can't generate anymore keys
-            return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
+        if (m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end) {
+            auto top_up{TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/1)};
+            if (!top_up) {
+                // We can't generate anymore keys
+                return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
+            }
+            notify_can_get_addresses_changed = true;
         }
         if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
             // We can't generate anymore keys
@@ -976,12 +987,18 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
             return util::Error{_("Error: Cannot extract destination from the generated scriptpubkey")}; // shouldn't happen
         }
         m_wallet_descriptor.next_index++;
+        if (index) *index = m_wallet_descriptor.next_index - 1;
         if (IsRangedP2MRDescriptorNoLock() && !m_deferred_create_keypool_top_up) {
             m_wallet_descriptor.deferred_create_keypool_top_up = false;
         }
         WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
         return dest;
+    }()};
+
+    if (notify_can_get_addresses_changed) {
+        NotifyCanGetAddressesChanged();
     }
+    return result;
 }
 
 bool DescriptorScriptPubKeyMan::IsMine(const CScript& script) const
@@ -1088,13 +1105,10 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetReservedDestination(const OutputType type, bool internal, int64_t& index, bool allow_internal_p2mr_refill)
 {
-    LOCK(cs_desc_man);
     if (internal && allow_internal_p2mr_refill) {
         MaybeTopUpInternalP2MRKeyPool();
     }
-    auto op_dest = GetNewDestination(type);
-    index = m_wallet_descriptor.next_index - 1;
-    return op_dest;
+    return GetNewDestinationInternal(type, &index);
 }
 
 void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, const CTxDestination& addr)
@@ -1213,6 +1227,16 @@ DescriptorScriptPubKeyMan::TopUpPreparation DescriptorScriptPubKeyMan::PrepareTo
 
 util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResult(std::optional<bool> internal_hint, unsigned int size)
 {
+    AssertLockNotHeld(cs_desc_man);
+    auto result{TopUpWithInternalHintResultNoNotify(internal_hint, size)};
+    if (result) {
+        NotifyCanGetAddressesChanged();
+    }
+    return result;
+}
+
+util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResultNoNotify(std::optional<bool> internal_hint, unsigned int size)
+{
     const TopUpPreparation prepared{PrepareTopUp(internal_hint)};
     {
         LOCK(cs_desc_man);
@@ -1232,10 +1256,6 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResult(std::o
         }
         if (!batch.TxnCommit()) throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet [%s]", m_storage.LogName()));
     }
-    // Do not invoke external observers while holding the descriptor mutex or
-    // the SQLite writer. Observers may synchronously query the wallet and take
-    // cs_wallet.
-    NotifyCanGetAddressesChanged();
     return {};
 }
 
@@ -1779,20 +1799,28 @@ bool DescriptorScriptPubKeyMan::NeedsP2MRKeyPoolRefillNoLock() const
 
 void DescriptorScriptPubKeyMan::MaybeTopUpInternalP2MRKeyPool()
 {
-    AssertLockHeld(cs_desc_man);
-    if (m_storage.IsLocked() || !NeedsP2MRKeyPoolRefillNoLock()) return;
+    bool notify_can_get_addresses_changed{false};
+    {
+        LOCK(cs_desc_man);
+        if (m_storage.IsLocked() || !NeedsP2MRKeyPoolRefillNoLock()) return;
 
-    const unsigned int target{GetP2MRReceiveKeyPoolRefillStepTargetNoLock()};
-    if (target == 0) return;
-    try {
-        util::Result<void> res{TopUpWithInternalHintResult(/*internal_hint=*/true, target)};
-        if (!res) {
+        const unsigned int target{GetP2MRReceiveKeyPoolRefillStepTargetNoLock()};
+        if (target == 0) return;
+        try {
+            util::Result<void> res{TopUpWithInternalHintResultNoNotify(/*internal_hint=*/true, target)};
+            if (!res) {
+                WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
+                    GetID().ToString(), target, GetKeyPoolSizeNoLock(), util::ErrorString(res).original);
+            } else {
+                notify_can_get_addresses_changed = true;
+            }
+        } catch (const std::exception& e) {
             WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
-                GetID().ToString(), target, GetKeyPoolSizeNoLock(), util::ErrorString(res).original);
+                GetID().ToString(), target, GetKeyPoolSizeNoLock(), e.what());
         }
-    } catch (const std::exception& e) {
-        WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
-            GetID().ToString(), target, GetKeyPoolSizeNoLock(), e.what());
+    }
+    if (notify_can_get_addresses_changed) {
+        NotifyCanGetAddressesChanged();
     }
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -942,63 +942,65 @@ bool LegacyDataSPKM::DeleteRecordsWithDB(WalletBatch& batch)
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
-    return GetNewDestinationInternal(type, /*index=*/nullptr);
+    bool notify_can_get_addresses_changed{false};
+    util::Result<CTxDestination> result{[&] {
+        LOCK(cs_desc_man);
+        return GetNewDestinationNoNotify(type, /*index=*/nullptr, notify_can_get_addresses_changed);
+    }()};
+    if (notify_can_get_addresses_changed) {
+        NotifyCanGetAddressesChanged();
+    }
+    return result;
 }
 
-util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestinationInternal(const OutputType type, int64_t* index)
+util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestinationNoNotify(const OutputType type, int64_t* index, bool& notify_can_get_addresses_changed)
 {
+    AssertLockHeld(cs_desc_man);
     // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later
     if (!CanGetAddresses()) {
         return util::Error{_("No addresses available")};
     }
 
-    bool notify_can_get_addresses_changed{false};
-    util::Result<CTxDestination> result{[&]() -> util::Result<CTxDestination> {
-        LOCK(cs_desc_man);
-        assert(m_wallet_descriptor.descriptor->IsSingleType()); // This is a combo descriptor which should not be an active descriptor
-        std::optional<OutputType> desc_addr_type = m_wallet_descriptor.descriptor->GetOutputType();
-        assert(desc_addr_type);
-        if (type != *desc_addr_type) {
-            throw std::runtime_error(std::string(__func__) + ": Types are inconsistent. Stored type does not match type of newly generated address");
-        }
+    assert(m_wallet_descriptor.descriptor->IsSingleType()); // This is a combo descriptor which should not be an active descriptor
+    std::optional<OutputType> desc_addr_type = m_wallet_descriptor.descriptor->GetOutputType();
+    assert(desc_addr_type);
+    if (type != *desc_addr_type) {
+        throw std::runtime_error(std::string(__func__) + ": Types are inconsistent. Stored type does not match type of newly generated address");
+    }
 
-        if (!m_deferred_create_keypool_top_up && !IsRangedP2MRDescriptorNoLock()) {
-            notify_can_get_addresses_changed = TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/0).has_value();
-        }
-
-        // Get the scriptPubKey from the descriptor
-        FlatSigningProvider out_keys;
-        std::vector<CScript> scripts_temp;
-        if (m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end) {
-            auto top_up{TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/1)};
-            if (!top_up) {
-                // We can't generate anymore keys
-                return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
-            }
+    if (!m_deferred_create_keypool_top_up && !IsRangedP2MRDescriptorNoLock()) {
+        if (TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/0)) {
             notify_can_get_addresses_changed = true;
         }
-        if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
+    }
+
+    // Get the scriptPubKey from the descriptor
+    FlatSigningProvider out_keys;
+    std::vector<CScript> scripts_temp;
+    if (m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end) {
+        auto top_up{TopUpWithInternalHintResultNoNotify(std::nullopt, /*size=*/1)};
+        if (!top_up) {
             // We can't generate anymore keys
             return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
         }
-
-        CTxDestination dest;
-        if (!ExtractDestination(scripts_temp[0], dest)) {
-            return util::Error{_("Error: Cannot extract destination from the generated scriptpubkey")}; // shouldn't happen
-        }
-        m_wallet_descriptor.next_index++;
-        if (index) *index = m_wallet_descriptor.next_index - 1;
-        if (IsRangedP2MRDescriptorNoLock() && !m_deferred_create_keypool_top_up) {
-            m_wallet_descriptor.deferred_create_keypool_top_up = false;
-        }
-        WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
-        return dest;
-    }()};
-
-    if (notify_can_get_addresses_changed) {
-        NotifyCanGetAddressesChanged();
+        notify_can_get_addresses_changed = true;
     }
-    return result;
+    if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
+        // We can't generate anymore keys
+        return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
+    }
+
+    CTxDestination dest;
+    if (!ExtractDestination(scripts_temp[0], dest)) {
+        return util::Error{_("Error: Cannot extract destination from the generated scriptpubkey")}; // shouldn't happen
+    }
+    m_wallet_descriptor.next_index++;
+    if (index) *index = m_wallet_descriptor.next_index - 1;
+    if (IsRangedP2MRDescriptorNoLock() && !m_deferred_create_keypool_top_up) {
+        m_wallet_descriptor.deferred_create_keypool_top_up = false;
+    }
+    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
+    return dest;
 }
 
 bool DescriptorScriptPubKeyMan::IsMine(const CScript& script) const
@@ -1105,10 +1107,18 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetReservedDestination(const OutputType type, bool internal, int64_t& index, bool allow_internal_p2mr_refill)
 {
-    if (internal && allow_internal_p2mr_refill) {
-        MaybeTopUpInternalP2MRKeyPool();
+    bool notify_can_get_addresses_changed{false};
+    util::Result<CTxDestination> result{[&] {
+        LOCK(cs_desc_man);
+        if (internal && allow_internal_p2mr_refill && MaybeTopUpInternalP2MRKeyPoolNoNotify()) {
+            notify_can_get_addresses_changed = true;
+        }
+        return GetNewDestinationNoNotify(type, &index, notify_can_get_addresses_changed);
+    }()};
+    if (notify_can_get_addresses_changed) {
+        NotifyCanGetAddressesChanged();
     }
-    return GetNewDestinationInternal(type, &index);
+    return result;
 }
 
 void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, const CTxDestination& addr)
@@ -1797,31 +1807,26 @@ bool DescriptorScriptPubKeyMan::NeedsP2MRKeyPoolRefillNoLock() const
            GetKeyPoolSizeNoLock() <= GetP2MRReceiveKeyPoolLowWatermarkNoLock();
 }
 
-void DescriptorScriptPubKeyMan::MaybeTopUpInternalP2MRKeyPool()
+bool DescriptorScriptPubKeyMan::MaybeTopUpInternalP2MRKeyPoolNoNotify()
 {
-    bool notify_can_get_addresses_changed{false};
-    {
-        LOCK(cs_desc_man);
-        if (m_storage.IsLocked() || !NeedsP2MRKeyPoolRefillNoLock()) return;
+    AssertLockHeld(cs_desc_man);
+    if (m_storage.IsLocked() || !NeedsP2MRKeyPoolRefillNoLock()) return false;
 
-        const unsigned int target{GetP2MRReceiveKeyPoolRefillStepTargetNoLock()};
-        if (target == 0) return;
-        try {
-            util::Result<void> res{TopUpWithInternalHintResultNoNotify(/*internal_hint=*/true, target)};
-            if (!res) {
-                WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
-                    GetID().ToString(), target, GetKeyPoolSizeNoLock(), util::ErrorString(res).original);
-            } else {
-                notify_can_get_addresses_changed = true;
-            }
-        } catch (const std::exception& e) {
+    const unsigned int target{GetP2MRReceiveKeyPoolRefillStepTargetNoLock()};
+    if (target == 0) return false;
+    try {
+        util::Result<void> res{TopUpWithInternalHintResultNoNotify(/*internal_hint=*/true, target)};
+        if (!res) {
             WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
-                GetID().ToString(), target, GetKeyPoolSizeNoLock(), e.what());
+                GetID().ToString(), target, GetKeyPoolSizeNoLock(), util::ErrorString(res).original);
+            return false;
         }
+    } catch (const std::exception& e) {
+        WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
+            GetID().ToString(), target, GetKeyPoolSizeNoLock(), e.what());
+        return false;
     }
-    if (notify_can_get_addresses_changed) {
-        NotifyCanGetAddressesChanged();
-    }
+    return true;
 }
 
 unsigned int DescriptorScriptPubKeyMan::GetP2MRReceiveKeyPoolLowWatermarkNoLock() const

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1099,12 +1099,14 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetReservedDestination(c
 
 void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, const CTxDestination& addr)
 {
-    LOCK(cs_desc_man);
-    // Only return when the index was the most recent
-    if (m_wallet_descriptor.next_index - 1 == index) {
-        m_wallet_descriptor.next_index--;
+    {
+        LOCK(cs_desc_man);
+        // Only return when the index was the most recent
+        if (m_wallet_descriptor.next_index - 1 == index) {
+            m_wallet_descriptor.next_index--;
+        }
+        WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
     }
-    WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
     NotifyCanGetAddressesChanged();
 }
 
@@ -1212,22 +1214,28 @@ DescriptorScriptPubKeyMan::TopUpPreparation DescriptorScriptPubKeyMan::PrepareTo
 util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResult(std::optional<bool> internal_hint, unsigned int size)
 {
     const TopUpPreparation prepared{PrepareTopUp(internal_hint)};
-    LOCK(cs_desc_man);
-    // Keep descriptor and database lock ordering aligned with address reservation.
-    WalletBatch batch(m_storage.GetDatabase());
-    if (!batch.TxnBegin()) {
-        return util::Error{_("Error starting descriptors keypool top-up database transaction")};
-    }
-    util::Result<void> res{TopUpWithDBPreparedResult(batch, size, prepared, /*throw_on_persistence_error=*/false, /*rollback_state_on_error=*/true)};
-    if (!res) {
-        if (!batch.TxnAbort()) {
-            throw std::runtime_error(strprintf(
-                "Error during descriptors keypool top up. Cannot abort changes for wallet [%s]: %s",
-                m_storage.LogName(), util::ErrorString(res).original));
+    {
+        LOCK(cs_desc_man);
+        // Keep descriptor and database lock ordering aligned with address reservation.
+        WalletBatch batch(m_storage.GetDatabase());
+        if (!batch.TxnBegin()) {
+            return util::Error{_("Error starting descriptors keypool top-up database transaction")};
         }
-        return res;
+        util::Result<void> res{TopUpWithDBPreparedResult(batch, size, prepared, /*throw_on_persistence_error=*/false, /*rollback_state_on_error=*/true)};
+        if (!res) {
+            if (!batch.TxnAbort()) {
+                throw std::runtime_error(strprintf(
+                    "Error during descriptors keypool top up. Cannot abort changes for wallet [%s]: %s",
+                    m_storage.LogName(), util::ErrorString(res).original));
+            }
+            return res;
+        }
+        if (!batch.TxnCommit()) throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet [%s]", m_storage.LogName()));
     }
-    if (!batch.TxnCommit()) throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet [%s]", m_storage.LogName()));
+    // Do not invoke external observers while holding the descriptor mutex or
+    // the SQLite writer. Observers may synchronously query the wallet and take
+    // cs_wallet.
+    NotifyCanGetAddressesChanged();
     return {};
 }
 
@@ -1239,8 +1247,23 @@ bool DescriptorScriptPubKeyMan::TopUpWithDB(WalletBatch& batch, unsigned int siz
 util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBResult(WalletBatch& batch, unsigned int size, std::optional<bool> internal_hint, bool throw_on_persistence_error, bool rollback_state_on_error)
 {
     const TopUpPreparation prepared{PrepareTopUp(internal_hint)};
-    LOCK(cs_desc_man);
-    return TopUpWithDBPreparedResult(batch, size, prepared, throw_on_persistence_error, rollback_state_on_error);
+    util::Result<void> result{[&] {
+        LOCK(cs_desc_man);
+        return TopUpWithDBPreparedResult(batch, size, prepared, throw_on_persistence_error, rollback_state_on_error);
+    }()};
+    if (!result) return result;
+
+    if (batch.HasActiveTxn()) {
+        // Caller-owned transactions publish address availability only after
+        // their complete descriptor update is durable.
+        batch.RegisterTxnListener({
+            .on_commit = [this] { NotifyCanGetAddressesChanged(); },
+            .on_abort = [] {},
+        });
+    } else {
+        NotifyCanGetAddressesChanged();
+    }
+    return {};
 }
 
 util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error)
@@ -1503,13 +1526,13 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
     assert(m_wallet_descriptor.range_end - 1 == m_max_cached_index);
 
     m_storage.TopUpCallback(new_spks, this);
-    NotifyCanGetAddressesChanged();
     return {};
 }
 
 std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(const CScript& script, const MarkUnusedAddressesOptions& options)
 {
     std::vector<WalletDestination> result;
+    bool notify_can_get_addresses_changed{false};
     bool p2mr_refill{false};
     bool non_p2mr_top_up{false};
     unsigned int p2mr_refill_target{0};
@@ -1547,7 +1570,7 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
                 if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
                     throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
                 }
-                NotifyCanGetAddressesChanged();
+                notify_can_get_addresses_changed = true;
             }
         } else if (IsRangedP2MRDescriptorNoLock()) {
             if (advanced_next_index) {
@@ -1556,25 +1579,27 @@ std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(co
                 if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
                     throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
                 }
-                NotifyCanGetAddressesChanged();
+                notify_can_get_addresses_changed = true;
             }
             const bool needs_p2mr_refill{
                 options.preserve_full_keypool_lookahead ?
                     GetKeyPoolSizeNoLock() < static_cast<unsigned int>(m_keypool_size) :
                     NeedsP2MRKeyPoolRefillNoLock()};
-            if (!needs_p2mr_refill) {
-                return result;
+            if (needs_p2mr_refill) {
+                p2mr_refill = true;
+                p2mr_refill_target = options.preserve_full_keypool_lookahead ? 0 : GetP2MRReceiveKeyPoolRefillStepTargetNoLock();
+                p2mr_full_refill_target = static_cast<unsigned int>(m_keypool_size);
+                p2mr_remaining = GetKeyPoolSizeNoLock();
+                p2mr_low_watermark = GetP2MRReceiveKeyPoolLowWatermarkNoLock();
+                p2mr_descriptor_id = GetID().ToString();
             }
-
-            p2mr_refill = true;
-            p2mr_refill_target = options.preserve_full_keypool_lookahead ? 0 : GetP2MRReceiveKeyPoolRefillStepTargetNoLock();
-            p2mr_full_refill_target = static_cast<unsigned int>(m_keypool_size);
-            p2mr_remaining = GetKeyPoolSizeNoLock();
-            p2mr_low_watermark = GetP2MRReceiveKeyPoolLowWatermarkNoLock();
-            p2mr_descriptor_id = GetID().ToString();
         } else {
             non_p2mr_top_up = true;
         }
+    }
+
+    if (notify_can_get_addresses_changed) {
+        NotifyCanGetAddressesChanged();
     }
 
     if (p2mr_refill) {

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -395,11 +395,13 @@ private:
         bool has_encryption_keys{false};
         std::optional<CKeyingMaterial> encryption_key;
     };
+    util::Result<CTxDestination> GetNewDestinationInternal(OutputType type, int64_t* index);
     TopUpPreparation PrepareTopUp(std::optional<bool> internal_hint) const;
+    util::Result<void> TopUpWithInternalHintResultNoNotify(std::optional<bool> internal_hint, unsigned int size);
     bool IsRangedP2MRDescriptorNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetKeyPoolSizeNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool NeedsP2MRKeyPoolRefillNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    void MaybeTopUpInternalP2MRKeyPool() EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    void MaybeTopUpInternalP2MRKeyPool();
     unsigned int GetP2MRReceiveKeyPoolLowWatermarkNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetP2MRReceiveKeyPoolRefillStepTargetNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
@@ -443,7 +445,7 @@ public:
     bool TopUp(unsigned int size = 0) override;
     util::Result<void> TopUpResult(unsigned int size = 0) override;
     bool TopUpWithInternalHint(std::optional<bool> internal_hint, unsigned int size = 0);
-    util::Result<void> TopUpWithInternalHintResult(std::optional<bool> internal_hint, unsigned int size = 0);
+    util::Result<void> TopUpWithInternalHintResult(std::optional<bool> internal_hint, unsigned int size = 0) LOCKS_EXCLUDED(cs_desc_man);
 
     std::vector<WalletDestination> MarkUnusedAddresses(const CScript& script, const MarkUnusedAddressesOptions& options = {}) override;
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -90,7 +90,8 @@ public:
     virtual bool IsLocked() const = 0;
     virtual bool WithWalletLock(std::function<bool()> cb) const = 0;
     virtual std::optional<bool> IsInternalScriptPubKeyMan(const ScriptPubKeyMan* spk_man) const = 0;
-    //! Callback function for after TopUp completes containing any scripts that were added by a SPKMan
+    //! Publish scripts added by a SPKMan after its database transaction has
+    //! committed and its manager lock has been released.
     virtual void TopUpCallback(const std::set<CScript>&, ScriptPubKeyMan*) = 0;
 };
 
@@ -395,13 +396,14 @@ private:
         bool has_encryption_keys{false};
         std::optional<CKeyingMaterial> encryption_key;
     };
-    util::Result<CTxDestination> GetNewDestinationNoNotify(OutputType type, int64_t* index, bool& notify_can_get_addresses_changed) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    void PublishTopUp(const std::set<CScript>& new_spks, bool notify_can_get_addresses_changed) LOCKS_EXCLUDED(cs_desc_man);
+    util::Result<CTxDestination> GetNewDestinationNoNotify(OutputType type, int64_t* index, bool& notify_can_get_addresses_changed, std::set<CScript>& committed_spks) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     TopUpPreparation PrepareTopUp(std::optional<bool> internal_hint) const;
-    util::Result<void> TopUpWithInternalHintResultNoNotify(std::optional<bool> internal_hint, unsigned int size);
+    util::Result<void> TopUpWithInternalHintResultNoNotify(std::optional<bool> internal_hint, unsigned int size, std::set<CScript>& committed_spks);
     bool IsRangedP2MRDescriptorNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetKeyPoolSizeNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool NeedsP2MRKeyPoolRefillNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    bool MaybeTopUpInternalP2MRKeyPoolNoNotify() EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool MaybeTopUpInternalP2MRKeyPoolNoNotify(std::set<CScript>& committed_spks) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetP2MRReceiveKeyPoolLowWatermarkNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetP2MRReceiveKeyPoolRefillStepTargetNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
@@ -419,9 +421,9 @@ protected:
     WalletDescriptor m_wallet_descriptor GUARDED_BY(cs_desc_man);
 
     //! Same as 'TopUp' but designed for use within a batch transaction context
-    bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0, std::optional<bool> internal_hint = std::nullopt);
-    util::Result<void> TopUpWithDBResult(WalletBatch& batch, unsigned int size = 0, std::optional<bool> internal_hint = std::nullopt, bool throw_on_persistence_error = false, bool rollback_state_on_error = true);
-    util::Result<void> TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0, std::optional<bool> internal_hint = std::nullopt) LOCKS_EXCLUDED(cs_desc_man);
+    util::Result<void> TopUpWithDBResult(WalletBatch& batch, unsigned int size = 0, std::optional<bool> internal_hint = std::nullopt, bool throw_on_persistence_error = false, bool rollback_state_on_error = true) LOCKS_EXCLUDED(cs_desc_man);
+    util::Result<void> TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error, std::set<CScript>& new_spks) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
 public:
     DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -395,13 +395,13 @@ private:
         bool has_encryption_keys{false};
         std::optional<CKeyingMaterial> encryption_key;
     };
-    util::Result<CTxDestination> GetNewDestinationInternal(OutputType type, int64_t* index);
+    util::Result<CTxDestination> GetNewDestinationNoNotify(OutputType type, int64_t* index, bool& notify_can_get_addresses_changed) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     TopUpPreparation PrepareTopUp(std::optional<bool> internal_hint) const;
     util::Result<void> TopUpWithInternalHintResultNoNotify(std::optional<bool> internal_hint, unsigned int size);
     bool IsRangedP2MRDescriptorNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetKeyPoolSizeNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool NeedsP2MRKeyPoolRefillNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    void MaybeTopUpInternalP2MRKeyPool();
+    bool MaybeTopUpInternalP2MRKeyPoolNoNotify() EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetP2MRReceiveKeyPoolLowWatermarkNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetP2MRReceiveKeyPoolRefillStepTargetNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 

--- a/src/wallet/spend.cpp
+++ b/src/wallet/spend.cpp
@@ -140,6 +140,7 @@ int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* wallet, 
 static std::unique_ptr<Descriptor> GetDescriptor(const CWallet* wallet, const CCoinControl* coin_control,
                                                  const CScript script_pubkey)
 {
+    LOCK(wallet->cs_wallet);
     MultiSigningProvider providers;
     for (const auto spkman: wallet->GetScriptPubKeyMans(script_pubkey)) {
         providers.AddProvider(spkman->GetSolvingProvider(script_pubkey));

--- a/src/wallet/test/wallet_p2mr_change_keypool_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_change_keypool_tests.cpp
@@ -76,7 +76,15 @@ BOOST_FIXTURE_TEST_CASE(P2MRGetNewChangeAddressBoundsLowWatermarkRefill, Regtest
         range_end_at_watermark = internal_spk_man->GetWalletDescriptor().range_end;
     }
 
-    BOOST_REQUIRE(wallet->GetNewChangeDestination(OutputType::P2MR));
+    int notification_count{0};
+    auto connection = internal_spk_man->NotifyCanGetAddressesChanged.connect([&] {
+        ++notification_count;
+        BOOST_CHECK(LockStackEmpty());
+    });
+    int64_t reserved_index{-1};
+    BOOST_REQUIRE(internal_spk_man->GetReservedDestination(OutputType::P2MR, /*internal=*/true, reserved_index));
+    BOOST_CHECK_GE(reserved_index, 0);
+    BOOST_CHECK_EQUAL(notification_count, 1);
     BOOST_CHECK_EQUAL(internal_spk_man->GetKeyPoolSize(), low_watermark + DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL - 1);
     BOOST_CHECK_LT(internal_spk_man->GetKeyPoolSize(), static_cast<unsigned int>(keypool_size));
     {

--- a/src/wallet/test/wallet_p2mr_change_keypool_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_change_keypool_tests.cpp
@@ -76,16 +76,23 @@ BOOST_FIXTURE_TEST_CASE(P2MRGetNewChangeAddressBoundsLowWatermarkRefill, Regtest
         range_end_at_watermark = internal_spk_man->GetWalletDescriptor().range_end;
     }
 
+    const unsigned int expected_keypool_size{low_watermark + DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL - 1};
+    int64_t reserved_index{-1};
     int notification_count{0};
     auto connection = internal_spk_man->NotifyCanGetAddressesChanged.connect([&] {
         ++notification_count;
         BOOST_CHECK(LockStackEmpty());
+        BOOST_CHECK_GE(reserved_index, 0);
+        BOOST_CHECK_EQUAL(internal_spk_man->GetKeyPoolSize(), expected_keypool_size);
+        LOCK(internal_spk_man->cs_desc_man);
+        const WalletDescriptor descriptor{internal_spk_man->GetWalletDescriptor()};
+        BOOST_CHECK_EQUAL(descriptor.next_index, reserved_index + 1);
+        BOOST_CHECK_EQUAL(descriptor.range_end, range_end_at_watermark + DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL);
     });
-    int64_t reserved_index{-1};
     BOOST_REQUIRE(internal_spk_man->GetReservedDestination(OutputType::P2MR, /*internal=*/true, reserved_index));
     BOOST_CHECK_GE(reserved_index, 0);
     BOOST_CHECK_EQUAL(notification_count, 1);
-    BOOST_CHECK_EQUAL(internal_spk_man->GetKeyPoolSize(), low_watermark + DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL - 1);
+    BOOST_CHECK_EQUAL(internal_spk_man->GetKeyPoolSize(), expected_keypool_size);
     BOOST_CHECK_LT(internal_spk_man->GetKeyPoolSize(), static_cast<unsigned int>(keypool_size));
     {
         LOCK(internal_spk_man->cs_desc_man);

--- a/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
@@ -504,11 +504,13 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSchedulesDeferredP2MRKeypoolTopUp, 
         BOOST_CHECK(wallet->m_deferred_create_keypool_top_up_scheduled);
     }
 
-    // Repeated scheduling while the first worker is pending must be a no-op.
+    // Repeated scheduling while the first worker is pending must not queue a
+    // second worker.
     MaybeSchedulePendingInitialKeyPoolTopUp(context, wallet);
     {
         LOCK(wallet->cs_wallet);
         BOOST_CHECK(wallet->m_deferred_create_keypool_top_up_scheduled);
+        BOOST_CHECK(wallet->m_deferred_create_keypool_top_up_reschedule_requested);
     }
 
     // Relocking before the worker runs must pause it and make a later unlock
@@ -521,9 +523,43 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSchedulesDeferredP2MRKeypoolTopUp, 
     {
         LOCK(wallet->cs_wallet);
         BOOST_CHECK(!wallet->m_deferred_create_keypool_top_up_scheduled);
+        BOOST_CHECK(!wallet->m_deferred_create_keypool_top_up_reschedule_requested);
     }
 
+    // Exercise the unlock race after a locked worker finishes its step but
+    // before it updates the scheduling flags.
+    std::promise<void> scheduler_blocked_again;
+    std::promise<void> release_scheduler_again;
+    auto release_scheduler_again_future{release_scheduler_again.get_future()};
+    scheduler.scheduleFromNow([&] {
+        scheduler_blocked_again.set_value();
+        release_scheduler_again_future.wait();
+    }, std::chrono::milliseconds{0});
+    scheduler_blocked_again.get_future().wait();
+
+    std::promise<void> step_finished;
+    std::promise<void> release_step;
+    auto release_step_future{release_step.get_future()};
+    std::atomic_bool pause_next_step{true};
+    context.deferred_keypool_top_up_step_finished_fn = [&] {
+        if (!pause_next_step.exchange(false)) return;
+        step_finished.set_value();
+        release_step_future.wait();
+    };
+
     BOOST_REQUIRE(wallet_interface->unlock(passphrase));
+    BOOST_REQUIRE(wallet_interface->lock());
+    release_scheduler_again.set_value();
+    step_finished.get_future().wait();
+
+    BOOST_REQUIRE(wallet_interface->unlock(passphrase));
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_CHECK(wallet->m_deferred_create_keypool_top_up_scheduled);
+        BOOST_CHECK(wallet->m_deferred_create_keypool_top_up_reschedule_requested);
+    }
+    release_step.set_value();
+
     for (int i = 0; i < 10 && wallet->HasPendingInitialKeyPoolTopUp(); ++i) {
         WaitForScheduler(scheduler);
     }
@@ -534,6 +570,7 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSchedulesDeferredP2MRKeypoolTopUp, 
     {
         LOCK(wallet->cs_wallet);
         BOOST_CHECK(!wallet->m_deferred_create_keypool_top_up_scheduled);
+        BOOST_CHECK(!wallet->m_deferred_create_keypool_top_up_reschedule_requested);
     }
 
     wallet_interface.reset();

--- a/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
@@ -10,9 +10,9 @@ using namespace wallet_p2mr_test;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_p2mr_deferred_keypool_tests, WalletTestingSetup)
 
-BOOST_FIXTURE_TEST_CASE(DeferredTopUpNotifiesAfterCommitWithoutWalletLockInversion, RegtestP2MROnlyWalletTestingSetup, * boost::unit_test::timeout(10))
+BOOST_FIXTURE_TEST_CASE(DeferredTopUpNotifiesAfterCommitWithoutWalletLockInversion, RegtestP2MROnlyWalletTestingSetup, * boost::unit_test::timeout(60))
 {
-    constexpr int64_t keypool_size{64};
+    constexpr int64_t keypool_size{DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL + 1};
     m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
 
     WalletContext context;
@@ -47,7 +47,7 @@ BOOST_FIXTURE_TEST_CASE(DeferredTopUpNotifiesAfterCommitWithoutWalletLockInversi
         callback_can_get_addresses = wallet->CanGetAddresses();
     });
 
-    BOOST_CHECK(wallet->RunPendingInitialKeyPoolTopUpStep() == CWallet::PendingInitialKeyPoolTopUpStepResult::PENDING);
+    BOOST_CHECK(wallet->RunPendingInitialKeyPoolTopUpStep() == CWallet::PendingInitialKeyPoolTopUpStepResult::COMPLETE);
     BOOST_REQUIRE(writer.joinable());
     writer.join();
 

--- a/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
@@ -10,6 +10,62 @@ using namespace wallet_p2mr_test;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_p2mr_deferred_keypool_tests, WalletTestingSetup)
 
+BOOST_AUTO_TEST_CASE(DescriptorTopUpPublishesCacheOnlyAfterCallerTransactionCommit)
+{
+    m_args.ForceSetArg("-keypool", util::ToString(SINGLE_ADDRESS_KEYPOOL_SIZE));
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+
+    auto wallet = TestLoadWallet(context);
+
+    CExtKey committed_master_key;
+    committed_master_key.SetSeed(GenerateRandomKey());
+    TestDescriptorScriptPubKeyMan committed_spk_man{*wallet, SINGLE_ADDRESS_KEYPOOL_SIZE};
+    CScript committed_script;
+    {
+        WalletBatch commit_batch{wallet->GetDatabase()};
+        BOOST_REQUIRE(commit_batch.TxnBegin());
+        BOOST_REQUIRE(committed_spk_man.SetupDescriptorGeneration(commit_batch, committed_master_key, OutputType::BECH32, /*internal=*/false));
+        committed_script = GetCachedScriptPubKey(committed_spk_man, 0);
+
+        {
+            LOCK(wallet->cs_wallet);
+            BOOST_CHECK(!wallet->IsMine(committed_script));
+            BOOST_CHECK(!wallet->GetSolvingProvider(committed_script));
+        }
+
+        BOOST_REQUIRE(commit_batch.TxnCommit());
+    }
+
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_CHECK(wallet->IsMine(committed_script));
+        BOOST_CHECK(wallet->GetSolvingProvider(committed_script));
+    }
+
+    CExtKey aborted_master_key;
+    aborted_master_key.SetSeed(GenerateRandomKey());
+    TestDescriptorScriptPubKeyMan aborted_spk_man{*wallet, SINGLE_ADDRESS_KEYPOOL_SIZE};
+    CScript aborted_script;
+    {
+        WalletBatch abort_batch{wallet->GetDatabase()};
+        BOOST_REQUIRE(abort_batch.TxnBegin());
+        BOOST_REQUIRE(aborted_spk_man.SetupDescriptorGeneration(abort_batch, aborted_master_key, OutputType::BECH32, /*internal=*/false));
+        aborted_script = GetCachedScriptPubKey(aborted_spk_man, 0);
+
+        BOOST_REQUIRE(abort_batch.TxnAbort());
+    }
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_CHECK(!wallet->IsMine(aborted_script));
+        BOOST_CHECK(!wallet->GetSolvingProvider(aborted_script));
+    }
+
+    TestUnloadWallet(std::move(wallet));
+}
+
 BOOST_FIXTURE_TEST_CASE(DeferredTopUpNotifiesAfterCommitWithoutWalletLockInversion, RegtestP2MROnlyWalletTestingSetup, * boost::unit_test::timeout(60))
 {
     constexpr int64_t keypool_size{DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL + 1};
@@ -56,6 +112,118 @@ BOOST_FIXTURE_TEST_CASE(DeferredTopUpNotifiesAfterCommitWithoutWalletLockInversi
     BOOST_CHECK(writer_succeeded);
 
     TestUnloadWallet(std::move(wallet));
+}
+
+BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSerializesDeferredTopUpCachePublicationWithReaders, RegtestP2MROnlyWalletTestingSetup, * boost::unit_test::timeout(60))
+{
+    constexpr int64_t keypool_size{DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL + 1};
+    const SecureString passphrase{"test-passphrase"};
+    m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
+    DeferredCreateKeyPoolTopUpBatchStepOverride batch_step_override{1};
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+    context.scheduler = Assert(m_node.scheduler).get();
+
+    DatabaseOptions options;
+    options.require_create = true;
+    options.create_flags = WALLET_FLAG_DESCRIPTORS;
+    options.create_passphrase = passphrase;
+
+    DatabaseStatus status;
+    bilingual_str error;
+    std::vector<bilingual_str> warnings;
+    auto wallet = CreateWallet(context, "interface_unlock_cache_publication_test", std::nullopt, options, status, error, warnings);
+    BOOST_REQUIRE(wallet);
+    BOOST_REQUIRE_EQUAL(status, DatabaseStatus::SUCCESS);
+    BOOST_REQUIRE(wallet->IsLocked());
+    BOOST_REQUIRE(wallet->HasPendingInitialKeyPoolTopUp());
+
+    auto* external_spk_man = WITH_LOCK(wallet->cs_wallet, return dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false)));
+    BOOST_REQUIRE(external_spk_man);
+    const CScript warm_script{GetCachedScriptPubKey(*external_spk_man, 0)};
+    auto& database{dynamic_cast<SQLiteDatabase&>(wallet->GetDatabase())};
+
+    std::promise<void> publication_ready;
+    std::promise<void> release_publication;
+    auto release_publication_future{release_publication.get_future()};
+    std::atomic_bool pause_next_publication{true};
+    std::atomic_bool publication_lock_stack_empty{false};
+    std::atomic_bool publication_transaction_inactive{false};
+    wallet->m_before_script_pub_key_cache_publish = [&] {
+        if (!pause_next_publication.exchange(false)) return;
+        publication_lock_stack_empty = LockStackEmpty();
+        publication_transaction_inactive = !database.HasActiveTxn();
+        publication_ready.set_value();
+        release_publication_future.wait();
+    };
+
+    std::promise<void> publication_complete;
+    auto publication_complete_future{publication_complete.get_future()};
+    std::atomic_bool signal_publication_complete{true};
+    auto connection = external_spk_man->NotifyCanGetAddressesChanged.connect([&] {
+        if (signal_publication_complete.exchange(false)) publication_complete.set_value();
+    });
+
+    auto wallet_interface{interfaces::MakeWallet(context, wallet)};
+    BOOST_REQUIRE(wallet_interface);
+    BOOST_REQUIRE(wallet_interface->unlock(passphrase));
+    publication_ready.get_future().wait();
+    BOOST_CHECK(publication_lock_stack_empty);
+    BOOST_CHECK(publication_transaction_inactive);
+
+    // Descriptor state and its transaction are complete, but the new script
+    // remains invisible until the publication batch acquires cs_wallet.
+    const CScript new_script{GetCachedScriptPubKey(*external_spk_man, DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL)};
+    std::promise<void> reader_locked;
+    std::promise<void> run_reader_checks;
+    auto run_reader_checks_future{run_reader_checks.get_future()};
+    std::promise<void> reader_checked;
+    std::promise<void> release_reader;
+    auto release_reader_future{release_reader.get_future()};
+    std::atomic_bool reader_observed_warm_script{true};
+    std::atomic_bool reader_observed_unpublished_script{false};
+    std::thread reader{[&] {
+        LOCK(wallet->cs_wallet);
+        reader_locked.set_value();
+        run_reader_checks_future.wait();
+        bool observed_warm_script{true};
+        for (int i = 0; i < 1000; ++i) {
+            observed_warm_script &= wallet->IsMine(warm_script);
+            observed_warm_script &= !!wallet->GetSolvingProvider(warm_script);
+        }
+        reader_observed_warm_script = observed_warm_script;
+        reader_observed_unpublished_script = wallet->IsMine(new_script) || !!wallet->GetSolvingProvider(new_script);
+        reader_checked.set_value();
+        release_reader_future.wait();
+    }};
+
+    reader_locked.get_future().wait();
+    release_publication.set_value();
+    run_reader_checks.set_value();
+    reader_checked.get_future().wait();
+    BOOST_CHECK(reader_observed_warm_script);
+    BOOST_CHECK(!reader_observed_unpublished_script);
+
+    // The publisher has been released, but must still be blocked by the
+    // foreground reader's cs_wallet ownership.
+    BOOST_CHECK(publication_complete_future.wait_for(std::chrono::milliseconds{100}) == std::future_status::timeout);
+    release_reader.set_value();
+    reader.join();
+    publication_complete_future.wait();
+
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_CHECK(wallet->IsMine(new_script));
+        BOOST_CHECK(wallet->GetSolvingProvider(new_script));
+    }
+
+    WaitForScheduler(*Assert(m_node.scheduler));
+    wallet->m_before_script_pub_key_cache_publish = {};
+    wallet_interface.reset();
+    BOOST_CHECK(RemoveWallet(context, wallet, std::nullopt));
+    WaitForDeleteWallet(std::move(wallet));
 }
 
 BOOST_FIXTURE_TEST_CASE(CreateWalletWarmsP2MRKeypoolThenDefersFullTopUp, RegtestDefaultWalletTestingSetup)

--- a/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
@@ -3,11 +3,60 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <wallet/test/wallet_p2mr_test_util.h>
+#include <wallet/sqlite.h>
 
 namespace wallet {
 using namespace wallet_p2mr_test;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_p2mr_deferred_keypool_tests, WalletTestingSetup)
+
+BOOST_FIXTURE_TEST_CASE(DeferredTopUpNotifiesAfterCommitWithoutWalletLockInversion, RegtestP2MROnlyWalletTestingSetup, * boost::unit_test::timeout(10))
+{
+    constexpr int64_t keypool_size{64};
+    m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+
+    auto wallet = TestLoadWallet(context);
+    auto* external_spk_man = WITH_LOCK(wallet->cs_wallet, return dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false)));
+    BOOST_REQUIRE(external_spk_man);
+    BOOST_REQUIRE(wallet->HasPendingInitialKeyPoolTopUp());
+
+    auto& database{dynamic_cast<SQLiteDatabase&>(wallet->GetDatabase())};
+    int notification_count{0};
+    bool callback_can_get_addresses{false};
+    std::atomic_bool writer_succeeded{false};
+    std::promise<void> wallet_lock_acquired;
+    auto wallet_lock_acquired_future{wallet_lock_acquired.get_future()};
+    std::thread writer;
+
+    auto connection = external_spk_man->NotifyCanGetAddressesChanged.connect([&] {
+        ++notification_count;
+        BOOST_CHECK(LockStackEmpty());
+        BOOST_CHECK(!database.HasActiveTxn());
+
+        writer = std::thread([&] {
+            LOCK(wallet->cs_wallet);
+            wallet_lock_acquired.set_value();
+            WalletBatch batch{wallet->GetDatabase()};
+            writer_succeeded = batch.WriteOrderPosNext(1);
+        });
+        wallet_lock_acquired_future.wait();
+        callback_can_get_addresses = wallet->CanGetAddresses();
+    });
+
+    BOOST_CHECK(wallet->RunPendingInitialKeyPoolTopUpStep() == CWallet::PendingInitialKeyPoolTopUpStepResult::PENDING);
+    BOOST_REQUIRE(writer.joinable());
+    writer.join();
+
+    BOOST_CHECK_EQUAL(notification_count, 1);
+    BOOST_CHECK(callback_can_get_addresses);
+    BOOST_CHECK(writer_succeeded);
+
+    TestUnloadWallet(std::move(wallet));
+}
 
 BOOST_FIXTURE_TEST_CASE(CreateWalletWarmsP2MRKeypoolThenDefersFullTopUp, RegtestDefaultWalletTestingSetup)
 {
@@ -400,6 +449,96 @@ BOOST_FIXTURE_TEST_CASE(LoadWalletUnlockRefillsDeferredP2MRKeypoolForEncryptedWa
 
     BOOST_CHECK(RemoveWallet(context, loaded_wallet, std::nullopt));
     WaitForDeleteWallet(std::move(loaded_wallet));
+}
+
+BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSchedulesDeferredP2MRKeypoolTopUp, RegtestP2MROnlyWalletTestingSetup)
+{
+    constexpr int64_t keypool_size{64};
+    const SecureString passphrase{"test-passphrase"};
+    m_args.ForceSetArg("-keypool", util::ToString(keypool_size));
+    DeferredCreateKeyPoolTopUpBatchStepOverride batch_step_override{1};
+
+    WalletContext context;
+    context.args = &m_args;
+    context.chain = m_node.chain.get();
+    context.scheduler = Assert(m_node.scheduler).get();
+
+    DatabaseOptions options;
+    options.require_create = true;
+    options.create_flags = WALLET_FLAG_DESCRIPTORS;
+    options.create_passphrase = passphrase;
+
+    DatabaseStatus status;
+    bilingual_str error;
+    std::vector<bilingual_str> warnings;
+    auto wallet = CreateWallet(context, "interface_unlock_refill_test", std::nullopt, options, status, error, warnings);
+    BOOST_REQUIRE(wallet);
+    BOOST_REQUIRE_EQUAL(status, DatabaseStatus::SUCCESS);
+    BOOST_REQUIRE(wallet->IsLocked());
+    BOOST_REQUIRE(wallet->HasPendingInitialKeyPoolTopUp());
+
+    auto* external_spk_man = WITH_LOCK(wallet->cs_wallet, return dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/false)));
+    auto* internal_spk_man = WITH_LOCK(wallet->cs_wallet, return dynamic_cast<DescriptorScriptPubKeyMan*>(wallet->GetScriptPubKeyMan(OutputType::P2MR, /*internal=*/true)));
+    BOOST_REQUIRE(external_spk_man);
+    BOOST_REQUIRE(internal_spk_man);
+
+    auto& scheduler{*Assert(m_node.scheduler)};
+    std::promise<void> scheduler_blocked;
+    std::promise<void> release_scheduler;
+    auto release_scheduler_future{release_scheduler.get_future()};
+    scheduler.scheduleFromNow([&] {
+        scheduler_blocked.set_value();
+        release_scheduler_future.wait();
+    }, std::chrono::milliseconds{0});
+    scheduler_blocked.get_future().wait();
+
+    auto wallet_interface{interfaces::MakeWallet(context, wallet)};
+    BOOST_REQUIRE(wallet_interface);
+    BOOST_REQUIRE(wallet_interface->unlock(passphrase));
+    BOOST_CHECK(!wallet->IsLocked());
+    BOOST_CHECK(wallet->HasPendingInitialKeyPoolTopUp());
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL);
+    BOOST_CHECK_EQUAL(internal_spk_man->GetKeyPoolSize(), DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL);
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_CHECK(wallet->m_deferred_create_keypool_top_up_scheduled);
+    }
+
+    // Repeated scheduling while the first worker is pending must be a no-op.
+    MaybeSchedulePendingInitialKeyPoolTopUp(context, wallet);
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_CHECK(wallet->m_deferred_create_keypool_top_up_scheduled);
+    }
+
+    // Relocking before the worker runs must pause it and make a later unlock
+    // able to schedule a fresh worker.
+    BOOST_REQUIRE(wallet_interface->lock());
+    release_scheduler.set_value();
+    WaitForScheduler(scheduler);
+    BOOST_CHECK(wallet->IsLocked());
+    BOOST_CHECK(wallet->HasPendingInitialKeyPoolTopUp());
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_CHECK(!wallet->m_deferred_create_keypool_top_up_scheduled);
+    }
+
+    BOOST_REQUIRE(wallet_interface->unlock(passphrase));
+    for (int i = 0; i < 10 && wallet->HasPendingInitialKeyPoolTopUp(); ++i) {
+        WaitForScheduler(scheduler);
+    }
+
+    BOOST_CHECK(!wallet->HasPendingInitialKeyPoolTopUp());
+    BOOST_CHECK_EQUAL(external_spk_man->GetKeyPoolSize(), keypool_size);
+    BOOST_CHECK_EQUAL(internal_spk_man->GetKeyPoolSize(), keypool_size);
+    {
+        LOCK(wallet->cs_wallet);
+        BOOST_CHECK(!wallet->m_deferred_create_keypool_top_up_scheduled);
+    }
+
+    wallet_interface.reset();
+    BOOST_CHECK(RemoveWallet(context, wallet, std::nullopt));
+    WaitForDeleteWallet(std::move(wallet));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
@@ -151,8 +151,11 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSerializesDeferredTopUpCachePublica
     std::atomic_bool pause_next_publication{true};
     std::atomic_bool publication_lock_stack_empty{false};
     std::atomic_bool publication_transaction_inactive{false};
-    wallet->m_before_script_pub_key_cache_publish = [&] {
+    std::set<CScript> unpublished_scripts;
+    wallet->m_before_script_pub_key_cache_publish = [&](const std::set<CScript>& spks, ScriptPubKeyMan* spk_man) {
+        if (spk_man != external_spk_man) return;
         if (!pause_next_publication.exchange(false)) return;
+        unpublished_scripts = spks;
         publication_lock_stack_empty = LockStackEmpty();
         publication_transaction_inactive = !database.HasActiveTxn();
         publication_ready.set_value();
@@ -175,7 +178,8 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSerializesDeferredTopUpCachePublica
 
     // Descriptor state and its transaction are complete, but the new script
     // remains invisible until the publication batch acquires cs_wallet.
-    const CScript new_script{GetCachedScriptPubKey(*external_spk_man, DEFAULT_CREATE_WALLET_P2MR_WARM_KEYPOOL)};
+    BOOST_REQUIRE_EQUAL(unpublished_scripts.size(), 1U);
+    const CScript new_script{*unpublished_scripts.begin()};
     std::promise<void> reader_locked;
     std::promise<void> run_reader_checks;
     auto run_reader_checks_future{run_reader_checks.get_future()};

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -569,6 +569,8 @@ BOOST_AUTO_TEST_CASE(DescriptorTopUpResultRestoresMemoryAfterWriteFailure)
     auto& database = GetMockableDatabase(wallet);
     const unsigned int previous_size{spk_man->GetKeyPoolSize()};
     const unsigned int target_size{previous_size + 1};
+    int notification_count{0};
+    auto connection = spk_man->NotifyCanGetAddressesChanged.connect([&] { ++notification_count; });
     database.ResetCounts();
     database.m_write_fail_after = 0;
 
@@ -577,12 +579,14 @@ BOOST_AUTO_TEST_CASE(DescriptorTopUpResultRestoresMemoryAfterWriteFailure)
     BOOST_CHECK_EQUAL(database.m_txn_abort_count, 1);
     BOOST_CHECK_EQUAL(database.m_txn_commit_count, 0);
     BOOST_CHECK_EQUAL(spk_man->GetKeyPoolSize(), previous_size);
+    BOOST_CHECK_EQUAL(notification_count, 0);
 
     database.ResetCounts();
     database.m_write_fail_after = -1;
     auto retry_res{spk_man->TopUpWithInternalHintResult(/*internal_hint=*/false, target_size)};
     BOOST_REQUIRE_MESSAGE(retry_res.has_value(), util::ErrorString(retry_res).original);
     BOOST_CHECK_EQUAL(spk_man->GetKeyPoolSize(), target_size);
+    BOOST_CHECK_EQUAL(notification_count, 1);
 }
 
 BOOST_AUTO_TEST_CASE(DescriptorSetupPropagatesTopUpWithDBWriteFailure)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -383,15 +383,18 @@ void RunScheduledPendingInitialKeyPoolTopUp(const std::shared_ptr<DeferredCreate
     }
     const auto step_result = wallet->RunPendingInitialKeyPoolTopUpStep();
     if (step_result == CWallet::PendingInitialKeyPoolTopUpStepResult::COMPLETE) {
+        WITH_LOCK(wallet->cs_wallet, wallet->m_deferred_create_keypool_top_up_scheduled = false);
         wallet->WalletLogPrintf("Deferred create-time keypool top up completed in %15dms\n",
             Ticks<std::chrono::milliseconds>(SteadyClock::now() - *state->refill_start));
         return;
     }
     if (step_result == CWallet::PendingInitialKeyPoolTopUpStepResult::FAILED) {
+        WITH_LOCK(wallet->cs_wallet, wallet->m_deferred_create_keypool_top_up_scheduled = false);
         wallet->WalletLogPrintf("Deferred create-time keypool top up paused after a failed background step\n");
         return;
     }
     if (wallet->IsLocked() || !wallet->HasPendingInitialKeyPoolTopUp()) {
+        WITH_LOCK(wallet->cs_wallet, wallet->m_deferred_create_keypool_top_up_scheduled = false);
         return;
     }
     if (--state->remaining_steps == 0) {
@@ -402,10 +405,16 @@ void RunScheduledPendingInitialKeyPoolTopUp(const std::shared_ptr<DeferredCreate
     state->scheduler->scheduleFromNow([state] { RunScheduledPendingInitialKeyPoolTopUp(state); }, std::chrono::milliseconds{1});
 }
 
-void SchedulePendingInitialKeyPoolTopUp(WalletContext& context, const std::shared_ptr<CWallet>& wallet)
+void SchedulePendingInitialKeyPoolTopUp(WalletContext& context, const std::shared_ptr<CWallet>& wallet, std::chrono::milliseconds delay)
 {
-    if (!context.scheduler || wallet->IsLocked() || !wallet->HasPendingInitialKeyPoolTopUp()) {
-        return;
+    if (!context.scheduler) return;
+
+    {
+        LOCK(wallet->cs_wallet);
+        if (wallet->m_deferred_create_keypool_top_up_scheduled || wallet->IsLocked() || !wallet->HasPendingInitialKeyPoolTopUp()) {
+            return;
+        }
+        wallet->m_deferred_create_keypool_top_up_scheduled = true;
     }
 
     auto state = std::make_shared<DeferredCreateKeyPoolTopUpState>(DeferredCreateKeyPoolTopUpState{
@@ -414,9 +423,7 @@ void SchedulePendingInitialKeyPoolTopUp(WalletContext& context, const std::share
         .remaining_steps = GetDeferredCreateKeyPoolTopUpStepsPerBatch(),
         .refill_start = std::nullopt,
     });
-    // Let wallet creation return and the first address calls finish before background
-    // PQC derivation starts competing for CPU.
-    context.scheduler->scheduleFromNow([state] { RunScheduledPendingInitialKeyPoolTopUp(state); }, std::chrono::seconds{30});
+    context.scheduler->scheduleFromNow([state] { RunScheduledPendingInitialKeyPoolTopUp(state); }, delay);
 }
 
 void RunScheduledP2MRKeyPoolRefill(const std::shared_ptr<P2MRKeyPoolRefillState>& state)
@@ -550,7 +557,9 @@ std::shared_ptr<CWallet> LoadWalletInternal(WalletContext& context, const std::s
         AddWallet(context, wallet);
         wallet->postInitProcess();
         if (context.scheduler) SchedulePlaintextPQCKeyValidationInternal(*context.scheduler, wallet);
-        SchedulePendingInitialKeyPoolTopUp(context, wallet);
+        // Let wallet loading return and initial address calls finish before
+        // background PQC derivation starts competing for CPU.
+        SchedulePendingInitialKeyPoolTopUp(context, wallet, std::chrono::seconds{30});
 
         // Write the wallet setting
         UpdateWalletSetting(*context.chain, name, load_on_start, warnings);
@@ -622,6 +631,11 @@ private:
 void SchedulePlaintextPQCKeyValidation(CScheduler& scheduler, const std::shared_ptr<CWallet>& wallet)
 {
     SchedulePlaintextPQCKeyValidationInternal(scheduler, wallet);
+}
+
+void MaybeSchedulePendingInitialKeyPoolTopUp(WalletContext& context, const std::shared_ptr<CWallet>& wallet)
+{
+    SchedulePendingInitialKeyPoolTopUp(context, wallet, std::chrono::milliseconds{1});
 }
 
 void MaybeScheduleP2MRKeyPoolRefill(WalletContext& context, const std::shared_ptr<CWallet>& wallet, OutputType type, bool internal)
@@ -732,7 +746,9 @@ std::shared_ptr<CWallet> CreateWallet(WalletContext& context, const std::string&
     NotifyWalletLoaded(context, wallet);
     AddWallet(context, wallet);
     wallet->postInitProcess();
-    SchedulePendingInitialKeyPoolTopUp(context, wallet);
+    // Let wallet creation return and initial address calls finish before
+    // background PQC derivation starts competing for CPU.
+    SchedulePendingInitialKeyPoolTopUp(context, wallet, std::chrono::seconds{30});
 
     // Write the wallet settings
     UpdateWalletSetting(*context.chain, name, load_on_start, warnings);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -356,6 +356,7 @@ struct DeferredCreateKeyPoolTopUpState {
     CScheduler* scheduler;
     int remaining_steps;
     std::optional<SteadyClock::time_point> refill_start;
+    std::function<void()> step_finished_fn;
 };
 
 struct P2MRKeyPoolRefillState {
@@ -382,19 +383,32 @@ void RunScheduledPendingInitialKeyPoolTopUp(const std::shared_ptr<DeferredCreate
         state->refill_start = SteadyClock::now();
     }
     const auto step_result = wallet->RunPendingInitialKeyPoolTopUpStep();
-    if (step_result == CWallet::PendingInitialKeyPoolTopUpStepResult::COMPLETE) {
-        WITH_LOCK(wallet->cs_wallet, wallet->m_deferred_create_keypool_top_up_scheduled = false);
-        wallet->WalletLogPrintf("Deferred create-time keypool top up completed in %15dms\n",
-            Ticks<std::chrono::milliseconds>(SteadyClock::now() - *state->refill_start));
-        return;
+    if (state->step_finished_fn) {
+        state->step_finished_fn();
     }
-    if (step_result == CWallet::PendingInitialKeyPoolTopUpStepResult::FAILED) {
-        WITH_LOCK(wallet->cs_wallet, wallet->m_deferred_create_keypool_top_up_scheduled = false);
-        wallet->WalletLogPrintf("Deferred create-time keypool top up paused after a failed background step\n");
-        return;
+
+    bool continue_refill{false};
+    {
+        LOCK(wallet->cs_wallet);
+        const bool can_continue{!wallet->IsLocked() && wallet->HasPendingInitialKeyPoolTopUp()};
+        if (can_continue &&
+            (step_result == CWallet::PendingInitialKeyPoolTopUpStepResult::PENDING ||
+             wallet->m_deferred_create_keypool_top_up_reschedule_requested)) {
+            wallet->m_deferred_create_keypool_top_up_reschedule_requested = false;
+            continue_refill = true;
+        } else {
+            wallet->m_deferred_create_keypool_top_up_scheduled = false;
+            wallet->m_deferred_create_keypool_top_up_reschedule_requested = false;
+        }
     }
-    if (wallet->IsLocked() || !wallet->HasPendingInitialKeyPoolTopUp()) {
-        WITH_LOCK(wallet->cs_wallet, wallet->m_deferred_create_keypool_top_up_scheduled = false);
+
+    if (!continue_refill) {
+        if (step_result == CWallet::PendingInitialKeyPoolTopUpStepResult::COMPLETE) {
+            wallet->WalletLogPrintf("Deferred create-time keypool top up completed in %15dms\n",
+                Ticks<std::chrono::milliseconds>(SteadyClock::now() - *state->refill_start));
+        } else if (step_result == CWallet::PendingInitialKeyPoolTopUpStepResult::FAILED) {
+            wallet->WalletLogPrintf("Deferred create-time keypool top up paused after a failed background step\n");
+        }
         return;
     }
     if (--state->remaining_steps == 0) {
@@ -411,10 +425,18 @@ void SchedulePendingInitialKeyPoolTopUp(WalletContext& context, const std::share
 
     {
         LOCK(wallet->cs_wallet);
-        if (wallet->m_deferred_create_keypool_top_up_scheduled || wallet->IsLocked() || !wallet->HasPendingInitialKeyPoolTopUp()) {
+        if (wallet->IsLocked() || !wallet->HasPendingInitialKeyPoolTopUp()) {
+            return;
+        }
+        if (wallet->m_deferred_create_keypool_top_up_scheduled) {
+            // Record the unlock/scheduling attempt so a worker that is about
+            // to retire hands ownership to a replacement instead of clearing
+            // the deduplication flag after the attempt returns.
+            wallet->m_deferred_create_keypool_top_up_reschedule_requested = true;
             return;
         }
         wallet->m_deferred_create_keypool_top_up_scheduled = true;
+        wallet->m_deferred_create_keypool_top_up_reschedule_requested = false;
     }
 
     auto state = std::make_shared<DeferredCreateKeyPoolTopUpState>(DeferredCreateKeyPoolTopUpState{
@@ -422,6 +444,7 @@ void SchedulePendingInitialKeyPoolTopUp(WalletContext& context, const std::share
         .scheduler = context.scheduler,
         .remaining_steps = GetDeferredCreateKeyPoolTopUpStepsPerBatch(),
         .refill_start = std::nullopt,
+        .step_finished_fn = context.deferred_keypool_top_up_step_finished_fn,
     });
     context.scheduler->scheduleFromNow([state] { RunScheduledPendingInitialKeyPoolTopUp(state); }, delay);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4588,6 +4588,7 @@ ScriptPubKeyMan* CWallet::GetScriptPubKeyMan(const OutputType& type, bool intern
 
 std::set<ScriptPubKeyMan*> CWallet::GetScriptPubKeyMans(const CScript& script) const
 {
+    AssertLockHeld(cs_wallet);
     std::set<ScriptPubKeyMan*> spk_mans;
 
     // Search the cache for relevant SPKMs instead of iterating m_spk_managers
@@ -4617,6 +4618,7 @@ std::unique_ptr<SigningProvider> CWallet::GetSolvingProvider(const CScript& scri
 
 std::unique_ptr<SigningProvider> CWallet::GetSolvingProvider(const CScript& script, SignatureData& sigdata) const
 {
+    LOCK(cs_wallet);
     // Search the cache for relevant SPKMs instead of iterating m_spk_managers
     const auto& it = m_cached_spks.find(script);
     if (it != m_cached_spks.end()) {
@@ -4630,6 +4632,7 @@ std::unique_ptr<SigningProvider> CWallet::GetSolvingProvider(const CScript& scri
 
 std::vector<WalletDescriptor> CWallet::GetWalletDescriptors(const CScript& script) const
 {
+    LOCK(cs_wallet);
     std::vector<WalletDescriptor> descs;
     for (const auto spk_man: GetScriptPubKeyMans(script)) {
         if (const auto desc_spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(spk_man)) {
@@ -5103,8 +5106,8 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
     // When the legacy wallet has no spendable scripts, the main wallet will be empty, leaving its script cache empty as well.
     // The watch-only and/or solvable wallet(s) will contain the scripts in their respective caches.
     if (!data.desc_spkms.empty()) Assume(!m_cached_spks.empty());
-    if (!data.watch_descs.empty()) Assume(!data.watchonly_wallet->m_cached_spks.empty());
-    if (!data.solvable_descs.empty()) Assume(!data.solvable_wallet->m_cached_spks.empty());
+    if (!data.watch_descs.empty()) Assume(WITH_LOCK(data.watchonly_wallet->cs_wallet, return !data.watchonly_wallet->m_cached_spks.empty()));
+    if (!data.solvable_descs.empty()) Assume(WITH_LOCK(data.solvable_wallet->cs_wallet, return !data.solvable_wallet->m_cached_spks.empty()));
 
     for (auto& desc_spkm : data.desc_spkms) {
         if (m_spk_managers.count(desc_spkm->GetID()) > 0) {
@@ -5666,6 +5669,10 @@ void CWallet::CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyM
 
 void CWallet::TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm)
 {
+    if (m_before_script_pub_key_cache_publish) {
+        m_before_script_pub_key_cache_publish();
+    }
+    LOCK(cs_wallet);
     // Update scriptPubKey cache
     CacheNewScriptPubKeys(spks, spkm);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -5670,7 +5670,7 @@ void CWallet::CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyM
 void CWallet::TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm)
 {
     if (m_before_script_pub_key_cache_publish) {
-        m_before_script_pub_key_cache_publish();
+        m_before_script_pub_key_cache_publish(spks, spkm);
     }
     LOCK(cs_wallet);
     // Update scriptPubKey cache

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -106,6 +106,7 @@ std::shared_ptr<CWallet> RestoreWallet(WalletContext& context, const fs::path& b
 std::unique_ptr<interfaces::Handler> HandleLoadWallet(WalletContext& context, LoadWalletFn load_wallet);
 void NotifyWalletLoaded(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
 void SchedulePlaintextPQCKeyValidation(CScheduler& scheduler, const std::shared_ptr<CWallet>& wallet);
+void MaybeSchedulePendingInitialKeyPoolTopUp(WalletContext& context, const std::shared_ptr<CWallet>& wallet);
 void MaybeScheduleP2MRKeyPoolRefill(WalletContext& context, const std::shared_ptr<CWallet>& wallet, OutputType type, bool internal);
 std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error);
 
@@ -821,6 +822,7 @@ public:
 
     /** Number of pre-generated keys/scripts by each spkm (part of the look-ahead process, used to detect payments) */
     int64_t m_keypool_size{DEFAULT_KEYPOOL_SIZE};
+    bool m_deferred_create_keypool_top_up_scheduled GUARDED_BY(cs_wallet){false};
     bool m_p2mr_receive_keypool_refill_scheduled GUARDED_BY(cs_wallet){false};
     bool m_p2mr_change_keypool_refill_scheduled GUARDED_BY(cs_wallet){false};
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -493,7 +493,7 @@ private:
     void SetWalletFlagWithDB(WalletBatch& batch, uint64_t flags);
 
     //! Cache of descriptor ScriptPubKeys used for IsMine. Maps ScriptPubKey to set of spkms
-    std::unordered_map<CScript, std::vector<ScriptPubKeyMan*>, SaltedSipHasher> m_cached_spks;
+    std::unordered_map<CScript, std::vector<ScriptPubKeyMan*>, SaltedSipHasher> m_cached_spks GUARDED_BY(cs_wallet);
 
     //! Set of both spent and unspent transaction outputs owned by this wallet
     std::unordered_map<COutPoint, WalletTXO, SaltedOutpointHasher> m_txos GUARDED_BY(cs_wallet);
@@ -822,6 +822,11 @@ public:
 
     /** Number of pre-generated keys/scripts by each spkm (part of the look-ahead process, used to detect payments) */
     int64_t m_keypool_size{DEFAULT_KEYPOOL_SIZE};
+    // Optional deterministic test hook invoked after descriptor persistence
+    // and before script cache publication takes cs_wallet. Configure it before
+    // starting concurrent wallet work and leave it unchanged until that work
+    // completes.
+    std::function<void()> m_before_script_pub_key_cache_publish;
     bool m_deferred_create_keypool_top_up_scheduled GUARDED_BY(cs_wallet){false};
     bool m_deferred_create_keypool_top_up_reschedule_requested GUARDED_BY(cs_wallet){false};
     bool m_p2mr_receive_keypool_refill_scheduled GUARDED_BY(cs_wallet){false};
@@ -1063,7 +1068,7 @@ public:
     ScriptPubKeyMan* GetScriptPubKeyMan(const OutputType& type, bool internal) const;
 
     //! Get all the ScriptPubKeyMans for a script
-    std::set<ScriptPubKeyMan*> GetScriptPubKeyMans(const CScript& script) const;
+    std::set<ScriptPubKeyMan*> GetScriptPubKeyMans(const CScript& script) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Get the ScriptPubKeyMan by id
     ScriptPubKeyMan* GetScriptPubKeyMan(const uint256& id) const;
 
@@ -1169,7 +1174,7 @@ public:
     bool CanGrindR() const;
 
     //! Add scriptPubKeys for this ScriptPubKeyMan into the scriptPubKey cache
-    void CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm);
+    void CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     void TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm) override;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -823,6 +823,7 @@ public:
     /** Number of pre-generated keys/scripts by each spkm (part of the look-ahead process, used to detect payments) */
     int64_t m_keypool_size{DEFAULT_KEYPOOL_SIZE};
     bool m_deferred_create_keypool_top_up_scheduled GUARDED_BY(cs_wallet){false};
+    bool m_deferred_create_keypool_top_up_reschedule_requested GUARDED_BY(cs_wallet){false};
     bool m_p2mr_receive_keypool_refill_scheduled GUARDED_BY(cs_wallet){false};
     bool m_p2mr_change_keypool_refill_scheduled GUARDED_BY(cs_wallet){false};
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -826,7 +826,7 @@ public:
     // and before script cache publication takes cs_wallet. Configure it before
     // starting concurrent wallet work and leave it unchanged until that work
     // completes.
-    std::function<void()> m_before_script_pub_key_cache_publish;
+    std::function<void(const std::set<CScript>&, ScriptPubKeyMan*)> m_before_script_pub_key_cache_publish;
     bool m_deferred_create_keypool_top_up_scheduled GUARDED_BY(cs_wallet){false};
     bool m_deferred_create_keypool_top_up_reschedule_requested GUARDED_BY(cs_wallet){false};
     bool m_p2mr_receive_keypool_refill_scheduled GUARDED_BY(cs_wallet){false};

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -116,9 +116,13 @@ class TestBitcoinCli(BitcoinTestFramework):
         initial_balance = (BLOCKS - COINBASE_MATURITY) * block_subsidy
 
         self.log.info("Compare responses from getblockchaininfo RPC and `qbit-cli getblockchaininfo`")
-        cli_response = self.nodes[0].cli.getblockchaininfo()
-        rpc_response = self.nodes[0].getblockchaininfo()
-        assert_equal(cli_response, rpc_response)
+        self.nodes[0].setmocktime(int(time.time()))
+        try:
+            cli_response = self.nodes[0].cli.getblockchaininfo()
+            rpc_response = self.nodes[0].getblockchaininfo()
+            assert_equal(cli_response, rpc_response)
+        finally:
+            self.nodes[0].setmocktime(0)
 
         self.log.info("Test named arguments")
         assert_equal(self.nodes[0].cli.echo(0, 1, arg3=3, arg5=5), ['0', '1', None, '3', None, '5'])


### PR DESCRIPTION
## Summary

Fixes #138.

This removes the wallet/SQLite lock cycle that could freeze `qbit-qt` immediately after a correct passphrase was entered.

- publish address-availability changes only after descriptor locks and database transactions have been released or committed
- deliver the Qt notification through an explicit queued connection
- let interface unlock return promptly and refill a pending initial P2MR keypool through deduplicated scheduler steps
- cover commit timing, lock ordering, relocking, duplicate scheduling, failed transactions, and queued Qt delivery with regressions

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands/checks:

- `cmake --build build_dev_mode --target test_bitcoin test_bitcoin-qt qbitd qbit-cli -j8`
- `wallet_tests/DescriptorTopUp*`
- `wallet_p2mr_deferred_keypool_tests/*`
- `wallet_p2mr_receive_keypool_tests/*`
- `wallet_p2mr_change_keypool_tests/*`
- `wallet_p2mr_markunused_tests/*`
- `test/functional/wallet_keypool_topup.py`
- full `ci/lint/06_script.sh` through the Ubuntu 24.04 Docker lint image

The new Qt regression compiled successfully. It was not independently executed because the macOS Qt test runner fails in a pre-existing `AppTests` case before reaching `WalletTests`.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.x.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

This changes wallet notification timing and the interface unlock path. Direct wallet/RPC unlock behavior remains unchanged. Review should focus on transaction-listener lifetime, scheduler deduplication/reset behavior, and lock ordering around `cs_wallet`, `cs_desc_man`, and the SQLite writer.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this restores intended unlock responsiveness and changes only internal wallet maintenance scheduling and notification timing.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786894198&installation_id=141183937&pr_number=143&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F143&signature=2469c194620c2fa3beae0bb2aae0e787343a2deeb5c8bbe3ac84598720fc1c30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches wallet unlock, keypool top-up, lock ordering around `cs_wallet`/`cs_desc_man`/SQLite, and address-availability notifications—areas that can deadlock or affect address generation.
> 
> **Overview**
> Fixes a deadlock that could freeze `qbit-qt` right after a correct passphrase unlock by breaking the wallet/SQLite lock cycle around deferred P2MR keypool top-up.
> 
> **Descriptor top-ups** now persist under `cs_desc_man`, then publish new scripts and `NotifyCanGetAddressesChanged` only after that lock is released and any caller DB transaction has committed (or via a commit listener). Failed top-ups no longer notify.
> 
> **Interface unlock** returns promptly without running the pending initial refill inline. It schedules a deduplicated background worker that can be paused on relock and resumed on later unlock. Qt delivers `canGetAddressesChanged` through an explicit **queued** connection.
> 
> Adds regressions for commit-vs-abort publication, lock-order safety, unlock/relock scheduling races, failed top-ups, and queued Qt notification delivery. Also tightens a few related `cs_wallet` lock annotations/acquisitions around script-cache reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67ba28116e32b5412c271ac5363fb0f09beb4d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->