### PR TITLE
wallet: publish descriptor top-ups after commit

### DIFF
--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -23,19 +23,21 @@ using common::PSBTError;
 namespace wallet {
 bool ExternalSignerScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, std::unique_ptr<Descriptor> desc)
 {
-    LOCK(cs_desc_man);
-    assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
-    assert(m_storage.IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
+    {
+        LOCK(cs_desc_man);
+        assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
+        assert(m_storage.IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER));
 
-    int64_t creation_time = GetTime();
+        int64_t creation_time = GetTime();
 
-    // Make the descriptor
-    WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
-    m_wallet_descriptor = w_desc;
+        // Make the descriptor
+        WalletDescriptor w_desc(std::move(desc), creation_time, 0, 0, 0);
+        m_wallet_descriptor = w_desc;
 
-    // Store the descriptor
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+        // Store the descriptor
+        if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+            throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+        }
     }
 
     // TopUp

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -927,6 +927,7 @@ std::optional<MigrationData> LegacyDataSPKM::MigrateToDescriptor()
 
     // Finalize transaction
     if (!batch.TxnCommit()) {
+        if (batch.HasActiveTxn()) batch.TxnAbort();
         LogPrintf("Error generating descriptors for migration, cannot commit db transaction\n");
         return std::nullopt;
     }
@@ -1212,22 +1213,35 @@ DescriptorScriptPubKeyMan::TopUpPreparation DescriptorScriptPubKeyMan::PrepareTo
 util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResult(std::optional<bool> internal_hint, unsigned int size)
 {
     const TopUpPreparation prepared{PrepareTopUp(internal_hint)};
-    LOCK(cs_desc_man);
-    // Keep descriptor and database lock ordering aligned with address reservation.
-    WalletBatch batch(m_storage.GetDatabase());
-    if (!batch.TxnBegin()) {
-        return util::Error{_("Error starting descriptors keypool top-up database transaction")};
-    }
-    util::Result<void> res{TopUpWithDBPreparedResult(batch, size, prepared, /*throw_on_persistence_error=*/false, /*rollback_state_on_error=*/true)};
-    if (!res) {
-        if (!batch.TxnAbort()) {
-            throw std::runtime_error(strprintf(
-                "Error during descriptors keypool top up. Cannot abort changes for wallet [%s]: %s",
-                m_storage.LogName(), util::ErrorString(res).original));
+    std::shared_ptr<TopUpChange> change;
+    {
+        LOCK(cs_desc_man);
+        // Keep descriptor and database lock ordering aligned with address reservation.
+        WalletBatch batch(m_storage.GetDatabase());
+        if (!batch.TxnBegin()) {
+            return util::Error{_("Error starting descriptors keypool top-up database transaction")};
         }
-        return res;
+        util::Result<std::shared_ptr<TopUpChange>> res{TopUpWithDBPreparedResult(batch, size, prepared, /*throw_on_persistence_error=*/false, /*rollback_state_on_error=*/true)};
+        if (!res) {
+            if (!batch.TxnAbort()) {
+                throw std::runtime_error(strprintf(
+                    "Error during descriptors keypool top up. Cannot abort changes for wallet [%s]: %s",
+                    m_storage.LogName(), util::ErrorString(res).original));
+            }
+            return util::Error{util::ErrorString(res)};
+        }
+        change = *res;
+        if (!batch.TxnCommit()) {
+            const bool aborted{!batch.HasActiveTxn() || batch.TxnAbort()};
+            change->rollback();
+            if (!aborted) {
+                throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot abort changes after commit failure for wallet [%s]", m_storage.LogName()));
+            }
+            throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet [%s]", m_storage.LogName()));
+        }
     }
-    if (!batch.TxnCommit()) throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet [%s]", m_storage.LogName()));
+
+    PublishTopUp(*change);
     return {};
 }
 
@@ -1239,27 +1253,56 @@ bool DescriptorScriptPubKeyMan::TopUpWithDB(WalletBatch& batch, unsigned int siz
 util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBResult(WalletBatch& batch, unsigned int size, std::optional<bool> internal_hint, bool throw_on_persistence_error, bool rollback_state_on_error)
 {
     const TopUpPreparation prepared{PrepareTopUp(internal_hint)};
-    LOCK(cs_desc_man);
-    return TopUpWithDBPreparedResult(batch, size, prepared, throw_on_persistence_error, rollback_state_on_error);
+    std::shared_ptr<TopUpChange> change;
+    {
+        LOCK(cs_desc_man);
+        util::Result<std::shared_ptr<TopUpChange>> res{TopUpWithDBPreparedResult(batch, size, prepared, throw_on_persistence_error, rollback_state_on_error || batch.HasActiveTxn())};
+        if (!res) return util::Error{util::ErrorString(res)};
+        change = *res;
+        if (batch.HasActiveTxn()) {
+            try {
+                RegisterTopUpTxnListener(batch, change);
+            } catch (...) {
+                change->rollback();
+                throw;
+            }
+            return {};
+        }
+    }
+
+    PublishTopUp(*change);
+    return {};
 }
 
-util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error)
+util::Result<std::shared_ptr<DescriptorScriptPubKeyMan::TopUpChange>> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error)
 {
     AssertLockHeld(cs_desc_man);
-    const int32_t old_range_start{m_wallet_descriptor.range_start};
-    const int32_t old_range_end{m_wallet_descriptor.range_end};
-    const std::optional<bool> old_descriptor_deferred_create_keypool_top_up{m_wallet_descriptor.deferred_create_keypool_top_up};
-    const int32_t old_max_cached_index{m_max_cached_index};
-    const bool old_deferred_create_keypool_top_up{m_deferred_create_keypool_top_up};
-    DescriptorCache added_cache_items;
-    std::map<CScript, std::optional<int32_t>> old_script_pub_key_values;
-    std::set<CPubKey> added_pubkeys;
     struct OldPQCKeyState {
         std::optional<CPQCKey> key;
         std::optional<CryptedPQCKeyRecord> crypted_key;
         std::optional<uint32_t> sig_counter;
     };
-    std::map<CPQCPubKey, OldPQCKeyState> old_pqc_key_values;
+    struct TopUpRollbackState {
+        int32_t old_range_start;
+        int32_t old_range_end;
+        std::optional<bool> old_descriptor_deferred_create_keypool_top_up;
+        int32_t old_max_cached_index;
+        bool old_deferred_create_keypool_top_up;
+        DescriptorCache added_cache_items;
+        std::map<CScript, std::optional<int32_t>> old_script_pub_key_values;
+        std::set<CPubKey> added_pubkeys;
+        std::map<CPQCPubKey, OldPQCKeyState> old_pqc_key_values;
+    };
+    auto rollback_state{std::make_shared<TopUpRollbackState>(
+        m_wallet_descriptor.range_start,
+        m_wallet_descriptor.range_end,
+        m_wallet_descriptor.deferred_create_keypool_top_up,
+        m_max_cached_index,
+        m_deferred_create_keypool_top_up)};
+    DescriptorCache& added_cache_items{rollback_state->added_cache_items};
+    auto& old_script_pub_key_values{rollback_state->old_script_pub_key_values};
+    auto& added_pubkeys{rollback_state->added_pubkeys};
+    auto& old_pqc_key_values{rollback_state->old_pqc_key_values};
     bool has_persisted_top_up_writes{false};
     const auto remember_script_pub_key = [&](const CScript& script) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) {
         if (old_script_pub_key_values.contains(script)) return;
@@ -1280,23 +1323,23 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
         }
         old_pqc_key_values.emplace(pubkey, std::move(state));
     };
-    const auto restore_top_up_state = [&]() EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) {
-        m_wallet_descriptor.range_start = old_range_start;
-        m_wallet_descriptor.range_end = old_range_end;
-        m_wallet_descriptor.deferred_create_keypool_top_up = old_descriptor_deferred_create_keypool_top_up;
-        m_wallet_descriptor.cache.Remove(added_cache_items);
-        m_max_cached_index = old_max_cached_index;
-        for (const auto& [script, old_index] : old_script_pub_key_values) {
+    const auto restore_top_up_state = [this, rollback_state]() EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) {
+        m_wallet_descriptor.range_start = rollback_state->old_range_start;
+        m_wallet_descriptor.range_end = rollback_state->old_range_end;
+        m_wallet_descriptor.deferred_create_keypool_top_up = rollback_state->old_descriptor_deferred_create_keypool_top_up;
+        m_wallet_descriptor.cache.Remove(rollback_state->added_cache_items);
+        m_max_cached_index = rollback_state->old_max_cached_index;
+        for (const auto& [script, old_index] : rollback_state->old_script_pub_key_values) {
             if (old_index) {
                 m_map_script_pub_keys[script] = *old_index;
             } else {
                 m_map_script_pub_keys.erase(script);
             }
         }
-        for (const CPubKey& pubkey : added_pubkeys) {
+        for (const CPubKey& pubkey : rollback_state->added_pubkeys) {
             m_map_pubkeys.erase(pubkey);
         }
-        for (const auto& [pubkey, old_state] : old_pqc_key_values) {
+        for (const auto& [pubkey, old_state] : rollback_state->old_pqc_key_values) {
             if (old_state.key) {
                 m_map_pqc_keys[pubkey] = *old_state.key;
             } else {
@@ -1313,18 +1356,18 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
                 m_map_pqc_sig_counters.erase(pubkey);
             }
         }
-        m_deferred_create_keypool_top_up = old_deferred_create_keypool_top_up;
+        m_deferred_create_keypool_top_up = rollback_state->old_deferred_create_keypool_top_up;
     };
     const auto restore_top_up_state_if_safe = [&](bool persistence_write_may_have_started) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) {
         if (rollback_state_on_error || (!persistence_write_may_have_started && !has_persisted_top_up_writes)) {
             restore_top_up_state();
         }
     };
-    const auto top_up_error = [&](bilingual_str error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) -> util::Result<void> {
+    const auto top_up_error = [&](bilingual_str error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) -> util::Result<std::shared_ptr<TopUpChange>> {
         restore_top_up_state_if_safe(/*persistence_write_may_have_started=*/false);
         return util::Error{std::move(error)};
     };
-    const auto persistence_error = [&](bilingual_str error, bool persistence_write_may_have_started = true) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) -> util::Result<void> {
+    const auto persistence_error = [&](bilingual_str error, bool persistence_write_may_have_started = true) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) -> util::Result<std::shared_ptr<TopUpChange>> {
         restore_top_up_state_if_safe(persistence_write_may_have_started);
         if (throw_on_persistence_error) throw std::runtime_error(error.original);
         return util::Error{std::move(error)};
@@ -1502,9 +1545,27 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBa
     // By this point, the cache size should be the size of the entire range
     assert(m_wallet_descriptor.range_end - 1 == m_max_cached_index);
 
-    m_storage.TopUpCallback(new_spks, this);
+    auto change{std::make_shared<TopUpChange>()};
+    change->new_spks = std::move(new_spks);
+    change->rollback = restore_top_up_state;
+    return change;
+}
+
+void DescriptorScriptPubKeyMan::PublishTopUp(const TopUpChange& change)
+{
+    m_storage.TopUpCallback(change.new_spks, this);
     NotifyCanGetAddressesChanged();
-    return {};
+}
+
+void DescriptorScriptPubKeyMan::RegisterTopUpTxnListener(WalletBatch& batch, const std::shared_ptr<TopUpChange>& change)
+{
+    batch.RegisterTxnListener({
+        .on_commit = [this, change] { PublishTopUp(*change); },
+        .on_abort = [this, change] {
+            LOCK(cs_desc_man);
+            change->rollback();
+        },
+    });
 }
 
 std::vector<WalletDestination> DescriptorScriptPubKeyMan::MarkUnusedAddresses(const CScript& script, const MarkUnusedAddressesOptions& options)
@@ -2781,33 +2842,35 @@ uint256 DescriptorScriptPubKeyMan::GetID() const
 
 void DescriptorScriptPubKeyMan::SetCache(const DescriptorCache& cache)
 {
-    LOCK(cs_desc_man);
     std::set<CScript> new_spks;
-    m_wallet_descriptor.cache = cache;
-    for (int32_t i = m_wallet_descriptor.range_start; i < m_wallet_descriptor.range_end; ++i) {
-        FlatSigningProvider out_keys;
-        std::vector<CScript> scripts_temp;
-        if (!m_wallet_descriptor.descriptor->ExpandFromCache(i, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
-            throw std::runtime_error("Error: Unable to expand wallet descriptor from cache");
-        }
-        // Add all of the scriptPubKeys to the scriptPubKey set
-        new_spks.insert(scripts_temp.begin(), scripts_temp.end());
-        for (const CScript& script : scripts_temp) {
-            if (m_map_script_pub_keys.count(script) != 0) {
-                throw std::runtime_error(strprintf("Error: Already loaded script at index %d as being at index %d", i, m_map_script_pub_keys[script]));
+    {
+        LOCK(cs_desc_man);
+        m_wallet_descriptor.cache = cache;
+        for (int32_t i = m_wallet_descriptor.range_start; i < m_wallet_descriptor.range_end; ++i) {
+            FlatSigningProvider out_keys;
+            std::vector<CScript> scripts_temp;
+            if (!m_wallet_descriptor.descriptor->ExpandFromCache(i, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
+                throw std::runtime_error("Error: Unable to expand wallet descriptor from cache");
             }
-            m_map_script_pub_keys[script] = i;
-        }
-        for (const auto& pk_pair : out_keys.pubkeys) {
-            const CPubKey& pubkey = pk_pair.second;
-            if (m_map_pubkeys.count(pubkey) != 0) {
-                // We don't need to give an error here.
-                // It doesn't matter which of many valid indexes the pubkey has, we just need an index where we can derive it and its private key
-                continue;
+            // Add all of the scriptPubKeys to the scriptPubKey set
+            new_spks.insert(scripts_temp.begin(), scripts_temp.end());
+            for (const CScript& script : scripts_temp) {
+                if (m_map_script_pub_keys.count(script) != 0) {
+                    throw std::runtime_error(strprintf("Error: Already loaded script at index %d as being at index %d", i, m_map_script_pub_keys[script]));
+                }
+                m_map_script_pub_keys[script] = i;
             }
-            m_map_pubkeys[pubkey] = i;
+            for (const auto& pk_pair : out_keys.pubkeys) {
+                const CPubKey& pubkey = pk_pair.second;
+                if (m_map_pubkeys.count(pubkey) != 0) {
+                    // We don't need to give an error here.
+                    // It doesn't matter which of many valid indexes the pubkey has, we just need an index where we can derive it and its private key
+                    continue;
+                }
+                m_map_pubkeys[pubkey] = i;
+            }
+            m_max_cached_index++;
         }
-        m_max_cached_index++;
     }
     // Make sure the wallet knows about our new spks
     m_storage.TopUpCallback(new_spks, this);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -943,10 +943,17 @@ bool LegacyDataSPKM::DeleteRecordsWithDB(WalletBatch& batch)
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const OutputType type)
 {
+    return GetNewDestinationWithIndex(type, /*index=*/nullptr);
+}
+
+util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestinationWithIndex(const OutputType type, int64_t* index)
+{
     // Returns true if this descriptor supports getting new addresses. Conditions where we may be unable to fetch them (e.g. locked) are caught later
     if (!CanGetAddresses()) {
         return util::Error{_("No addresses available")};
     }
+
+    bool top_up{false};
     {
         LOCK(cs_desc_man);
         assert(m_wallet_descriptor.descriptor->IsSingleType()); // This is a combo descriptor which should not be an active descriptor
@@ -955,33 +962,41 @@ util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetNewDestination(const 
         if (type != *desc_addr_type) {
             throw std::runtime_error(std::string(__func__) + ": Types are inconsistent. Stored type does not match type of newly generated address");
         }
+        top_up = !m_deferred_create_keypool_top_up && !IsRangedP2MRDescriptorNoLock();
+    }
+    if (top_up) TopUp();
 
-        if (!m_deferred_create_keypool_top_up && !IsRangedP2MRDescriptorNoLock()) {
-            TopUp();
+    while (true) {
+        {
+            LOCK(cs_desc_man);
+            if (m_wallet_descriptor.next_index < m_wallet_descriptor.range_end) {
+                // Get the scriptPubKey from the descriptor and reserve its index
+                // atomically after any cache publication has completed.
+                FlatSigningProvider out_keys;
+                std::vector<CScript> scripts_temp;
+                if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
+                    return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
+                }
+
+                CTxDestination dest;
+                if (!ExtractDestination(scripts_temp[0], dest)) {
+                    return util::Error{_("Error: Cannot extract destination from the generated scriptpubkey")}; // shouldn't happen
+                }
+                if (index) *index = m_wallet_descriptor.next_index;
+                m_wallet_descriptor.next_index++;
+                if (IsRangedP2MRDescriptorNoLock() && !m_deferred_create_keypool_top_up) {
+                    m_wallet_descriptor.deferred_create_keypool_top_up = false;
+                }
+                WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
+                return dest;
+            }
         }
 
-        // Get the scriptPubKey from the descriptor
-        FlatSigningProvider out_keys;
-        std::vector<CScript> scripts_temp;
-        if (m_wallet_descriptor.next_index >= m_wallet_descriptor.range_end && !TopUp(1)) {
-            // We can't generate anymore keys
+        // Another address consumer can exhaust the range after a top-up. Retry
+        // outside the descriptor lock instead of returning a spurious failure.
+        if (!TopUp(1)) {
             return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
         }
-        if (!m_wallet_descriptor.descriptor->ExpandFromCache(m_wallet_descriptor.next_index, m_wallet_descriptor.cache, scripts_temp, out_keys)) {
-            // We can't generate anymore keys
-            return util::Error{_("Error: Keypool ran out, please call keypoolrefill first")};
-        }
-
-        CTxDestination dest;
-        if (!ExtractDestination(scripts_temp[0], dest)) {
-            return util::Error{_("Error: Cannot extract destination from the generated scriptpubkey")}; // shouldn't happen
-        }
-        m_wallet_descriptor.next_index++;
-        if (IsRangedP2MRDescriptorNoLock() && !m_deferred_create_keypool_top_up) {
-            m_wallet_descriptor.deferred_create_keypool_top_up = false;
-        }
-        WalletBatch(m_storage.GetDatabase()).WriteDescriptor(GetID(), m_wallet_descriptor);
-        return dest;
     }
 }
 
@@ -1089,13 +1104,10 @@ bool DescriptorScriptPubKeyMan::Encrypt(const CKeyingMaterial& master_key, Walle
 
 util::Result<CTxDestination> DescriptorScriptPubKeyMan::GetReservedDestination(const OutputType type, bool internal, int64_t& index, bool allow_internal_p2mr_refill)
 {
-    LOCK(cs_desc_man);
     if (internal && allow_internal_p2mr_refill) {
         MaybeTopUpInternalP2MRKeyPool();
     }
-    auto op_dest = GetNewDestination(type);
-    index = m_wallet_descriptor.next_index - 1;
-    return op_dest;
+    return GetNewDestinationWithIndex(type, &index);
 }
 
 void DescriptorScriptPubKeyMan::ReturnDestination(int64_t index, bool internal, const CTxDestination& addr)
@@ -1231,14 +1243,36 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResult(std::o
             return util::Error{util::ErrorString(res)};
         }
         change = *res;
-        if (!batch.TxnCommit()) {
+        try {
+            change->publication_id = m_storage.StageTopUpPublication(change->new_spks, this, change->lifetime);
+            m_storage.BeginTopUpCommit(change->publication_id);
+        } catch (...) {
+            if (batch.HasActiveTxn()) batch.TxnAbort();
+            RollbackTopUp(*change->rollback_state);
+            throw;
+        }
+
+        bool committed{false};
+        try {
+            committed = batch.TxnCommit();
+        } catch (...) {
+            m_storage.FinishTopUpCommit(change->publication_id, /*committed=*/false);
+            if (batch.HasActiveTxn()) batch.TxnAbort();
+            m_storage.CancelTopUpPublication(change->publication_id);
+            RollbackTopUp(*change->rollback_state);
+            throw;
+        }
+        if (!committed) {
+            m_storage.FinishTopUpCommit(change->publication_id, /*committed=*/false);
             const bool aborted{!batch.HasActiveTxn() || batch.TxnAbort()};
+            m_storage.CancelTopUpPublication(change->publication_id);
             RollbackTopUp(*change->rollback_state);
             if (!aborted) {
                 throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot abort changes after commit failure for wallet [%s]", m_storage.LogName()));
             }
             throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot commit changes for wallet [%s]", m_storage.LogName()));
         }
+        m_storage.FinishTopUpCommit(change->publication_id, /*committed=*/true);
     }
 
     PublishTopUp(*change);
@@ -1259,14 +1293,20 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBResult(WalletBatch& bat
         util::Result<std::shared_ptr<TopUpChange>> res{TopUpWithDBPreparedResult(batch, size, prepared, throw_on_persistence_error, rollback_state_on_error || batch.HasActiveTxn())};
         if (!res) return util::Error{util::ErrorString(res)};
         change = *res;
-        if (batch.HasActiveTxn()) {
-            try {
+        try {
+            change->publication_id = m_storage.StageTopUpPublication(change->new_spks, this, change->lifetime);
+            if (batch.HasActiveTxn()) {
                 RegisterTopUpTxnListener(batch, change);
-            } catch (...) {
-                RollbackTopUp(*change->rollback_state);
-                throw;
+                return {};
             }
-            return {};
+            // Without a caller-owned transaction, every successful write is
+            // already durable when TopUpWithDBPreparedResult() returns.
+            m_storage.BeginTopUpCommit(change->publication_id);
+            m_storage.FinishTopUpCommit(change->publication_id, /*committed=*/true);
+        } catch (...) {
+            m_storage.CancelTopUpPublication(change->publication_id);
+            RollbackTopUp(*change->rollback_state);
+            throw;
         }
     }
 
@@ -1497,6 +1537,7 @@ util::Result<std::shared_ptr<DescriptorScriptPubKeyMan::TopUpChange>> Descriptor
     auto change{std::make_shared<TopUpChange>()};
     change->new_spks = std::move(new_spks);
     change->rollback_state = std::move(rollback_state);
+    change->lifetime = m_lifetime;
     return change;
 }
 
@@ -1540,26 +1581,40 @@ void DescriptorScriptPubKeyMan::RollbackTopUp(const TopUpRollbackState& state)
 
 void DescriptorScriptPubKeyMan::PublishTopUp(const TopUpChange& change)
 {
-    m_storage.TopUpCallback(change.new_spks, this);
-    NotifyCanGetAddressesChanged();
+    AssertLockNotHeld(cs_desc_man);
+    if (m_storage.TopUpCallback(change.new_spks, this, change.publication_id)) {
+        NotifyCanGetAddressesChanged();
+    }
 }
 
 void DescriptorScriptPubKeyMan::RegisterTopUpTxnListener(WalletBatch& batch, const std::shared_ptr<TopUpChange>& change)
 {
-    const std::weak_ptr<void> lifetime{m_lifetime};
     DescriptorScriptPubKeyMan* const self{this};
     WalletStorage* const storage{&m_storage};
     batch.RegisterTxnListener({
-        .on_commit = [self, storage, change, lifetime] {
+        .on_commit_prepare = [storage, change] {
+            storage->BeginTopUpCommit(change->publication_id);
+        },
+        .on_commit_success = [storage, change] {
+            storage->FinishTopUpCommit(change->publication_id, /*committed=*/true);
+        },
+        .on_commit_failure = [storage, change] {
+            storage->FinishTopUpCommit(change->publication_id, /*committed=*/false);
+        },
+        .on_commit = [self, storage, change] {
             storage->WithWalletLock([&] {
-                if (lifetime.expired()) return true;
+                if (change->lifetime.expired()) {
+                    storage->CancelTopUpPublication(change->publication_id);
+                    return true;
+                }
                 self->PublishTopUp(*change);
                 return true;
             });
         },
-        .on_abort = [self, storage, change, lifetime] {
+        .on_abort = [self, storage, change] {
+            storage->CancelTopUpPublication(change->publication_id);
             storage->WithWalletLock([&] {
-                if (lifetime.expired()) return true;
+                if (change->lifetime.expired()) return true;
                 LOCK(self->cs_desc_man);
                 self->RollbackTopUp(*change->rollback_state);
                 return true;
@@ -1742,29 +1797,33 @@ bool DescriptorScriptPubKeyMan::AddDescriptorPQCKeyWithDB(WalletBatch& batch, co
 
 bool DescriptorScriptPubKeyMan::SetupDescriptorGeneration(WalletBatch& batch, const CExtKey& master_key, OutputType addr_type, bool internal, unsigned int initial_keypool_size)
 {
-    LOCK(cs_desc_man);
-    assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
+    unsigned int top_up_size;
+    {
+        LOCK(cs_desc_man);
+        assert(m_storage.IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
 
-    // Ignore when there is already a descriptor
-    if (m_wallet_descriptor.descriptor) {
-        return false;
+        // Ignore when there is already a descriptor
+        if (m_wallet_descriptor.descriptor) {
+            return false;
+        }
+
+        m_wallet_descriptor = GenerateWalletDescriptor(master_key.Neuter(), addr_type, internal);
+
+        // Store the master private key, and descriptor
+        if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
+            throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
+        }
+        if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
+            throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
+        }
+
+        // Wallet creation on P2MR-only chains seeds a small synchronous pool first,
+        // then refills the remainder after create returns.
+        m_deferred_create_keypool_top_up = initial_keypool_size > 0 && initial_keypool_size < m_keypool_size;
+        m_wallet_descriptor.deferred_create_keypool_top_up = m_deferred_create_keypool_top_up;
+        top_up_size = m_deferred_create_keypool_top_up ? initial_keypool_size : 0;
     }
 
-    m_wallet_descriptor = GenerateWalletDescriptor(master_key.Neuter(), addr_type, internal);
-
-    // Store the master private key, and descriptor
-    if (!AddDescriptorKeyWithDB(batch, master_key.key, master_key.key.GetPubKey())) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor master private key failed");
-    }
-    if (!batch.WriteDescriptor(GetID(), m_wallet_descriptor)) {
-        throw std::runtime_error(std::string(__func__) + ": writing descriptor failed");
-    }
-
-    // Wallet creation on P2MR-only chains seeds a small synchronous pool first,
-    // then refills the remainder after create returns.
-    m_deferred_create_keypool_top_up = initial_keypool_size > 0 && initial_keypool_size < m_keypool_size;
-    m_wallet_descriptor.deferred_create_keypool_top_up = m_deferred_create_keypool_top_up;
-    const unsigned int top_up_size = m_deferred_create_keypool_top_up ? initial_keypool_size : 0;
     TopUpWithDB(batch, top_up_size, internal);
 
     m_storage.UnsetBlankWalletFlag(batch);
@@ -1815,20 +1874,24 @@ bool DescriptorScriptPubKeyMan::NeedsP2MRKeyPoolRefillNoLock() const
 
 void DescriptorScriptPubKeyMan::MaybeTopUpInternalP2MRKeyPool()
 {
-    AssertLockHeld(cs_desc_man);
-    if (m_storage.IsLocked() || !NeedsP2MRKeyPoolRefillNoLock()) return;
-
-    const unsigned int target{GetP2MRReceiveKeyPoolRefillStepTargetNoLock()};
-    if (target == 0) return;
+    unsigned int target;
+    std::string descriptor_id;
+    {
+        LOCK(cs_desc_man);
+        if (m_storage.IsLocked() || !NeedsP2MRKeyPoolRefillNoLock()) return;
+        target = GetP2MRReceiveKeyPoolRefillStepTargetNoLock();
+        if (target == 0) return;
+        descriptor_id = GetID().ToString();
+    }
     try {
         util::Result<void> res{TopUpWithInternalHintResult(/*internal_hint=*/true, target)};
         if (!res) {
             WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
-                GetID().ToString(), target, GetKeyPoolSizeNoLock(), util::ErrorString(res).original);
+                descriptor_id, target, GetKeyPoolSize(), util::ErrorString(res).original);
         }
     } catch (const std::exception& e) {
         WalletLogPrintf("P2MR change keypool inline low-watermark refill failed (descriptor id %s, target=%u, remaining=%u): %s\n",
-            GetID().ToString(), target, GetKeyPoolSizeNoLock(), e.what());
+            descriptor_id, target, GetKeyPoolSize(), e.what());
     }
 }
 

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -1233,7 +1233,7 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithInternalHintResult(std::o
         change = *res;
         if (!batch.TxnCommit()) {
             const bool aborted{!batch.HasActiveTxn() || batch.TxnAbort()};
-            change->rollback();
+            RollbackTopUp(*change->rollback_state);
             if (!aborted) {
                 throw std::runtime_error(strprintf("Error during descriptors keypool top up. Cannot abort changes after commit failure for wallet [%s]", m_storage.LogName()));
             }
@@ -1263,7 +1263,7 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBResult(WalletBatch& bat
             try {
                 RegisterTopUpTxnListener(batch, change);
             } catch (...) {
-                change->rollback();
+                RollbackTopUp(*change->rollback_state);
                 throw;
             }
             return {};
@@ -1277,22 +1277,6 @@ util::Result<void> DescriptorScriptPubKeyMan::TopUpWithDBResult(WalletBatch& bat
 util::Result<std::shared_ptr<DescriptorScriptPubKeyMan::TopUpChange>> DescriptorScriptPubKeyMan::TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error)
 {
     AssertLockHeld(cs_desc_man);
-    struct OldPQCKeyState {
-        std::optional<CPQCKey> key;
-        std::optional<CryptedPQCKeyRecord> crypted_key;
-        std::optional<uint32_t> sig_counter;
-    };
-    struct TopUpRollbackState {
-        int32_t old_range_start;
-        int32_t old_range_end;
-        std::optional<bool> old_descriptor_deferred_create_keypool_top_up;
-        int32_t old_max_cached_index;
-        bool old_deferred_create_keypool_top_up;
-        DescriptorCache added_cache_items;
-        std::map<CScript, std::optional<int32_t>> old_script_pub_key_values;
-        std::set<CPubKey> added_pubkeys;
-        std::map<CPQCPubKey, OldPQCKeyState> old_pqc_key_values;
-    };
     auto rollback_state{std::make_shared<TopUpRollbackState>(
         m_wallet_descriptor.range_start,
         m_wallet_descriptor.range_end,
@@ -1311,7 +1295,7 @@ util::Result<std::shared_ptr<DescriptorScriptPubKeyMan::TopUpChange>> Descriptor
     };
     const auto remember_pqc_key = [&](const CPQCPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) {
         if (old_pqc_key_values.contains(pubkey)) return;
-        OldPQCKeyState state;
+        TopUpOldPQCKeyState state;
         if (const auto it = m_map_pqc_keys.find(pubkey); it != m_map_pqc_keys.end()) {
             state.key = it->second;
         }
@@ -1323,44 +1307,9 @@ util::Result<std::shared_ptr<DescriptorScriptPubKeyMan::TopUpChange>> Descriptor
         }
         old_pqc_key_values.emplace(pubkey, std::move(state));
     };
-    const auto restore_top_up_state = [this, rollback_state]() EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) {
-        m_wallet_descriptor.range_start = rollback_state->old_range_start;
-        m_wallet_descriptor.range_end = rollback_state->old_range_end;
-        m_wallet_descriptor.deferred_create_keypool_top_up = rollback_state->old_descriptor_deferred_create_keypool_top_up;
-        m_wallet_descriptor.cache.Remove(rollback_state->added_cache_items);
-        m_max_cached_index = rollback_state->old_max_cached_index;
-        for (const auto& [script, old_index] : rollback_state->old_script_pub_key_values) {
-            if (old_index) {
-                m_map_script_pub_keys[script] = *old_index;
-            } else {
-                m_map_script_pub_keys.erase(script);
-            }
-        }
-        for (const CPubKey& pubkey : rollback_state->added_pubkeys) {
-            m_map_pubkeys.erase(pubkey);
-        }
-        for (const auto& [pubkey, old_state] : rollback_state->old_pqc_key_values) {
-            if (old_state.key) {
-                m_map_pqc_keys[pubkey] = *old_state.key;
-            } else {
-                m_map_pqc_keys.erase(pubkey);
-            }
-            if (old_state.crypted_key) {
-                m_map_crypted_pqc_keys[pubkey] = *old_state.crypted_key;
-            } else {
-                m_map_crypted_pqc_keys.erase(pubkey);
-            }
-            if (old_state.sig_counter) {
-                m_map_pqc_sig_counters[pubkey] = *old_state.sig_counter;
-            } else {
-                m_map_pqc_sig_counters.erase(pubkey);
-            }
-        }
-        m_deferred_create_keypool_top_up = rollback_state->old_deferred_create_keypool_top_up;
-    };
     const auto restore_top_up_state_if_safe = [&](bool persistence_write_may_have_started) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) {
         if (rollback_state_on_error || (!persistence_write_may_have_started && !has_persisted_top_up_writes)) {
-            restore_top_up_state();
+            RollbackTopUp(*rollback_state);
         }
     };
     const auto top_up_error = [&](bilingual_str error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man) -> util::Result<std::shared_ptr<TopUpChange>> {
@@ -1547,8 +1496,46 @@ util::Result<std::shared_ptr<DescriptorScriptPubKeyMan::TopUpChange>> Descriptor
 
     auto change{std::make_shared<TopUpChange>()};
     change->new_spks = std::move(new_spks);
-    change->rollback = restore_top_up_state;
+    change->rollback_state = std::move(rollback_state);
     return change;
+}
+
+void DescriptorScriptPubKeyMan::RollbackTopUp(const TopUpRollbackState& state)
+{
+    AssertLockHeld(cs_desc_man);
+    m_wallet_descriptor.range_start = state.old_range_start;
+    m_wallet_descriptor.range_end = state.old_range_end;
+    m_wallet_descriptor.deferred_create_keypool_top_up = state.old_descriptor_deferred_create_keypool_top_up;
+    m_wallet_descriptor.cache.Remove(state.added_cache_items);
+    m_max_cached_index = state.old_max_cached_index;
+    for (const auto& [script, old_index] : state.old_script_pub_key_values) {
+        if (old_index) {
+            m_map_script_pub_keys[script] = *old_index;
+        } else {
+            m_map_script_pub_keys.erase(script);
+        }
+    }
+    for (const CPubKey& pubkey : state.added_pubkeys) {
+        m_map_pubkeys.erase(pubkey);
+    }
+    for (const auto& [pubkey, old_state] : state.old_pqc_key_values) {
+        if (old_state.key) {
+            m_map_pqc_keys[pubkey] = *old_state.key;
+        } else {
+            m_map_pqc_keys.erase(pubkey);
+        }
+        if (old_state.crypted_key) {
+            m_map_crypted_pqc_keys[pubkey] = *old_state.crypted_key;
+        } else {
+            m_map_crypted_pqc_keys.erase(pubkey);
+        }
+        if (old_state.sig_counter) {
+            m_map_pqc_sig_counters[pubkey] = *old_state.sig_counter;
+        } else {
+            m_map_pqc_sig_counters.erase(pubkey);
+        }
+    }
+    m_deferred_create_keypool_top_up = state.old_deferred_create_keypool_top_up;
 }
 
 void DescriptorScriptPubKeyMan::PublishTopUp(const TopUpChange& change)
@@ -1559,11 +1546,24 @@ void DescriptorScriptPubKeyMan::PublishTopUp(const TopUpChange& change)
 
 void DescriptorScriptPubKeyMan::RegisterTopUpTxnListener(WalletBatch& batch, const std::shared_ptr<TopUpChange>& change)
 {
+    const std::weak_ptr<void> lifetime{m_lifetime};
+    DescriptorScriptPubKeyMan* const self{this};
+    WalletStorage* const storage{&m_storage};
     batch.RegisterTxnListener({
-        .on_commit = [this, change] { PublishTopUp(*change); },
-        .on_abort = [this, change] {
-            LOCK(cs_desc_man);
-            change->rollback();
+        .on_commit = [self, storage, change, lifetime] {
+            storage->WithWalletLock([&] {
+                if (lifetime.expired()) return true;
+                self->PublishTopUp(*change);
+                return true;
+            });
+        },
+        .on_abort = [self, storage, change, lifetime] {
+            storage->WithWalletLock([&] {
+                if (lifetime.expired()) return true;
+                LOCK(self->cs_desc_man);
+                self->RollbackTopUp(*change->rollback_state);
+                return true;
+            });
         },
     });
 }

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -395,7 +395,13 @@ private:
         bool has_encryption_keys{false};
         std::optional<CKeyingMaterial> encryption_key;
     };
+    struct TopUpChange {
+        std::set<CScript> new_spks;
+        std::function<void()> rollback;
+    };
     TopUpPreparation PrepareTopUp(std::optional<bool> internal_hint) const;
+    void PublishTopUp(const TopUpChange& change);
+    void RegisterTopUpTxnListener(WalletBatch& batch, const std::shared_ptr<TopUpChange>& change);
     bool IsRangedP2MRDescriptorNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetKeyPoolSizeNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool NeedsP2MRKeyPoolRefillNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
@@ -419,7 +425,7 @@ protected:
     //! Same as 'TopUp' but designed for use within a batch transaction context
     bool TopUpWithDB(WalletBatch& batch, unsigned int size = 0, std::optional<bool> internal_hint = std::nullopt);
     util::Result<void> TopUpWithDBResult(WalletBatch& batch, unsigned int size = 0, std::optional<bool> internal_hint = std::nullopt, bool throw_on_persistence_error = false, bool rollback_state_on_error = true);
-    util::Result<void> TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    util::Result<std::shared_ptr<TopUpChange>> TopUpWithDBPreparedResult(WalletBatch& batch, unsigned int size, const TopUpPreparation& prepared, bool throw_on_persistence_error, bool rollback_state_on_error) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 
 public:
     DescriptorScriptPubKeyMan(WalletStorage& storage, WalletDescriptor& descriptor, int64_t keypool_size);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -25,6 +25,7 @@
 
 #include <boost/signals2/signal.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>
@@ -37,6 +38,8 @@ enum class OutputType;
 namespace wallet {
 struct MigrationData;
 class ScriptPubKeyMan;
+using TopUpPublicationId = uint64_t;
+static constexpr TopUpPublicationId INVALID_TOPUP_PUBLICATION_ID{0};
 std::vector<CPQCPubKey> ExtractP2MRPubkeys(const CScript& script);
 
 struct PSBTSigningProvider
@@ -90,8 +93,15 @@ public:
     virtual bool IsLocked() const = 0;
     virtual bool WithWalletLock(std::function<bool()> cb) const = 0;
     virtual std::optional<bool> IsInternalScriptPubKeyMan(const ScriptPubKeyMan* spk_man) const = 0;
+    //! Track descriptor scripts before their transaction outcome is known.
+    virtual TopUpPublicationId StageTopUpPublication(const std::set<CScript>&, ScriptPubKeyMan*, std::weak_ptr<void>) = 0;
+    //! Resolve the commit boundary without taking wallet or descriptor locks.
+    virtual void BeginTopUpCommit(TopUpPublicationId) = 0;
+    virtual void FinishTopUpCommit(TopUpPublicationId, bool committed) = 0;
+    //! Remove a staged or resolved publication without touching the manager.
+    virtual void CancelTopUpPublication(TopUpPublicationId) = 0;
     //! Callback function for after TopUp completes containing any scripts that were added by a SPKMan
-    virtual void TopUpCallback(const std::set<CScript>&, ScriptPubKeyMan*) = 0;
+    virtual bool TopUpCallback(const std::set<CScript>&, ScriptPubKeyMan*, TopUpPublicationId = INVALID_TOPUP_PUBLICATION_ID) = 0;
 };
 
 //! Constant representing an unknown spkm creation time
@@ -416,15 +426,18 @@ private:
         // Detached state can outlive a manager destroyed while its caller-owned
         // transaction is still active.
         std::shared_ptr<TopUpRollbackState> rollback_state;
+        std::weak_ptr<void> lifetime;
+        TopUpPublicationId publication_id{INVALID_TOPUP_PUBLICATION_ID};
     };
     void RollbackTopUp(const TopUpRollbackState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     TopUpPreparation PrepareTopUp(std::optional<bool> internal_hint) const;
+    util::Result<CTxDestination> GetNewDestinationWithIndex(OutputType type, int64_t* index);
     void PublishTopUp(const TopUpChange& change);
     void RegisterTopUpTxnListener(WalletBatch& batch, const std::shared_ptr<TopUpChange>& change);
     bool IsRangedP2MRDescriptorNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetKeyPoolSizeNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     bool NeedsP2MRKeyPoolRefillNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
-    void MaybeTopUpInternalP2MRKeyPool() EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
+    void MaybeTopUpInternalP2MRKeyPool();
     unsigned int GetP2MRReceiveKeyPoolLowWatermarkNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     unsigned int GetP2MRReceiveKeyPoolRefillStepTargetNoLock() const EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
 

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -395,10 +395,29 @@ private:
         bool has_encryption_keys{false};
         std::optional<CKeyingMaterial> encryption_key;
     };
+    struct TopUpOldPQCKeyState {
+        std::optional<CPQCKey> key;
+        std::optional<CryptedPQCKeyRecord> crypted_key;
+        std::optional<uint32_t> sig_counter;
+    };
+    struct TopUpRollbackState {
+        int32_t old_range_start;
+        int32_t old_range_end;
+        std::optional<bool> old_descriptor_deferred_create_keypool_top_up;
+        int32_t old_max_cached_index;
+        bool old_deferred_create_keypool_top_up;
+        DescriptorCache added_cache_items;
+        std::map<CScript, std::optional<int32_t>> old_script_pub_key_values;
+        std::set<CPubKey> added_pubkeys;
+        std::map<CPQCPubKey, TopUpOldPQCKeyState> old_pqc_key_values;
+    };
     struct TopUpChange {
         std::set<CScript> new_spks;
-        std::function<void()> rollback;
+        // Detached state can outlive a manager destroyed while its caller-owned
+        // transaction is still active.
+        std::shared_ptr<TopUpRollbackState> rollback_state;
     };
+    void RollbackTopUp(const TopUpRollbackState& state) EXCLUSIVE_LOCKS_REQUIRED(cs_desc_man);
     TopUpPreparation PrepareTopUp(std::optional<bool> internal_hint) const;
     void PublishTopUp(const TopUpChange& change);
     void RegisterTopUpTxnListener(WalletBatch& batch, const std::shared_ptr<TopUpChange>& change);

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -227,22 +227,45 @@ std::unique_ptr<DatabaseCursor> MockableBatch::GetNewPrefixCursor(std::span<cons
     return std::make_unique<MockableCursor>(m_database.m_records, m_database.m_pass && m_database.m_read_pass, prefix);
 }
 
+MockableBatch::~MockableBatch()
+{
+    Close();
+}
+
+void MockableBatch::Close()
+{
+    if (!m_txn_active) return;
+    m_database.m_records = std::move(*m_txn_snapshot);
+    m_txn_snapshot.reset();
+    m_txn_active = false;
+}
+
 bool MockableBatch::TxnBegin()
 {
     ++m_database.m_txn_begin_count;
-    return m_database.m_pass && m_database.m_txn_begin_pass;
+    if (m_txn_active || !m_database.m_pass || !m_database.m_txn_begin_pass) return false;
+    m_txn_snapshot = m_database.m_records;
+    m_txn_active = true;
+    return true;
 }
 
 bool MockableBatch::TxnCommit()
 {
     ++m_database.m_txn_commit_count;
-    return m_database.m_pass && m_database.m_txn_commit_pass;
+    if (!m_txn_active || !m_database.m_pass || !m_database.m_txn_commit_pass) return false;
+    m_txn_snapshot.reset();
+    m_txn_active = false;
+    return true;
 }
 
 bool MockableBatch::TxnAbort()
 {
     ++m_database.m_txn_abort_count;
-    return m_database.m_pass && m_database.m_txn_abort_pass;
+    if (!m_txn_active || !m_database.m_pass || !m_database.m_txn_abort_pass) return false;
+    m_database.m_records = std::move(*m_txn_snapshot);
+    m_txn_snapshot.reset();
+    m_txn_active = false;
+    return true;
 }
 
 std::unique_ptr<WalletDatabase> CreateMockableWalletDatabase(MockableData records)

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -256,10 +256,13 @@ bool MockableBatch::TxnBegin()
 bool MockableBatch::TxnCommit()
 {
     ++m_database.m_txn_commit_count;
-    if (!m_txn_active || !m_database.m_pass || !m_database.m_txn_commit_pass) return false;
-    m_txn_snapshot.reset();
-    m_txn_active = false;
-    return true;
+    const bool success{m_txn_active && m_database.m_pass && m_database.m_txn_commit_pass};
+    if (success) {
+        m_txn_snapshot.reset();
+        m_txn_active = false;
+    }
+    if (m_database.m_txn_commit_result_hook) m_database.m_txn_commit_result_hook(success);
+    return success;
 }
 
 bool MockableBatch::TxnAbort()

--- a/src/wallet/test/util.cpp
+++ b/src/wallet/test/util.cpp
@@ -167,11 +167,15 @@ bool MockableBatch::ReadKey(DataStream&& key, DataStream& value)
 bool MockableBatch::WriteKey(DataStream&& key, DataStream&& value, bool overwrite)
 {
     ++m_database.m_write_count;
+    SerializeData key_data{key.begin(), key.end()};
+    DataStream wallet_flags_key;
+    wallet_flags_key << DBKeys::FLAGS;
+    const bool is_wallet_flags_key{key_data == SerializeData{wallet_flags_key.begin(), wallet_flags_key.end()}};
     if (!m_database.m_pass || !m_database.m_write_pass ||
+        (!m_database.m_wallet_flags_write_pass && is_wallet_flags_key) ||
         (m_database.m_write_fail_after >= 0 && m_database.m_write_count > m_database.m_write_fail_after)) {
         return false;
     }
-    SerializeData key_data{key.begin(), key.end()};
     SerializeData value_data{value.begin(), value.end()};
     auto [it, inserted] = m_database.m_records.emplace(key_data, value_data);
     if (!inserted && overwrite) { // Overwrite if requested

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -10,6 +10,7 @@
 #include <wallet/scriptpubkeyman.h>
 
 #include <memory>
+#include <optional>
 #include <span>
 
 class ArgsManager;
@@ -69,6 +70,8 @@ class MockableBatch : public DatabaseBatch
 {
 private:
     MockableDatabase& m_database;
+    bool m_txn_active{false};
+    std::optional<MockableData> m_txn_snapshot;
 
     bool ReadKey(DataStream&& key, DataStream& value) override;
     bool WriteKey(DataStream&& key, DataStream&& value, bool overwrite=true) override;
@@ -78,16 +81,16 @@ private:
 
 public:
     explicit MockableBatch(MockableDatabase& database) : m_database(database) {}
-    ~MockableBatch() = default;
+    ~MockableBatch() override;
 
-    void Close() override {}
+    void Close() override;
 
     std::unique_ptr<DatabaseCursor> GetNewCursor() override;
     std::unique_ptr<DatabaseCursor> GetNewPrefixCursor(std::span<const std::byte> prefix) override;
     bool TxnBegin() override;
     bool TxnCommit() override;
     bool TxnAbort() override;
-    bool HasActiveTxn() override { return false; }
+    bool HasActiveTxn() override { return m_txn_active; }
 };
 
 /** A WalletDatabase whose contents and return values can be modified as needed for testing

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -106,6 +106,7 @@ public:
     bool m_txn_begin_pass{true};
     bool m_txn_commit_pass{true};
     bool m_txn_abort_pass{true};
+    bool m_wallet_flags_write_pass{true};
     int m_write_fail_after{-1};
     int m_write_count{0};
     int m_txn_begin_count{0};

--- a/src/wallet/test/util.h
+++ b/src/wallet/test/util.h
@@ -9,6 +9,7 @@
 #include <wallet/db.h>
 #include <wallet/scriptpubkeyman.h>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <span>
@@ -107,6 +108,9 @@ public:
     bool m_txn_commit_pass{true};
     bool m_txn_abort_pass{true};
     bool m_wallet_flags_write_pass{true};
+    //! Runs after a successful mock commit becomes durable, or immediately
+    //! before a failed commit returns, while WalletBatch listeners are COMMITTING.
+    std::function<void(bool)> m_txn_commit_result_hook;
     int m_write_fail_after{-1};
     int m_write_count{0};
     int m_txn_begin_count{0};

--- a/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_deferred_keypool_tests.cpp
@@ -176,8 +176,8 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSerializesDeferredTopUpCachePublica
     BOOST_CHECK(publication_lock_stack_empty);
     BOOST_CHECK(publication_transaction_inactive);
 
-    // Descriptor state and its transaction are complete, but the new script
-    // remains invisible until the publication batch acquires cs_wallet.
+    // Descriptor state and its transaction are complete, so the new script
+    // remains visible while publication into the wallet cache is pending.
     BOOST_REQUIRE_EQUAL(unpublished_scripts.size(), 1U);
     const CScript new_script{*unpublished_scripts.begin()};
     std::promise<void> reader_locked;
@@ -187,7 +187,7 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSerializesDeferredTopUpCachePublica
     std::promise<void> release_reader;
     auto release_reader_future{release_reader.get_future()};
     std::atomic_bool reader_observed_warm_script{true};
-    std::atomic_bool reader_observed_unpublished_script{false};
+    std::atomic_bool reader_observed_committed_script{false};
     std::thread reader{[&] {
         LOCK(wallet->cs_wallet);
         reader_locked.set_value();
@@ -198,7 +198,7 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSerializesDeferredTopUpCachePublica
             observed_warm_script &= !!wallet->GetSolvingProvider(warm_script);
         }
         reader_observed_warm_script = observed_warm_script;
-        reader_observed_unpublished_script = wallet->IsMine(new_script) || !!wallet->GetSolvingProvider(new_script);
+        reader_observed_committed_script = wallet->IsMine(new_script) && !!wallet->GetSolvingProvider(new_script);
         reader_checked.set_value();
         release_reader_future.wait();
     }};
@@ -208,7 +208,7 @@ BOOST_FIXTURE_TEST_CASE(WalletInterfaceUnlockSerializesDeferredTopUpCachePublica
     run_reader_checks.set_value();
     reader_checked.get_future().wait();
     BOOST_CHECK(reader_observed_warm_script);
-    BOOST_CHECK(!reader_observed_unpublished_script);
+    BOOST_CHECK(reader_observed_committed_script);
 
     // The publisher has been released, but must still be blocked by the
     // foreground reader's cs_wallet ownership.

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -48,6 +48,7 @@
 #include <univalue.h>
 
 #include <chrono>
+#include <thread>
 
 using node::MAX_BLOCKFILE_SIZE;
 
@@ -583,6 +584,120 @@ BOOST_AUTO_TEST_CASE(DescriptorTopUpResultRestoresMemoryAfterWriteFailure)
     auto retry_res{spk_man->TopUpWithInternalHintResult(/*internal_hint=*/false, target_size)};
     BOOST_REQUIRE_MESSAGE(retry_res.has_value(), util::ErrorString(retry_res).original);
     BOOST_CHECK_EQUAL(spk_man->GetKeyPoolSize(), target_size);
+}
+
+BOOST_AUTO_TEST_CASE(DescriptorTopUpResultRestoresMemoryAfterCommitFailure)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    LOCK(wallet.cs_wallet);
+    wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    wallet.SetupDescriptorScriptPubKeyMans(BECH32_ONLY_OUTPUT_TYPES);
+
+    auto* spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet.GetScriptPubKeyMan(OutputType::BECH32, /*internal=*/false));
+    BOOST_REQUIRE(spk_man);
+
+    auto& database = GetMockableDatabase(wallet);
+    const unsigned int previous_size{spk_man->GetKeyPoolSize()};
+    const unsigned int target_size{previous_size + 1};
+    int notifications{0};
+    boost::signals2::scoped_connection connection{spk_man->NotifyCanGetAddressesChanged.connect([&] { ++notifications; })};
+    database.ResetCounts();
+    database.m_txn_commit_pass = false;
+
+    BOOST_CHECK_THROW(
+        spk_man->TopUpWithInternalHintResult(/*internal_hint=*/false, target_size),
+        std::runtime_error);
+    BOOST_CHECK_EQUAL(database.m_txn_begin_count, 1);
+    BOOST_CHECK_EQUAL(database.m_txn_commit_count, 1);
+    BOOST_CHECK_EQUAL(database.m_txn_abort_count, 1);
+    BOOST_CHECK_EQUAL(spk_man->GetKeyPoolSize(), previous_size);
+    BOOST_CHECK_EQUAL(notifications, 0);
+
+    database.ResetCounts();
+    database.m_txn_commit_pass = true;
+    auto retry_res{spk_man->TopUpWithInternalHintResult(/*internal_hint=*/false, target_size)};
+    BOOST_REQUIRE_MESSAGE(retry_res.has_value(), util::ErrorString(retry_res).original);
+    BOOST_CHECK_EQUAL(spk_man->GetKeyPoolSize(), target_size);
+    BOOST_CHECK_EQUAL(notifications, 1);
+}
+
+BOOST_AUTO_TEST_CASE(DescriptorTopUpWithDBPublishesOnExternalTransactionCommit)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    LOCK(wallet.cs_wallet);
+    wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+
+    CExtKey master_key;
+    master_key.SetSeed(GenerateRandomKey());
+    TestDescriptorScriptPubKeyMan spk_man{wallet, SINGLE_ADDRESS_KEYPOOL_SIZE};
+    WalletBatch setup_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(spk_man.SetupDescriptorGeneration(setup_batch, master_key, OutputType::BECH32, /*internal=*/false));
+
+    const unsigned int previous_size{spk_man.GetKeyPoolSize()};
+    const unsigned int target_size{previous_size + 1};
+    int notifications{0};
+    WalletBatch batch{wallet.GetDatabase()};
+    boost::signals2::scoped_connection connection{spk_man.NotifyCanGetAddressesChanged.connect([&] {
+        BOOST_CHECK(!batch.HasActiveTxn());
+        ++notifications;
+    })};
+
+    BOOST_REQUIRE(batch.TxnBegin());
+    BOOST_REQUIRE(spk_man.TopUpWithDB(batch, target_size, /*internal_hint=*/false));
+    BOOST_REQUIRE(spk_man.TopUpWithDB(batch, target_size + 1, /*internal_hint=*/false));
+    BOOST_CHECK_EQUAL(spk_man.GetKeyPoolSize(), target_size + 1);
+    BOOST_CHECK_EQUAL(notifications, 0);
+    BOOST_REQUIRE(batch.TxnAbort());
+    BOOST_CHECK_EQUAL(spk_man.GetKeyPoolSize(), previous_size);
+    BOOST_CHECK_EQUAL(notifications, 0);
+
+    BOOST_REQUIRE(batch.TxnBegin());
+    BOOST_REQUIRE(spk_man.TopUpWithDB(batch, target_size, /*internal_hint=*/false));
+    BOOST_CHECK_EQUAL(notifications, 0);
+    BOOST_REQUIRE(batch.TxnCommit());
+    BOOST_CHECK_EQUAL(spk_man.GetKeyPoolSize(), target_size);
+    BOOST_CHECK_EQUAL(notifications, 1);
+}
+
+BOOST_AUTO_TEST_CASE(DescriptorTopUpCacheSupportsConcurrentReaders)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        wallet.SetupDescriptorScriptPubKeyMans(BECH32_ONLY_OUTPUT_TYPES);
+    }
+
+    DescriptorScriptPubKeyMan* spk_man{nullptr};
+    {
+        LOCK(wallet.cs_wallet);
+        spk_man = dynamic_cast<DescriptorScriptPubKeyMan*>(wallet.GetScriptPubKeyMan(OutputType::BECH32, /*internal=*/false));
+    }
+    BOOST_REQUIRE(spk_man);
+
+    std::atomic<bool> done{false};
+    std::atomic<bool> lookup_failed{false};
+    std::thread reader{[&] {
+        while (!done.load()) {
+            for (const CScript& script : spk_man->GetScriptPubKeys()) {
+                if (wallet.GetScriptPubKeyMans(script).empty()) lookup_failed = true;
+            }
+        }
+    }};
+
+    bool top_ups_succeeded{true};
+    const unsigned int initial_size{spk_man->GetKeyPoolSize()};
+    for (unsigned int target_size{initial_size + 1}; target_size <= initial_size + 50; ++target_size) {
+        if (!spk_man->TopUpWithInternalHintResult(/*internal_hint=*/false, target_size)) {
+            top_ups_succeeded = false;
+            break;
+        }
+    }
+    done = true;
+    reader.join();
+
+    BOOST_CHECK(top_ups_succeeded);
+    BOOST_CHECK(!lookup_failed);
 }
 
 BOOST_AUTO_TEST_CASE(DescriptorSetupPropagatesTopUpWithDBWriteFailure)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -659,6 +659,32 @@ BOOST_AUTO_TEST_CASE(DescriptorTopUpWithDBPublishesOnExternalTransactionCommit)
     BOOST_CHECK_EQUAL(notifications, 1);
 }
 
+BOOST_AUTO_TEST_CASE(DescriptorSetupAbortIgnoresDestroyedManager)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    LOCK(wallet.cs_wallet);
+    wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+
+    auto& database{GetMockableDatabase(wallet)};
+    database.ResetCounts();
+    database.m_wallet_flags_write_pass = false;
+
+    {
+        WalletBatch batch{wallet.GetDatabase()};
+        BOOST_REQUIRE(batch.TxnBegin());
+        CExtKey master_key;
+        master_key.SetSeed(GenerateRandomKey());
+
+        BOOST_CHECK_THROW(
+            wallet.SetupDescriptorScriptPubKeyMan(batch, master_key, OutputType::BECH32, /*internal=*/false),
+            std::runtime_error);
+        BOOST_CHECK(batch.HasActiveTxn());
+        BOOST_CHECK(wallet.GetAllScriptPubKeyMans().empty());
+    }
+
+    BOOST_CHECK_EQUAL(database.m_txn_abort_count, 1);
+}
+
 BOOST_AUTO_TEST_CASE(DescriptorTopUpCacheSupportsConcurrentReaders)
 {
     CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -4,13 +4,14 @@
 
 #include <wallet/wallet.h>
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <future>
 #include <map>
 #include <memory>
-#include <array>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -72,6 +73,66 @@ public:
     using DescriptorScriptPubKeyMan::DescriptorScriptPubKeyMan;
     using DescriptorScriptPubKeyMan::TopUpWithDB;
 };
+
+class CountingDescriptorScriptPubKeyMan final : public TestDescriptorScriptPubKeyMan
+{
+public:
+    using TestDescriptorScriptPubKeyMan::TestDescriptorScriptPubKeyMan;
+
+    bool IsMine(const CScript& script) const override
+    {
+        ++m_is_mine_calls;
+        return TestDescriptorScriptPubKeyMan::IsMine(script);
+    }
+
+    bool CanProvide(const CScript& script, SignatureData& sigdata) override
+    {
+        ++m_can_provide_calls;
+        return TestDescriptorScriptPubKeyMan::CanProvide(script, sigdata);
+    }
+
+    std::unique_ptr<SigningProvider> GetSolvingProvider(const CScript& script) const override
+    {
+        ++m_get_solving_provider_calls;
+        return TestDescriptorScriptPubKeyMan::GetSolvingProvider(script);
+    }
+
+    void ResetLookupCounts()
+    {
+        m_is_mine_calls = 0;
+        m_can_provide_calls = 0;
+        m_get_solving_provider_calls = 0;
+    }
+
+    int LookupCount() const { return m_is_mine_calls + m_can_provide_calls + m_get_solving_provider_calls; }
+
+private:
+    mutable int m_is_mine_calls{0};
+    int m_can_provide_calls{0};
+    mutable int m_get_solving_provider_calls{0};
+};
+
+template <typename ScriptSet>
+CScript FindNewScript(const ScriptSet& before, const ScriptSet& after)
+{
+    for (const CScript& script : after) {
+        if (!before.contains(script)) return script;
+    }
+    BOOST_FAIL("descriptor top-up did not create a script");
+    return {};
+}
+
+bool IsTopUpScriptVisible(CWallet& wallet, const CScript& script)
+{
+    LOCK(wallet.cs_wallet);
+    const bool is_mine{wallet.IsMine(script)};
+    const bool has_manager{!wallet.GetScriptPubKeyMans(script).empty()};
+    const bool has_provider{wallet.GetSolvingProvider(script) != nullptr};
+    if (is_mine != has_manager || is_mine != has_provider) {
+        throw std::logic_error{"top-up script lookup APIs disagree"};
+    }
+    return is_mine;
+}
 } // namespace
 
 static CMutableTransaction TestSimpleSpend(const CTransaction& from, uint32_t index, const CKey& key, const CScript& pubkey)
@@ -669,20 +730,249 @@ BOOST_AUTO_TEST_CASE(DescriptorSetupAbortIgnoresDestroyedManager)
     database.ResetCounts();
     database.m_wallet_flags_write_pass = false;
 
-    {
-        WalletBatch batch{wallet.GetDatabase()};
-        BOOST_REQUIRE(batch.TxnBegin());
-        CExtKey master_key;
-        master_key.SetSeed(GenerateRandomKey());
+    WalletBatch batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(batch.TxnBegin());
+    CExtKey master_key;
+    master_key.SetSeed(GenerateRandomKey());
 
-        BOOST_CHECK_THROW(
-            wallet.SetupDescriptorScriptPubKeyMan(batch, master_key, OutputType::BECH32, /*internal=*/false),
-            std::runtime_error);
-        BOOST_CHECK(batch.HasActiveTxn());
-        BOOST_CHECK(wallet.GetAllScriptPubKeyMans().empty());
-    }
+    BOOST_CHECK_THROW(
+        wallet.SetupDescriptorScriptPubKeyMan(batch, master_key, OutputType::BECH32, /*internal=*/false),
+        std::runtime_error);
+    BOOST_CHECK(batch.HasActiveTxn());
+    BOOST_CHECK(wallet.GetAllScriptPubKeyMans().empty());
+    BOOST_REQUIRE(batch.TxnAbort());
 
     BOOST_CHECK_EQUAL(database.m_txn_abort_count, 1);
+}
+
+BOOST_AUTO_TEST_CASE(DescriptorTopUpPublicationFollowsExternalTransactionOutcome)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    }
+
+    CExtKey master_key;
+    master_key.SetSeed(GenerateRandomKey());
+    TestDescriptorScriptPubKeyMan spk_man{wallet, SINGLE_ADDRESS_KEYPOOL_SIZE};
+    WalletBatch setup_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(spk_man.SetupDescriptorGeneration(setup_batch, master_key, OutputType::BECH32, /*internal=*/false));
+
+    const unsigned int target_size{spk_man.GetKeyPoolSize() + 1};
+    const auto previous_scripts{spk_man.GetScriptPubKeys()};
+    auto& database{GetMockableDatabase(wallet)};
+
+    WalletBatch abort_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(abort_batch.TxnBegin());
+    BOOST_REQUIRE(spk_man.TopUpWithDB(abort_batch, target_size, /*internal_hint=*/false));
+    const CScript abort_script{FindNewScript(previous_scripts, spk_man.GetScriptPubKeys())};
+    BOOST_CHECK(!IsTopUpScriptVisible(wallet, abort_script));
+    BOOST_REQUIRE(abort_batch.TxnAbort());
+    BOOST_CHECK(!IsTopUpScriptVisible(wallet, abort_script));
+    BOOST_CHECK(spk_man.GetScriptPubKeys() == previous_scripts);
+
+    WalletBatch failed_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(failed_batch.TxnBegin());
+    BOOST_REQUIRE(spk_man.TopUpWithDB(failed_batch, target_size, /*internal_hint=*/false));
+    const CScript failed_script{FindNewScript(previous_scripts, spk_man.GetScriptPubKeys())};
+    database.m_txn_commit_pass = false;
+    BOOST_CHECK(!failed_batch.TxnCommit());
+    BOOST_CHECK(!IsTopUpScriptVisible(wallet, failed_script));
+    BOOST_REQUIRE(failed_batch.TxnAbort());
+    BOOST_CHECK(!IsTopUpScriptVisible(wallet, failed_script));
+    database.m_txn_commit_pass = true;
+
+    WalletBatch commit_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(commit_batch.TxnBegin());
+    BOOST_REQUIRE(spk_man.TopUpWithDB(commit_batch, target_size, /*internal_hint=*/false));
+    const CScript committed_script{FindNewScript(previous_scripts, spk_man.GetScriptPubKeys())};
+    BOOST_CHECK(!IsTopUpScriptVisible(wallet, committed_script));
+    BOOST_REQUIRE(commit_batch.TxnCommit());
+    BOOST_CHECK(IsTopUpScriptVisible(wallet, committed_script));
+}
+
+BOOST_AUTO_TEST_CASE(DescriptorTopUpCallerOwnedCommitBoundaryIsAtomic)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    }
+
+    CExtKey master_key;
+    master_key.SetSeed(GenerateRandomKey());
+    TestDescriptorScriptPubKeyMan spk_man{wallet, SINGLE_ADDRESS_KEYPOOL_SIZE};
+    WalletBatch setup_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(spk_man.SetupDescriptorGeneration(setup_batch, master_key, OutputType::BECH32, /*internal=*/false));
+
+    WalletBatch batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(batch.TxnBegin());
+    const unsigned int first_target{spk_man.GetKeyPoolSize() + 1};
+    BOOST_REQUIRE(spk_man.TopUpWithDB(batch, first_target, /*internal_hint=*/false));
+    const auto after_first{spk_man.GetScriptPubKeys()};
+    BOOST_REQUIRE(spk_man.TopUpWithDB(batch, first_target + 1, /*internal_hint=*/false));
+    const CScript second_script{FindNewScript(after_first, spk_man.GetScriptPubKeys())};
+
+    std::promise<void> commit_boundary;
+    std::future<void> commit_boundary_future{commit_boundary.get_future()};
+    std::promise<void> release_commit;
+    std::shared_future<void> release_commit_future{release_commit.get_future().share()};
+    auto& database{GetMockableDatabase(wallet)};
+    database.m_txn_commit_result_hook = [&](bool success) {
+        if (success) commit_boundary.set_value();
+        release_commit_future.wait();
+    };
+
+    std::future<bool> commit_future{std::async(std::launch::async, [&] { return batch.TxnCommit(); })};
+    const bool reached_boundary{commit_boundary_future.wait_for(std::chrono::seconds{5}) == std::future_status::ready};
+
+    std::promise<void> lookup_started;
+    std::future<void> lookup_started_future{lookup_started.get_future()};
+    std::future<bool> lookup_future{std::async(std::launch::async, [&] {
+        lookup_started.set_value();
+        return IsTopUpScriptVisible(wallet, second_script);
+    })};
+    lookup_started_future.wait();
+    const bool lookup_waited{lookup_future.wait_for(std::chrono::milliseconds{100}) == std::future_status::timeout};
+    release_commit.set_value();
+
+    const bool commit_succeeded{commit_future.get()};
+    const bool lookup_succeeded{lookup_future.get()};
+    database.m_txn_commit_result_hook = {};
+    BOOST_REQUIRE(reached_boundary);
+    BOOST_CHECK(lookup_waited);
+    BOOST_CHECK(commit_succeeded);
+    BOOST_CHECK(lookup_succeeded);
+    BOOST_CHECK(IsTopUpScriptVisible(wallet, second_script));
+}
+
+BOOST_AUTO_TEST_CASE(DescriptorTopUpSelfOwnedCommitBoundaryIsAtomic)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    }
+
+    CExtKey master_key;
+    master_key.SetSeed(GenerateRandomKey());
+    TestDescriptorScriptPubKeyMan spk_man{wallet, SINGLE_ADDRESS_KEYPOOL_SIZE};
+    WalletBatch setup_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(spk_man.SetupDescriptorGeneration(setup_batch, master_key, OutputType::BECH32, /*internal=*/false));
+    auto& database{GetMockableDatabase(wallet)};
+
+    const auto run_handoff = [&](bool commit_success) {
+        const unsigned int target_size{spk_man.GetKeyPoolSize() + 1};
+        const auto previous_scripts{spk_man.GetScriptPubKeys()};
+        WalletBatch preview_batch{wallet.GetDatabase()};
+        BOOST_REQUIRE(preview_batch.TxnBegin());
+        BOOST_REQUIRE(spk_man.TopUpWithDB(preview_batch, target_size, /*internal_hint=*/false));
+        const CScript script{FindNewScript(previous_scripts, spk_man.GetScriptPubKeys())};
+        BOOST_REQUIRE(preview_batch.TxnAbort());
+
+        std::promise<void> commit_boundary;
+        std::future<void> commit_boundary_future{commit_boundary.get_future()};
+        std::promise<void> release_commit;
+        std::shared_future<void> release_commit_future{release_commit.get_future().share()};
+        std::atomic<bool> hook_result_matches{false};
+        database.m_txn_commit_pass = commit_success;
+        database.m_txn_commit_result_hook = [&](bool result) {
+            hook_result_matches = result == commit_success;
+            commit_boundary.set_value();
+            release_commit_future.wait();
+        };
+
+        std::future<bool> top_up_future{std::async(std::launch::async, [&] {
+            try {
+                return spk_man.TopUpWithInternalHintResult(/*internal_hint=*/false, target_size).has_value();
+            } catch (const std::runtime_error&) {
+                return false;
+            }
+        })};
+        const bool reached_boundary{commit_boundary_future.wait_for(std::chrono::seconds{5}) == std::future_status::ready};
+
+        std::promise<void> lookup_started;
+        std::future<void> lookup_started_future{lookup_started.get_future()};
+        std::future<bool> lookup_future{std::async(std::launch::async, [&] {
+            lookup_started.set_value();
+            return IsTopUpScriptVisible(wallet, script);
+        })};
+        lookup_started_future.wait();
+        const bool lookup_waited{lookup_future.wait_for(std::chrono::milliseconds{100}) == std::future_status::timeout};
+        release_commit.set_value();
+
+        const bool top_up_succeeded{top_up_future.get()};
+        const bool visible{lookup_future.get()};
+        database.m_txn_commit_result_hook = {};
+        database.m_txn_commit_pass = true;
+        BOOST_REQUIRE(reached_boundary);
+        BOOST_CHECK(hook_result_matches);
+        BOOST_CHECK(lookup_waited);
+        BOOST_CHECK_EQUAL(top_up_succeeded, commit_success);
+        BOOST_CHECK_EQUAL(visible, commit_success);
+        BOOST_CHECK_EQUAL(IsTopUpScriptVisible(wallet, script), commit_success);
+    };
+
+    run_handoff(/*commit_success=*/true);
+    run_handoff(/*commit_success=*/false);
+}
+
+BOOST_AUTO_TEST_CASE(DescriptorTopUpPublicationCleanupUsesUniqueId)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    }
+
+    CExtKey master_key;
+    master_key.SetSeed(GenerateRandomKey());
+    TestDescriptorScriptPubKeyMan spk_man{wallet, SINGLE_ADDRESS_KEYPOOL_SIZE};
+    WalletBatch setup_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(spk_man.SetupDescriptorGeneration(setup_batch, master_key, OutputType::BECH32, /*internal=*/false));
+    const CScript script{*spk_man.GetScriptPubKeys().begin()};
+    const std::set<CScript> scripts{script};
+
+    const TopUpPublicationId first{wallet.StageTopUpPublication(scripts, &spk_man, spk_man.GetLifetimeToken())};
+    const TopUpPublicationId second{wallet.StageTopUpPublication(scripts, &spk_man, spk_man.GetLifetimeToken())};
+    wallet.BeginTopUpCommit(first);
+    wallet.BeginTopUpCommit(second);
+    wallet.FinishTopUpCommit(first, /*committed=*/true);
+    wallet.FinishTopUpCommit(second, /*committed=*/true);
+
+    BOOST_CHECK(wallet.TopUpCallback(scripts, &spk_man, first));
+    BOOST_CHECK(!wallet.TopUpCallback(scripts, &spk_man, first));
+    BOOST_CHECK(wallet.TopUpCallback(scripts, &spk_man, second));
+    BOOST_CHECK(!wallet.TopUpCallback(scripts, &spk_man, second));
+    BOOST_CHECK(IsTopUpScriptVisible(wallet, script));
+}
+
+BOOST_AUTO_TEST_CASE(DescriptorTopUpLookupDoesNotScanUnrelatedPublications)
+{
+    CWallet wallet(m_node.chain.get(), "", CreateMockableWalletDatabase());
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+    }
+
+    CExtKey master_key;
+    master_key.SetSeed(GenerateRandomKey());
+    CountingDescriptorScriptPubKeyMan spk_man{wallet, SINGLE_ADDRESS_KEYPOOL_SIZE};
+    WalletBatch setup_batch{wallet.GetDatabase()};
+    BOOST_REQUIRE(spk_man.SetupDescriptorGeneration(setup_batch, master_key, OutputType::BECH32, /*internal=*/false));
+    const CScript tracked_script{*spk_man.GetScriptPubKeys().begin()};
+    const std::set<CScript> scripts{tracked_script};
+    const TopUpPublicationId publication{wallet.StageTopUpPublication(scripts, &spk_man, spk_man.GetLifetimeToken())};
+    wallet.BeginTopUpCommit(publication);
+    wallet.FinishTopUpCommit(publication, /*committed=*/true);
+
+    spk_man.ResetLookupCounts();
+    const CScript unrelated_script{CScript{} << OP_TRUE};
+    BOOST_CHECK(!IsTopUpScriptVisible(wallet, unrelated_script));
+    BOOST_CHECK_EQUAL(spk_man.LookupCount(), 0);
+
+    wallet.CancelTopUpPublication(publication);
 }
 
 BOOST_AUTO_TEST_CASE(DescriptorTopUpCacheSupportsConcurrentReaders)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -1000,6 +1000,7 @@ BOOST_AUTO_TEST_CASE(DescriptorTopUpCacheSupportsConcurrentReaders)
     std::thread reader{[&] {
         while (!done.load()) {
             for (const CScript& script : spk_man->GetScriptPubKeys()) {
+                LOCK(wallet.cs_wallet);
                 if (wallet.GetScriptPubKeyMans(script).empty()) lookup_failed = true;
             }
         }

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -9,6 +9,9 @@
 #include <wallet/test/util.h>
 #include <wallet/wallet.h>
 
+#include <string>
+#include <vector>
+
 #include <boost/test/unit_test.hpp>
 
 namespace wallet {
@@ -42,6 +45,44 @@ BOOST_AUTO_TEST_CASE(walletdb_writecryptedpqckey_overwrite)
 
     BOOST_CHECK(batch.WriteCryptedDescriptorPQCKey(descriptor_id, pubkey, secret, /*sig_counter=*/0));
     BOOST_CHECK(batch.WriteCryptedDescriptorPQCKey(descriptor_id, pubkey, secret, /*sig_counter=*/1));
+}
+
+BOOST_AUTO_TEST_CASE(walletdb_transaction_listener_commit_phases)
+{
+    auto database = std::make_unique<MockableDatabase>();
+    WalletBatch batch(*database);
+    std::vector<std::string> events;
+    const auto listener = [&](std::string name) {
+        return DbTxnListener{
+            .on_commit_prepare = [&, name] { events.push_back("prepare_" + name); },
+            .on_commit_success = [&, name] { events.push_back("success_" + name); },
+            .on_commit_failure = [&, name] { events.push_back("failure_" + name); },
+            .on_commit = [&, name] { events.push_back("commit_" + name); },
+            .on_abort = [&, name] { events.push_back("abort_" + name); },
+        };
+    };
+
+    BOOST_REQUIRE(batch.TxnBegin());
+    batch.RegisterTxnListener(listener("one"));
+    batch.RegisterTxnListener(listener("two"));
+    BOOST_REQUIRE(batch.TxnCommit());
+    const std::vector<std::string> expected_success{
+        "prepare_one", "prepare_two", "success_one", "success_two", "commit_one", "commit_two"};
+    BOOST_CHECK(events == expected_success);
+
+    events.clear();
+    database->m_txn_commit_pass = false;
+    BOOST_REQUIRE(batch.TxnBegin());
+    batch.RegisterTxnListener(listener("one"));
+    batch.RegisterTxnListener(listener("two"));
+    BOOST_CHECK(!batch.TxnCommit());
+    const std::vector<std::string> expected_failure{
+        "prepare_one", "prepare_two", "failure_one", "failure_two"};
+    BOOST_CHECK(events == expected_failure);
+    BOOST_REQUIRE(batch.TxnAbort());
+    const std::vector<std::string> expected_abort{
+        "prepare_one", "prepare_two", "failure_one", "failure_two", "abort_two", "abort_one"};
+    BOOST_CHECK(events == expected_abort);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1946,7 +1946,14 @@ bool CWallet::IsMine(const CScript& script) const
         return res;
     }
 
-    return false;
+    // A committed descriptor top-up publishes into m_cached_spks immediately after
+    // the database transaction commits. Fall back to the managers during that
+    // narrow handoff so transaction processing cannot miss a newly durable script.
+    bool res{false};
+    for (const auto& [_, spkm] : m_spk_managers) {
+        res = spkm->IsMine(script) || res;
+    }
+    return res;
 }
 
 bool CWallet::IsMine(const CTransaction& tx) const
@@ -4549,12 +4556,18 @@ ScriptPubKeyMan* CWallet::GetScriptPubKeyMan(const OutputType& type, bool intern
 
 std::set<ScriptPubKeyMan*> CWallet::GetScriptPubKeyMans(const CScript& script) const
 {
+    LOCK(cs_wallet);
     std::set<ScriptPubKeyMan*> spk_mans;
 
     // Search the cache for relevant SPKMs instead of iterating m_spk_managers
     const auto& it = m_cached_spks.find(script);
     if (it != m_cached_spks.end()) {
         spk_mans.insert(it->second.begin(), it->second.end());
+    } else {
+        for (const auto& [_, spkm] : m_spk_managers) {
+            SignatureData sigdata;
+            if (spkm->CanProvide(script, sigdata)) spk_mans.insert(spkm.get());
+        }
     }
     SignatureData sigdata;
     Assume(std::all_of(spk_mans.begin(), spk_mans.end(), [&script, &sigdata](ScriptPubKeyMan* spkm) { return spkm->CanProvide(script, sigdata); }));
@@ -4578,12 +4591,17 @@ std::unique_ptr<SigningProvider> CWallet::GetSolvingProvider(const CScript& scri
 
 std::unique_ptr<SigningProvider> CWallet::GetSolvingProvider(const CScript& script, SignatureData& sigdata) const
 {
+    LOCK(cs_wallet);
     // Search the cache for relevant SPKMs instead of iterating m_spk_managers
     const auto& it = m_cached_spks.find(script);
     if (it != m_cached_spks.end()) {
         // All spkms for a given script must already be able to make a SigningProvider for the script, so just return the first one.
         Assume(it->second.at(0)->CanProvide(script, sigdata));
         return it->second.at(0)->GetSolvingProvider(script);
+    }
+
+    for (const auto& [_, spkm] : m_spk_managers) {
+        if (spkm->CanProvide(script, sigdata)) return spkm->GetSolvingProvider(script);
     }
 
     return nullptr;
@@ -4800,7 +4818,10 @@ void CWallet::SetupDescriptorScriptPubKeyMans(bool use_create_keypool_warmup)
         }
 
         // Ensure imported descriptors are committed to disk
-        if (!batch.TxnCommit()) throw std::runtime_error("Error: cannot commit db transaction for descriptors import");
+        if (!batch.TxnCommit()) {
+            if (batch.HasActiveTxn()) batch.TxnAbort();
+            throw std::runtime_error("Error: cannot commit db transaction for descriptors import");
+        }
     }
 }
 
@@ -5064,8 +5085,14 @@ util::Result<void> CWallet::ApplyMigrationData(WalletBatch& local_wallet_batch, 
     // When the legacy wallet has no spendable scripts, the main wallet will be empty, leaving its script cache empty as well.
     // The watch-only and/or solvable wallet(s) will contain the scripts in their respective caches.
     if (!data.desc_spkms.empty()) Assume(!m_cached_spks.empty());
-    if (!data.watch_descs.empty()) Assume(!data.watchonly_wallet->m_cached_spks.empty());
-    if (!data.solvable_descs.empty()) Assume(!data.solvable_wallet->m_cached_spks.empty());
+    if (!data.watch_descs.empty()) {
+        LOCK(data.watchonly_wallet->cs_wallet);
+        Assume(!data.watchonly_wallet->m_cached_spks.empty());
+    }
+    if (!data.solvable_descs.empty()) {
+        LOCK(data.solvable_wallet->cs_wallet);
+        Assume(!data.solvable_wallet->m_cached_spks.empty());
+    }
 
     for (auto& desc_spkm : data.desc_spkms) {
         if (m_spk_managers.count(desc_spkm->GetID()) > 0) {
@@ -5620,6 +5647,7 @@ util::Result<MigrationResult> MigrateLegacyToDescriptor(std::shared_ptr<CWallet>
 
 void CWallet::CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm)
 {
+    AssertLockHeld(cs_wallet);
     for (const auto& script : spks) {
         m_cached_spks[script].push_back(spkm);
     }
@@ -5627,6 +5655,7 @@ void CWallet::CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyM
 
 void CWallet::TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm)
 {
+    LOCK(cs_wallet);
     // Update scriptPubKey cache
     CacheNewScriptPubKeys(spks, spkm);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3192,22 +3192,28 @@ util::Result<void> CWallet::RemoveTxs(WalletBatch& batch, std::vector<Txid>& txs
     }
 
     // Register callback to update the memory state only when the db txn is actually dumped to disk
-    batch.RegisterTxnListener({.on_commit=[&, erased_txs]() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
-        // Update the in-memory state and notify upper layers about the removals
-        for (const auto& it : erased_txs) {
-            const Txid hash{it->first};
-            wtxOrdered.erase(it->second.m_it_wtxOrdered);
-            for (const auto& txin : it->second.tx->vin)
-                mapTxSpends.erase(txin.prevout);
-            for (unsigned int i = 0; i < it->second.tx->vout.size(); ++i) {
-                m_txos.erase(COutPoint(hash, i));
+    batch.RegisterTxnListener({
+        .on_commit_prepare = {},
+        .on_commit_success = {},
+        .on_commit_failure = {},
+        .on_commit = [&, erased_txs]() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
+            // Update the in-memory state and notify upper layers about the removals
+            for (const auto& it : erased_txs) {
+                const Txid hash{it->first};
+                wtxOrdered.erase(it->second.m_it_wtxOrdered);
+                for (const auto& txin : it->second.tx->vin)
+                    mapTxSpends.erase(txin.prevout);
+                for (unsigned int i = 0; i < it->second.tx->vout.size(); ++i) {
+                    m_txos.erase(COutPoint(hash, i));
+                }
+                mapWallet.erase(it);
+                NotifyTransactionChanged(hash, CT_DELETED);
             }
-            mapWallet.erase(it);
-            NotifyTransactionChanged(hash, CT_DELETED);
-        }
 
-        MarkDirty();
-    }, .on_abort={}});
+            MarkDirty();
+        },
+        .on_abort = {},
+    });
 
     return {};
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4629,8 +4629,9 @@ LegacyDataSPKM* CWallet::GetLegacyDataSPKM() const
     return dynamic_cast<LegacyDataSPKM*>(it->second);
 }
 
-void CWallet::AddScriptPubKeyMan(const uint256& id, std::unique_ptr<ScriptPubKeyMan> spkm_man)
+void CWallet::AddScriptPubKeyMan(const uint256& id, std::unique_ptr<ScriptPubKeyMan> spkm_man) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
+    AssertLockHeld(cs_wallet);
     // Add spkm_man to m_spk_managers before calling any method
     // that might access it.
     const auto& spkm = m_spk_managers[id] = std::move(spkm_man);
@@ -4645,7 +4646,7 @@ LegacyDataSPKM* CWallet::GetOrCreateLegacyDataSPKM()
     return GetLegacyDataSPKM();
 }
 
-void CWallet::SetupLegacyScriptPubKeyMan()
+void CWallet::SetupLegacyScriptPubKeyMan() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     if (!m_internal_spk_managers.empty() || !m_external_spk_managers.empty() || !m_spk_managers.empty() || IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS)) {
         return;
@@ -4689,7 +4690,7 @@ void CWallet::ConnectScriptPubKeyManNotifiers()
     }
 }
 
-DescriptorScriptPubKeyMan& CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc)
+DescriptorScriptPubKeyMan& CWallet::LoadDescriptorScriptPubKeyMan(uint256 id, WalletDescriptor& desc) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     DescriptorScriptPubKeyMan* spk_manager;
     if (IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1946,11 +1946,10 @@ bool CWallet::IsMine(const CScript& script) const
         return res;
     }
 
-    // A committed descriptor top-up publishes into m_cached_spks immediately after
-    // the database transaction commits. Fall back to the managers during that
-    // narrow handoff so transaction processing cannot miss a newly durable script.
+    // Consult only exact scripts whose database commit completed while their
+    // wallet cache publication is still pending.
     bool res{false};
-    for (const auto& [_, spkm] : m_spk_managers) {
+    for (ScriptPubKeyMan* spkm : GetCommittedTopUpScriptPubKeyMans(script)) {
         res = spkm->IsMine(script) || res;
     }
     return res;
@@ -4563,11 +4562,13 @@ std::set<ScriptPubKeyMan*> CWallet::GetScriptPubKeyMans(const CScript& script) c
     const auto& it = m_cached_spks.find(script);
     if (it != m_cached_spks.end()) {
         spk_mans.insert(it->second.begin(), it->second.end());
-    } else {
-        for (const auto& [_, spkm] : m_spk_managers) {
-            SignatureData sigdata;
-            if (spkm->CanProvide(script, sigdata)) spk_mans.insert(spkm.get());
-        }
+    }
+    // A second manager may have committed the same script while existing
+    // managers are already cached, so merge rather than treating this as a
+    // total-cache-miss-only fallback.
+    for (ScriptPubKeyMan* spkm : GetCommittedTopUpScriptPubKeyMans(script)) {
+        SignatureData sigdata;
+        if (spkm->CanProvide(script, sigdata)) spk_mans.insert(spkm);
     }
     SignatureData sigdata;
     Assume(std::all_of(spk_mans.begin(), spk_mans.end(), [&script, &sigdata](ScriptPubKeyMan* spkm) { return spkm->CanProvide(script, sigdata); }));
@@ -4600,7 +4601,7 @@ std::unique_ptr<SigningProvider> CWallet::GetSolvingProvider(const CScript& scri
         return it->second.at(0)->GetSolvingProvider(script);
     }
 
-    for (const auto& [_, spkm] : m_spk_managers) {
+    for (ScriptPubKeyMan* spkm : GetCommittedTopUpScriptPubKeyMans(script)) {
         if (spkm->CanProvide(script, sigdata)) return spkm->GetSolvingProvider(script);
     }
 
@@ -5650,15 +5651,119 @@ void CWallet::CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyM
 {
     AssertLockHeld(cs_wallet);
     for (const auto& script : spks) {
-        m_cached_spks[script].push_back(spkm);
+        auto& managers{m_cached_spks[script]};
+        if (std::find(managers.begin(), managers.end(), spkm) == managers.end()) managers.push_back(spkm);
     }
 }
 
-void CWallet::TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm)
+void CWallet::EraseTopUpPublication(TopUpPublicationId id)
+{
+    AssertLockHeld(m_topup_pub_mutex);
+    const auto publication_it{m_topup_publications.find(id)};
+    if (publication_it == m_topup_publications.end()) return;
+    for (const CScript& script : publication_it->second.scripts) {
+        const auto script_it{m_topup_publications_by_script.find(script)};
+        if (script_it == m_topup_publications_by_script.end()) continue;
+        std::erase(script_it->second, id);
+        if (script_it->second.empty()) m_topup_publications_by_script.erase(script_it);
+    }
+    m_topup_publications.erase(publication_it);
+}
+
+std::vector<ScriptPubKeyMan*> CWallet::GetCommittedTopUpScriptPubKeyMans(const CScript& script) const NO_THREAD_SAFETY_ANALYSIS
+{
+    AssertLockHeld(cs_wallet);
+    WAIT_LOCK(m_topup_pub_mutex, lock);
+    m_topup_pub_cv.wait(lock, [&]() EXCLUSIVE_LOCKS_REQUIRED(m_topup_pub_mutex) {
+        const auto script_it{m_topup_publications_by_script.find(script)};
+        if (script_it == m_topup_publications_by_script.end()) return true;
+        return std::none_of(script_it->second.begin(), script_it->second.end(), [&](TopUpPublicationId id) EXCLUSIVE_LOCKS_REQUIRED(m_topup_pub_mutex) {
+            const auto publication_it{m_topup_publications.find(id)};
+            return publication_it != m_topup_publications.end() && publication_it->second.state == TopUpPublicationState::COMMITTING;
+        });
+    });
+
+    std::vector<ScriptPubKeyMan*> managers;
+    const auto script_it{m_topup_publications_by_script.find(script)};
+    if (script_it == m_topup_publications_by_script.end()) return managers;
+    for (TopUpPublicationId id : script_it->second) {
+        const auto publication_it{m_topup_publications.find(id)};
+        if (publication_it == m_topup_publications.end()) continue;
+        const TopUpPublicationRecord& publication{publication_it->second};
+        if (publication.state != TopUpPublicationState::COMMITTED_PENDING_CACHE || publication.lifetime.expired()) continue;
+        if (std::find(managers.begin(), managers.end(), publication.spkm) == managers.end()) managers.push_back(publication.spkm);
+    }
+    return managers;
+}
+
+TopUpPublicationId CWallet::StageTopUpPublication(const std::set<CScript>& spks, ScriptPubKeyMan* spkm, std::weak_ptr<void> lifetime) NO_THREAD_SAFETY_ANALYSIS
+{
+    LOCK(m_topup_pub_mutex);
+    assert(m_next_topup_pub_id != INVALID_TOPUP_PUBLICATION_ID);
+    const TopUpPublicationId id{m_next_topup_pub_id++};
+    auto [publication_it, inserted]{m_topup_publications.emplace(id, TopUpPublicationRecord{spkm, std::move(lifetime), spks})};
+    assert(inserted);
+    try {
+        for (const CScript& script : spks) {
+            m_topup_publications_by_script[script].push_back(id);
+        }
+    } catch (...) {
+        EraseTopUpPublication(id);
+        throw;
+    }
+    return id;
+}
+
+void CWallet::BeginTopUpCommit(TopUpPublicationId id) NO_THREAD_SAFETY_ANALYSIS
+{
+    LOCK(m_topup_pub_mutex);
+    const auto it{m_topup_publications.find(id)};
+    assert(it != m_topup_publications.end());
+    assert(it->second.state == TopUpPublicationState::STAGED);
+    it->second.state = TopUpPublicationState::COMMITTING;
+}
+
+void CWallet::FinishTopUpCommit(TopUpPublicationId id, bool committed) NO_THREAD_SAFETY_ANALYSIS
+{
+    {
+        LOCK(m_topup_pub_mutex);
+        const auto it{m_topup_publications.find(id)};
+        if (it == m_topup_publications.end()) return;
+        assert(it->second.state == TopUpPublicationState::COMMITTING);
+        it->second.state = committed ? TopUpPublicationState::COMMITTED_PENDING_CACHE : TopUpPublicationState::STAGED;
+    }
+    m_topup_pub_cv.notify_all();
+}
+
+void CWallet::CancelTopUpPublication(TopUpPublicationId id) NO_THREAD_SAFETY_ANALYSIS
+{
+    if (id == INVALID_TOPUP_PUBLICATION_ID) return;
+    {
+        LOCK(m_topup_pub_mutex);
+        EraseTopUpPublication(id);
+    }
+    m_topup_pub_cv.notify_all();
+}
+
+bool CWallet::TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm, TopUpPublicationId id) NO_THREAD_SAFETY_ANALYSIS
 {
     LOCK(cs_wallet);
+    if (id != INVALID_TOPUP_PUBLICATION_ID) {
+        LOCK(m_topup_pub_mutex);
+        const auto it{m_topup_publications.find(id)};
+        if (it == m_topup_publications.end()) return false;
+        assert(it->second.state == TopUpPublicationState::COMMITTED_PENDING_CACHE);
+        if (it->second.spkm != spkm || it->second.scripts != spks || it->second.lifetime.expired()) {
+            EraseTopUpPublication(id);
+            return false;
+        }
+        CacheNewScriptPubKeys(spks, spkm);
+        EraseTopUpPublication(id);
+        return true;
+    }
     // Update scriptPubKey cache
     CacheNewScriptPubKeys(spks, spkm);
+    return true;
 }
 
 std::set<CExtPubKey> CWallet::GetActiveHDPubKeys() const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -492,7 +492,7 @@ private:
     void SetWalletFlagWithDB(WalletBatch& batch, uint64_t flags);
 
     //! Cache of descriptor ScriptPubKeys used for IsMine. Maps ScriptPubKey to set of spkms
-    std::unordered_map<CScript, std::vector<ScriptPubKeyMan*>, SaltedSipHasher> m_cached_spks;
+    std::unordered_map<CScript, std::vector<ScriptPubKeyMan*>, SaltedSipHasher> m_cached_spks GUARDED_BY(cs_wallet);
 
     //! Set of both spent and unspent transaction outputs owned by this wallet
     std::unordered_map<COutPoint, WalletTXO, SaltedOutpointHasher> m_txos GUARDED_BY(cs_wallet);
@@ -1166,7 +1166,7 @@ public:
     bool CanGrindR() const;
 
     //! Add scriptPubKeys for this ScriptPubKeyMan into the scriptPubKey cache
-    void CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm);
+    void CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     void TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm) override;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -494,6 +494,29 @@ private:
     //! Cache of descriptor ScriptPubKeys used for IsMine. Maps ScriptPubKey to set of spkms
     std::unordered_map<CScript, std::vector<ScriptPubKeyMan*>, SaltedSipHasher> m_cached_spks GUARDED_BY(cs_wallet);
 
+    enum class TopUpPublicationState {
+        STAGED,
+        COMMITTING,
+        COMMITTED_PENDING_CACHE,
+    };
+    struct TopUpPublicationRecord {
+        ScriptPubKeyMan* spkm;
+        std::weak_ptr<void> lifetime;
+        std::set<CScript> scripts;
+        TopUpPublicationState state{TopUpPublicationState::STAGED};
+    };
+
+    // Exact scripts crossing the database-commit-to-wallet-cache handoff. This
+    // mutex is never held while acquiring cs_wallet or a descriptor lock.
+    mutable Mutex m_topup_pub_mutex;
+    mutable std::condition_variable_any m_topup_pub_cv;
+    TopUpPublicationId m_next_topup_pub_id GUARDED_BY(m_topup_pub_mutex){1};
+    std::unordered_map<TopUpPublicationId, TopUpPublicationRecord> m_topup_publications GUARDED_BY(m_topup_pub_mutex);
+    std::unordered_map<CScript, std::vector<TopUpPublicationId>, SaltedSipHasher> m_topup_publications_by_script GUARDED_BY(m_topup_pub_mutex);
+
+    void EraseTopUpPublication(TopUpPublicationId id) EXCLUSIVE_LOCKS_REQUIRED(m_topup_pub_mutex);
+    std::vector<ScriptPubKeyMan*> GetCommittedTopUpScriptPubKeyMans(const CScript& script) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     //! Set of both spent and unspent transaction outputs owned by this wallet
     std::unordered_map<COutPoint, WalletTXO, SaltedOutpointHasher> m_txos GUARDED_BY(cs_wallet);
 
@@ -1168,7 +1191,11 @@ public:
     //! Add scriptPubKeys for this ScriptPubKeyMan into the scriptPubKey cache
     void CacheNewScriptPubKeys(const std::set<CScript>& spks, ScriptPubKeyMan* spkm) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    void TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm) override;
+    TopUpPublicationId StageTopUpPublication(const std::set<CScript>& spks, ScriptPubKeyMan* spkm, std::weak_ptr<void> lifetime) override;
+    void BeginTopUpCommit(TopUpPublicationId id) override;
+    void FinishTopUpCommit(TopUpPublicationId id, bool committed) override;
+    void CancelTopUpPublication(TopUpPublicationId id) override;
+    bool TopUpCallback(const std::set<CScript>& spks, ScriptPubKeyMan* spkm, TopUpPublicationId id = INVALID_TOPUP_PUBLICATION_ID) override;
 
     //! Retrieve the xpubs in use by the active descriptors
     std::set<CExtPubKey> GetActiveHDPubKeys() const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1478,6 +1478,9 @@ static bool RunWithinTxn(WalletBatch& batch, std::string_view process_desc, cons
 
     if (!batch.TxnCommit()) {
         LogDebug(BCLog::WALLETDB, "Error: cannot commit db txn for %s\n", process_desc);
+        if (batch.HasActiveTxn() && !batch.TxnAbort()) {
+            LogDebug(BCLog::WALLETDB, "Error: cannot abort db txn after commit failure for %s\n", process_desc);
+        }
         return false;
     }
 
@@ -1541,12 +1544,24 @@ bool WalletBatch::TxnBegin()
     return m_batch->TxnBegin();
 }
 
+WalletBatch::~WalletBatch()
+{
+    if (!HasActiveTxn()) return;
+    try {
+        if (!TxnAbort()) {
+            LogDebug(BCLog::WALLETDB, "Error: cannot abort active db txn while destroying wallet batch\n");
+        }
+    } catch (const std::exception& e) {
+        LogDebug(BCLog::WALLETDB, "Error aborting active db txn while destroying wallet batch: %s\n", e.what());
+    }
+}
+
 bool WalletBatch::TxnCommit()
 {
     bool res = m_batch->TxnCommit();
     if (res) {
         for (const auto& listener : m_txn_listeners) {
-            listener.on_commit();
+            if (listener.on_commit) listener.on_commit();
         }
         // txn finished, clear listeners
         m_txn_listeners.clear();
@@ -1558,8 +1573,8 @@ bool WalletBatch::TxnAbort()
 {
     bool res = m_batch->TxnAbort();
     if (res) {
-        for (const auto& listener : m_txn_listeners) {
-            listener.on_abort();
+        for (auto it = m_txn_listeners.rbegin(); it != m_txn_listeners.rend(); ++it) {
+            if (it->on_abort) it->on_abort();
         }
         // txn finished, clear listeners
         m_txn_listeners.clear();

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -27,6 +27,7 @@
 #include <atomic>
 #include <algorithm>
 #include <array>
+#include <exception>
 #include <optional>
 #include <span>
 #include <string>
@@ -1558,15 +1559,75 @@ WalletBatch::~WalletBatch()
 
 bool WalletBatch::TxnCommit()
 {
-    bool res = m_batch->TxnCommit();
-    if (res) {
+    size_t prepared{0};
+    try {
         for (const auto& listener : m_txn_listeners) {
-            if (listener.on_commit) listener.on_commit();
+            ++prepared;
+            if (listener.on_commit_prepare) listener.on_commit_prepare();
         }
-        // txn finished, clear listeners
-        m_txn_listeners.clear();
+    } catch (...) {
+        const std::exception_ptr prepare_error{std::current_exception()};
+        for (size_t i{0}; i < prepared; ++i) {
+            try {
+                if (m_txn_listeners[i].on_commit_failure) m_txn_listeners[i].on_commit_failure();
+            } catch (...) {
+            }
+        }
+        std::rethrow_exception(prepare_error);
     }
-    return res;
+
+    bool res{false};
+    try {
+        res = m_batch->TxnCommit();
+    } catch (...) {
+        const std::exception_ptr commit_error{std::current_exception()};
+        for (const auto& listener : m_txn_listeners) {
+            try {
+                if (listener.on_commit_failure) listener.on_commit_failure();
+            } catch (...) {
+            }
+        }
+        std::rethrow_exception(commit_error);
+    }
+
+    if (!res) {
+        std::exception_ptr callback_error;
+        for (const auto& listener : m_txn_listeners) {
+            try {
+                if (listener.on_commit_failure) listener.on_commit_failure();
+            } catch (...) {
+                if (!callback_error) callback_error = std::current_exception();
+            }
+        }
+        if (callback_error) std::rethrow_exception(callback_error);
+        return false;
+    }
+
+    // The database is durable. Move listeners out so callbacks are never run
+    // again even if an outcome or publication callback throws.
+    std::vector<DbTxnListener> listeners{std::move(m_txn_listeners)};
+    m_txn_listeners.clear();
+    std::exception_ptr callback_error;
+    for (const auto& listener : listeners) {
+        try {
+            if (listener.on_commit_success) listener.on_commit_success();
+        } catch (...) {
+            if (!callback_error) callback_error = std::current_exception();
+        }
+    }
+    // Resolve every transaction outcome before a publication callback can
+    // acquire cs_wallet. This lets readers wait on COMMITTING safely.
+    if (!callback_error) {
+        for (const auto& listener : listeners) {
+            try {
+                if (listener.on_commit) listener.on_commit();
+            } catch (...) {
+                if (!callback_error) callback_error = std::current_exception();
+            }
+        }
+    }
+    if (callback_error) std::rethrow_exception(callback_error);
+    return true;
 }
 
 bool WalletBatch::TxnAbort()

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -220,6 +220,7 @@ public:
     }
     WalletBatch(const WalletBatch&) = delete;
     WalletBatch& operator=(const WalletBatch&) = delete;
+    ~WalletBatch();
 
     bool WriteName(const std::string& strAddress, const std::string& strName);
     bool EraseName(const std::string& strAddress);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -182,6 +182,11 @@ public:
 
 struct DbTxnListener
 {
+    // Commit outcome callbacks must not acquire wallet or descriptor locks.
+    // All success outcomes are resolved before any on_commit publication runs.
+    std::function<void()> on_commit_prepare;
+    std::function<void()> on_commit_success;
+    std::function<void()> on_commit_failure;
     std::function<void()> on_commit, on_abort;
 };
 

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -116,9 +116,13 @@ class TestBitcoinCli(BitcoinTestFramework):
         initial_balance = (BLOCKS - COINBASE_MATURITY) * block_subsidy
 
         self.log.info("Compare responses from getblockchaininfo RPC and `qbit-cli getblockchaininfo`")
-        cli_response = self.nodes[0].cli.getblockchaininfo()
-        rpc_response = self.nodes[0].getblockchaininfo()
-        assert_equal(cli_response, rpc_response)
+        self.nodes[0].setmocktime(int(time.time()))
+        try:
+            cli_response = self.nodes[0].cli.getblockchaininfo()
+            rpc_response = self.nodes[0].getblockchaininfo()
+            assert_equal(cli_response, rpc_response)
+        finally:
+            self.nodes[0].setmocktime(0)
 
         self.log.info("Test named arguments")
         assert_equal(self.nodes[0].cli.echo(0, 1, arg3=3, arg5=5), ['0', '1', None, '3', None, '5'])


### PR DESCRIPTION
## Summary

Fixes #139.

Descriptor top-up now stages newly derived scripts and publishes wallet ownership/cache updates only after the backing database transaction commits. Standalone top-ups retain the descriptor lock through commit, then release descriptor/database state before acquiring the wallet lock for publication. Top-ups running inside caller-owned transactions register commit and abort listeners so successful transactions publish once while aborts restore descriptor, keypool, cache, and PQC state.

`CWallet::m_cached_spks` is now explicitly guarded by `cs_wallet`, and cache misses fall back to querying script managers during the narrow commit-to-publication handoff. Transaction listeners also abort on commit failure or scope exit and unwind in reverse order.

The mock wallet database now models active transactions and rollback, enabling regression coverage for commit failure, external transaction publication order, multi-top-up abort ordering, and concurrent cache readers.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason:

Commands and configurations:

- `cmake --build build --target test_bitcoin -j4`
- `cmake --build build-debug --target test_bitcoin -j4`
- `build/bin/test_qbit --run_test='wallet_tests,walletdb_tests,wallet_p2mr_change_keypool_tests,wallet_p2mr_deferred_keypool_tests,wallet_p2mr_descriptor_tests' --log_level=message`
- `build-debug/bin/test_qbit --run_test='wallet_tests/DescriptorTopUp*' --log_level=message`
- `build-debug/bin/test_qbit --run_test='wallet_p2mr_change_keypool_tests,wallet_p2mr_deferred_keypool_tests' --log_level=message`
- Docker lint image from `ci/lint_imagefile`: all checks passed.
- `git diff --check`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.x.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- Wallet transaction publication and lock ordering changed; consensus, script validation, networking, and on-disk schema are unchanged.
- Review should focus on commit/abort callback lifetime, reverse-order rollback, and the wallet-to-descriptor lock order in cache-miss fallbacks.
- Deferred initial and low-watermark P2MR top-ups remain outside `cs_wallet` during derivation and persistence.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this corrects internal wallet synchronization and transaction publication without changing user-facing APIs or configuration.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; `src/libbitcoinpqc` is unchanged.

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786896268&installation_id=141183937&pr_number=144&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F144&signature=8803a7b4aef28b57c4f4b44b41d3187fa928b778ac313b3d19193ea1987e3e4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet lock ordering, in-memory vs durable publication, and transaction listener lifetimes; incorrect rollback or cache-miss fallback could miss or mis-attribute outputs, though consensus and on-disk schema are unchanged.
> 
> **Overview**
> Descriptor keypool top-ups now **stage** new scripts and wallet-visible updates until the backing DB transaction succeeds, instead of updating `TopUpCallback` and notifications while writes may still roll back.
> 
> **`TopUpChange`** captures new scriptPubKeys plus a rollback closure; standalone top-ups commit under `cs_desc_man`, then call **`PublishTopUp`** outside that lock. Top-ups inside a caller-owned **`WalletBatch`** register commit/abort listeners so publication runs once on commit and descriptor/keypool/PQC state is restored on abort (including after commit failure).
> 
> **`m_cached_spks`** is explicitly **`GUARDED_BY(cs_wallet)`**; **`TopUpCallback`** and cache helpers take **`cs_wallet`**. **`IsMine`**, **`GetScriptPubKeyMans`**, and **`GetSolvingProvider`** fall back to script managers on cache miss during the narrow post-commit handoff. **`SetCache`** narrows the descriptor lock scope before publishing.
> 
> **`WalletBatch`** destructor aborts active transactions; commit failure attempts abort; abort listeners run in **reverse** order. Migration/descriptor import paths abort when commit fails.
> 
> **Mockable** wallet DB implements real txn snapshots for tests; new wallet tests cover commit failure rollback, deferred publication in external txns, and concurrent cache readers. Functional test pins mock time for stable **`getblockchaininfo`** CLI comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b614e8a567fceda8fc365a90eb98daacf63913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->