### PR TITLE
qt: move PSBT signing off GUI thread

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -238,7 +238,8 @@ public:
         size_t* n_signed,
         PartiallySignedTransaction& psbtx,
         bool& complete,
-        wallet::PQCUsageReport* pqc_usage = nullptr) = 0;
+        wallet::PQCUsageReport* pqc_usage = nullptr,
+        const SigningProgressCallback& progress_callback = {}) = 0;
 
     //! Get balances.
     virtual WalletBalances getBalances() = 0;

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -17,16 +17,48 @@
 #include <qt/optionsmodel.h>
 #include <util/fs.h>
 #include <util/strencodings.h>
+#include <wallet/pqc_usage.h>
 
+#include <algorithm>
+#include <exception>
 #include <fstream>
 #include <iostream>
+#include <memory>
+#include <optional>
 #include <string>
+
+#include <QMetaObject>
+#include <QProgressBar>
+#include <QProgressDialog>
+#include <QThread>
+#include <QTimer>
 
 using common::TransactionErrorString;
 using node::AnalyzePSBT;
 using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
 using node::PSBTAnalysis;
 using node::TransactionError;
+
+namespace {
+std::unique_ptr<interfaces::Wallet> GetBackgroundWallet(interfaces::Node& node, const std::string& wallet_name)
+{
+    for (auto& wallet : node.walletLoader().getWallets()) {
+        if (wallet && wallet->getWalletName() == wallet_name) {
+            return std::move(wallet);
+        }
+    }
+    return nullptr;
+}
+} // namespace
+
+struct PSBTOperationsDialog::SignResult {
+    PartiallySignedTransaction psbt;
+    std::optional<common::PSBTError> error;
+    std::string exception;
+    size_t n_signed{0};
+    bool complete{false};
+    wallet::PQCUsageReport pqc_usage;
+};
 
 PSBTOperationsDialog::PSBTOperationsDialog(
     QWidget* parent, WalletModel* wallet_model, ClientModel* client_model) : QDialog(parent, GUIUtil::dialog_flags),
@@ -49,6 +81,16 @@ PSBTOperationsDialog::PSBTOperationsDialog(
 
 PSBTOperationsDialog::~PSBTOperationsDialog()
 {
+    m_sign_cancel_requested = true;
+    clearSignProgressDialog();
+    if (m_sign_thread) {
+        QThread* thread = m_sign_thread;
+        m_sign_thread = nullptr;
+        disconnect(thread, nullptr, this, nullptr);
+        thread->wait();
+        delete thread;
+    }
+    m_sign_unlock_context.reset();
     delete m_ui;
 }
 
@@ -78,33 +120,252 @@ void PSBTOperationsDialog::openWithPSBT(PartiallySignedTransaction psbtx)
 
 void PSBTOperationsDialog::signTransaction()
 {
-    bool complete;
-    size_t n_signed;
-
-    WalletModel::UnlockContext ctx(m_wallet_model->requestUnlock());
-
-    const auto err{m_wallet_model->wallet().fillPSBT(std::nullopt, /*sign=*/true, /*bip32derivs=*/true, &n_signed, m_transaction_data, complete)};
-
-    if (err) {
-        showStatus(tr("Failed to sign transaction: %1")
-            .arg(QString::fromStdString(PSBTErrorString(*err).translated)), StatusLevel::ERR);
+    if (m_sign_thread || !m_wallet_model) {
         return;
     }
 
-    updateTransactionDisplay();
+    m_sign_unlock_context = std::make_unique<WalletModel::UnlockContext>(m_wallet_model->requestUnlock());
 
-    if (!complete && !ctx.isValid()) {
+    std::unique_ptr<interfaces::Wallet> wallet = m_wallet_model->wallet().clone();
+    if (!wallet) {
+        wallet = GetBackgroundWallet(m_wallet_model->node(), m_wallet_model->wallet().getWalletName());
+    }
+    if (!wallet) {
+        showStatus(tr("Failed to sign transaction: Wallet is no longer loaded."), StatusLevel::ERR);
+        m_sign_unlock_context.reset();
+        return;
+    }
+
+    clearSignProgressDialog();
+    const uint64_t generation = ++m_sign_generation;
+    m_sign_cancel_requested = false;
+    m_sign_counters_reserved = false;
+    m_last_sign_pqc_usage.reset();
+    setSigningControlsEnabled(false);
+
+    m_sign_progress_dialog = new QProgressDialog(this);
+    m_sign_progress_dialog->setObjectName(QStringLiteral("psbtSigningProgressDialog"));
+    m_sign_progress_dialog->setWindowTitle(tr("Signing Transaction"));
+    m_sign_progress_dialog->setLabelText(tr("Preparing transaction..."));
+    m_sign_progress_dialog->setCancelButtonText(tr("Cancel"));
+    m_sign_progress_bar = new QProgressBar(m_sign_progress_dialog);
+    m_sign_progress_bar->setRange(0, 0);
+    m_sign_progress_dialog->setBar(m_sign_progress_bar);
+    m_sign_progress_dialog->setMinimumDuration(250);
+    m_sign_progress_dialog->setAutoClose(false);
+    m_sign_progress_dialog->setAutoReset(false);
+    m_sign_progress_dialog->setWindowModality(Qt::ApplicationModal);
+    GUIUtil::PolishProgressDialog(m_sign_progress_dialog);
+    connect(m_sign_progress_dialog, &QProgressDialog::canceled, this, &PSBTOperationsDialog::cancelSignTransaction);
+    QTimer::singleShot(250, m_sign_progress_dialog, [this, generation] {
+        if (generation == m_sign_generation && m_sign_progress_dialog) {
+            m_sign_progress_dialog->show();
+        }
+    });
+
+    QPointer<PSBTOperationsDialog> dialog(this);
+    std::atomic_bool* cancel_flag = &m_sign_cancel_requested;
+    std::atomic_bool* counters_reserved_flag = &m_sign_counters_reserved;
+    QThread* thread = QThread::create([dialog,
+                                       generation,
+                                       wallet = std::move(wallet),
+                                       psbt = m_transaction_data,
+                                       cancel_flag,
+                                       counters_reserved_flag]() mutable {
+        auto result = std::make_shared<SignResult>();
+        result->psbt = std::move(psbt);
+        SigningProgressCallback progress_callback = [dialog, generation, cancel_flag, counters_reserved_flag](const SigningProgress& progress) {
+            if (!progress.cancellable) counters_reserved_flag->store(true);
+            const bool cancellable{progress.cancellable && !counters_reserved_flag->load()};
+            if (dialog) {
+                QMetaObject::invokeMethod(dialog, [dialog, generation, progress] {
+                    if (dialog) dialog->signTransactionProgress(generation, progress);
+                }, Qt::QueuedConnection);
+            }
+            if (!cancellable) return true;
+            return dialog && !cancel_flag->load();
+        };
+        try {
+            result->error = wallet->fillPSBT(std::nullopt,
+                                             /*sign=*/true,
+                                             /*bip32derivs=*/true,
+                                             &result->n_signed,
+                                             result->psbt,
+                                             result->complete,
+                                             &result->pqc_usage,
+                                             progress_callback);
+        } catch (const std::exception& e) {
+            result->exception = e.what();
+        }
+        if (!dialog) return;
+        QMetaObject::invokeMethod(dialog, [dialog, generation, result] {
+            if (dialog) dialog->signTransactionFinished(generation, result);
+        }, Qt::QueuedConnection);
+    });
+
+    m_sign_thread = thread;
+    connect(thread, &QThread::finished, this, [this, thread] {
+        if (m_sign_thread == thread) {
+            m_sign_thread = nullptr;
+            thread->deleteLater();
+        }
+    });
+    thread->start();
+}
+
+void PSBTOperationsDialog::signTransactionProgress(uint64_t generation, SigningProgress progress)
+{
+    if (generation != m_sign_generation || !m_sign_progress_dialog || !m_sign_progress_bar) return;
+
+    if (!progress.cancellable || m_sign_counters_reserved.load()) {
+        m_sign_counters_reserved = true;
+        m_sign_progress_dialog->setCancelButton(nullptr);
+    }
+    if (m_sign_cancel_requested.load() && !m_sign_counters_reserved.load()) return;
+
+    switch (progress.phase) {
+    case SigningProgressPhase::PREPARING_TRANSACTION:
+        m_sign_progress_dialog->setLabelText(tr("Preparing transaction..."));
+        m_sign_progress_bar->setRange(0, 0);
+        break;
+    case SigningProgressPhase::RESERVING_PQC_COUNTERS:
+        m_sign_progress_dialog->setLabelText(tr("Reserving signing counters..."));
+        m_sign_progress_bar->setRange(0, 0);
+        break;
+    case SigningProgressPhase::SIGNING_INPUTS:
+        if (progress.total == 0) {
+            m_sign_progress_dialog->setLabelText(tr("Signing inputs..."));
+            m_sign_progress_bar->setRange(0, 0);
+        } else {
+            progress.completed = std::min(progress.completed, progress.total);
+            m_sign_progress_dialog->setLabelText(tr("Signing inputs: %1 of %2 complete...").arg(progress.completed).arg(progress.total));
+            m_sign_progress_bar->setRange(0, static_cast<int>(progress.total));
+            m_sign_progress_bar->setValue(static_cast<int>(progress.completed));
+        }
+        break;
+    case SigningProgressPhase::FINALIZING_TRANSACTION:
+        m_sign_progress_dialog->setLabelText(tr("Finalizing transaction..."));
+        m_sign_progress_bar->setRange(0, 0);
+        break;
+    case SigningProgressPhase::VERIFYING_TRANSACTION:
+        m_sign_progress_dialog->setLabelText(tr("Verifying transaction..."));
+        if (progress.total == 0) {
+            m_sign_progress_bar->setRange(0, 0);
+        } else {
+            progress.completed = std::min(progress.completed, progress.total);
+            m_sign_progress_bar->setRange(0, static_cast<int>(progress.total));
+            m_sign_progress_bar->setValue(static_cast<int>(progress.completed));
+        }
+        break;
+    }
+}
+
+void PSBTOperationsDialog::signTransactionFinished(uint64_t generation, std::shared_ptr<SignResult> result)
+{
+    if (generation != m_sign_generation) return;
+    ++m_sign_generation;
+
+    const bool cancel_requested{m_sign_cancel_requested.load()};
+    const bool counters_reserved{m_sign_counters_reserved.load()};
+    const bool unlock_valid{m_sign_unlock_context && m_sign_unlock_context->isValid()};
+    m_sign_cancel_requested = false;
+    m_sign_counters_reserved = false;
+    clearSignProgressDialog();
+    m_last_sign_pqc_usage = std::make_shared<const wallet::PQCUsageReport>(std::move(result->pqc_usage));
+
+    if (!m_wallet_model) {
+        showStatus(tr("Failed to sign transaction: Wallet is no longer loaded."), StatusLevel::ERR);
+        m_sign_unlock_context.reset();
+        setSigningControlsEnabled(true);
+        return;
+    }
+    if (cancel_requested && !counters_reserved) {
+        showStatus(tr("Transaction signing canceled."), StatusLevel::INFO);
+        m_sign_unlock_context.reset();
+        setSigningControlsEnabled(true);
+        return;
+    }
+    if (!result->exception.empty()) {
+        showStatus(tr("Failed to sign transaction: %1").arg(QString::fromLocal8Bit(result->exception.c_str())), StatusLevel::ERR);
+        m_sign_unlock_context.reset();
+        setSigningControlsEnabled(true);
+        return;
+    }
+    if (result->error) {
+        showStatus(tr("Failed to sign transaction: %1")
+                       .arg(QString::fromStdString(PSBTErrorString(*result->error).translated)),
+                   StatusLevel::ERR);
+        m_sign_unlock_context.reset();
+        setSigningControlsEnabled(true);
+        return;
+    }
+
+    m_transaction_data = std::move(result->psbt);
+    updateTransactionDisplay();
+    setSigningControlsEnabled(true);
+
+    if (!result->complete && !unlock_valid) {
         showStatus(tr("Cannot sign inputs while wallet is locked."), StatusLevel::WARN);
-    } else if (!complete && n_signed < 1) {
+    } else if (!result->complete && result->n_signed < 1) {
         showStatus(tr("Could not sign any more inputs."), StatusLevel::WARN);
-    } else if (!complete) {
-        showStatus(tr("Signed %1 inputs, but more signatures are still required.").arg(n_signed),
+    } else if (!result->complete) {
+        showStatus(tr("Signed %1 inputs, but more signatures are still required.").arg(result->n_signed),
             StatusLevel::INFO);
     } else {
         showStatus(tr("Signed transaction successfully. Transaction is ready to broadcast."),
             StatusLevel::INFO);
         m_ui->broadcastTransactionButton->setEnabled(true);
     }
+    m_sign_unlock_context.reset();
+}
+
+void PSBTOperationsDialog::cancelSignTransaction()
+{
+    if (m_sign_counters_reserved.load()) {
+        m_sign_cancel_requested = false;
+        if (m_sign_progress_dialog) {
+            m_sign_progress_dialog->setCancelButton(nullptr);
+            if (m_sign_progress_bar) m_sign_progress_bar->setRange(0, 0);
+            m_sign_progress_dialog->setLabelText(tr("Finishing transaction signing..."));
+            m_sign_progress_dialog->show();
+        }
+        return;
+    }
+    m_sign_cancel_requested = true;
+    if (m_sign_progress_dialog) {
+        m_sign_progress_dialog->setCancelButton(nullptr);
+        if (m_sign_progress_bar) m_sign_progress_bar->setRange(0, 0);
+        m_sign_progress_dialog->setLabelText(tr("Canceling transaction signing..."));
+    }
+}
+
+void PSBTOperationsDialog::clearSignProgressDialog()
+{
+    if (!m_sign_progress_dialog) return;
+    QProgressDialog* dialog = m_sign_progress_dialog;
+    m_sign_progress_dialog = nullptr;
+    m_sign_progress_bar = nullptr;
+    disconnect(dialog, nullptr, this, nullptr);
+    dialog->close();
+    dialog->deleteLater();
+}
+
+void PSBTOperationsDialog::setSigningControlsEnabled(bool enabled)
+{
+    m_ui->copyToClipboardButton->setEnabled(enabled);
+    m_ui->saveButton->setEnabled(enabled);
+    if (!enabled) {
+        m_ui->signTransactionButton->setEnabled(false);
+        m_ui->broadcastTransactionButton->setEnabled(false);
+        return;
+    }
+
+    PartiallySignedTransaction finalized{m_transaction_data};
+    const bool complete{FinalizePSBT(finalized)};
+    const size_t n_could_sign{m_wallet_model ? couldSignInputs(m_transaction_data) : 0};
+    m_ui->signTransactionButton->setEnabled(
+        m_wallet_model && !complete && !m_wallet_model->wallet().privateKeysDisabled() && n_could_sign > 0);
+    m_ui->broadcastTransactionButton->setEnabled(complete);
 }
 
 void PSBTOperationsDialog::broadcastTransaction()

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -126,6 +126,11 @@ void PSBTOperationsDialog::signTransaction()
     }
 
     m_sign_unlock_context = std::make_unique<WalletModel::UnlockContext>(m_wallet_model->requestUnlock());
+    if (!m_sign_unlock_context->isValid()) {
+        m_sign_unlock_context.reset();
+        showStatus(tr("Cannot sign inputs while wallet is locked."), StatusLevel::WARN);
+        return;
+    }
 
     std::unique_ptr<interfaces::Wallet> wallet = m_wallet_model->wallet().clone();
     if (!wallet) {
@@ -188,7 +193,7 @@ void PSBTOperationsDialog::signTransaction()
                 result->cancel_observed = true;
                 return false;
             }
-            return bool{dialog};
+            return !dialog.isNull();
         };
         try {
             result->error = wallet->fillPSBT(std::nullopt,

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -25,11 +25,13 @@
 #include <iostream>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 
 #include <QMetaObject>
 #include <QProgressBar>
 #include <QProgressDialog>
+#include <QStringList>
 #include <QThread>
 #include <QTimer>
 
@@ -40,6 +42,36 @@ using node::PSBTAnalysis;
 using node::TransactionError;
 
 namespace {
+QString BilingualToQString(const bilingual_str& message)
+{
+    return QString::fromStdString(message.translated.empty() ? message.original : message.translated);
+}
+
+QString AppendPQCUsageStatus(QString message, const wallet::PQCUsageReport& report)
+{
+    if (report.key_states.empty()) return message;
+
+    QStringList lines;
+    lines.append(std::move(message));
+    lines.append(PSBTOperationsDialog::tr("PQC signature capacity was consumed during this signing attempt."));
+    if (report.overall_state.has_value()) {
+        lines.append(PSBTOperationsDialog::tr("PQC usage state after this signing attempt: %1.")
+                         .arg(QString::fromStdString(std::string{wallet::PQCSignatureLimitStateName(*report.overall_state)})));
+    }
+    for (const wallet::PQCUsageSnapshot& key_state : report.key_states) {
+        lines.append(PSBTOperationsDialog::tr("PQC key %1: %2 of %3 signatures used, %4 remaining; state: %5.")
+                         .arg(QString::fromStdString(HexStr(std::span<const unsigned char>{key_state.pubkey.begin(), key_state.pubkey.end()})))
+                         .arg(key_state.signature_count)
+                         .arg(key_state.signature_limit)
+                         .arg(key_state.signatures_remaining)
+                         .arg(QString::fromStdString(std::string{wallet::PQCSignatureLimitStateName(key_state.limit_state)})));
+    }
+    for (const bilingual_str& warning : wallet::FormatPQCUsageWarnings(report.warnings)) {
+        lines.append(BilingualToQString(warning));
+    }
+    return lines.join("\n");
+}
+
 std::unique_ptr<interfaces::Wallet> GetBackgroundWallet(interfaces::Node& node, const std::string& wallet_name)
 {
     for (auto& wallet : node.walletLoader().getWallets()) {
@@ -68,6 +100,7 @@ PSBTOperationsDialog::PSBTOperationsDialog(
                                                                              m_client_model(client_model)
 {
     m_ui->setupUi(this);
+    m_ui->statusBar->setWordWrap(true);
 
     connect(m_ui->signTransactionButton, &QPushButton::clicked, this, &PSBTOperationsDialog::signTransaction);
     connect(m_ui->broadcastTransactionButton, &QPushButton::clicked, this, &PSBTOperationsDialog::broadcastTransaction);
@@ -280,29 +313,32 @@ void PSBTOperationsDialog::signTransactionFinished(uint64_t generation, std::sha
     m_sign_counters_reserved = false;
     clearSignProgressDialog();
     m_last_sign_pqc_usage = std::make_shared<const wallet::PQCUsageReport>(std::move(result->pqc_usage));
+    const auto show_result_status = [this](QString message, StatusLevel level) {
+        showStatus(AppendPQCUsageStatus(std::move(message), *m_last_sign_pqc_usage), level);
+    };
 
     if (!m_wallet_model) {
-        showStatus(tr("Failed to sign transaction: Wallet is no longer loaded."), StatusLevel::ERR);
+        show_result_status(tr("Failed to sign transaction: Wallet is no longer loaded."), StatusLevel::ERR);
         m_sign_unlock_context.reset();
         setSigningControlsEnabled(true);
         return;
     }
     if (result->cancel_observed) {
-        showStatus(tr("Transaction signing canceled."), StatusLevel::INFO);
+        show_result_status(tr("Transaction signing canceled."), StatusLevel::INFO);
         m_sign_unlock_context.reset();
         setSigningControlsEnabled(true);
         return;
     }
     if (!result->exception.empty()) {
-        showStatus(tr("Failed to sign transaction: %1").arg(QString::fromLocal8Bit(result->exception.c_str())), StatusLevel::ERR);
+        show_result_status(tr("Failed to sign transaction: %1").arg(QString::fromLocal8Bit(result->exception.c_str())), StatusLevel::ERR);
         m_sign_unlock_context.reset();
         setSigningControlsEnabled(true);
         return;
     }
     if (result->error) {
-        showStatus(tr("Failed to sign transaction: %1")
-                       .arg(QString::fromStdString(PSBTErrorString(*result->error).translated)),
-                   StatusLevel::ERR);
+        show_result_status(tr("Failed to sign transaction: %1")
+                               .arg(QString::fromStdString(PSBTErrorString(*result->error).translated)),
+                           StatusLevel::ERR);
         m_sign_unlock_context.reset();
         setSigningControlsEnabled(true);
         return;
@@ -313,15 +349,15 @@ void PSBTOperationsDialog::signTransactionFinished(uint64_t generation, std::sha
     setSigningControlsEnabled(true);
 
     if (!result->complete && !unlock_valid) {
-        showStatus(tr("Cannot sign inputs while wallet is locked."), StatusLevel::WARN);
+        show_result_status(tr("Cannot sign inputs while wallet is locked."), StatusLevel::WARN);
     } else if (!result->complete && result->n_signed < 1) {
-        showStatus(tr("Could not sign any more inputs."), StatusLevel::WARN);
+        show_result_status(tr("Could not sign any more inputs."), StatusLevel::WARN);
     } else if (!result->complete) {
-        showStatus(tr("Signed %1 inputs, but more signatures are still required.").arg(result->n_signed),
-            StatusLevel::INFO);
+        show_result_status(tr("Signed %1 inputs, but more signatures are still required.").arg(result->n_signed),
+                           StatusLevel::INFO);
     } else {
-        showStatus(tr("Signed transaction successfully. Transaction is ready to broadcast."),
-            StatusLevel::INFO);
+        show_result_status(tr("Signed transaction successfully. Transaction is ready to broadcast."),
+                           StatusLevel::INFO);
         m_ui->broadcastTransactionButton->setEnabled(true);
     }
     m_sign_unlock_context.reset();

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -57,6 +57,7 @@ struct PSBTOperationsDialog::SignResult {
     std::string exception;
     size_t n_signed{0};
     bool complete{false};
+    bool cancel_observed{false};
     wallet::PQCUsageReport pqc_usage;
 };
 
@@ -174,7 +175,7 @@ void PSBTOperationsDialog::signTransaction()
                                        counters_reserved_flag]() mutable {
         auto result = std::make_shared<SignResult>();
         result->psbt = std::move(psbt);
-        SigningProgressCallback progress_callback = [dialog, generation, cancel_flag, counters_reserved_flag](const SigningProgress& progress) {
+        SigningProgressCallback progress_callback = [dialog, generation, result, cancel_flag, counters_reserved_flag](const SigningProgress& progress) {
             if (!progress.cancellable) counters_reserved_flag->store(true);
             const bool cancellable{progress.cancellable && !counters_reserved_flag->load()};
             if (dialog) {
@@ -183,7 +184,11 @@ void PSBTOperationsDialog::signTransaction()
                 }, Qt::QueuedConnection);
             }
             if (!cancellable) return true;
-            return dialog && !cancel_flag->load();
+            if (cancel_flag->load()) {
+                result->cancel_observed = true;
+                return false;
+            }
+            return bool{dialog};
         };
         try {
             result->error = wallet->fillPSBT(std::nullopt,
@@ -265,8 +270,6 @@ void PSBTOperationsDialog::signTransactionFinished(uint64_t generation, std::sha
     if (generation != m_sign_generation) return;
     ++m_sign_generation;
 
-    const bool cancel_requested{m_sign_cancel_requested.load()};
-    const bool counters_reserved{m_sign_counters_reserved.load()};
     const bool unlock_valid{m_sign_unlock_context && m_sign_unlock_context->isValid()};
     m_sign_cancel_requested = false;
     m_sign_counters_reserved = false;
@@ -279,7 +282,7 @@ void PSBTOperationsDialog::signTransactionFinished(uint64_t generation, std::sha
         setSigningControlsEnabled(true);
         return;
     }
-    if (cancel_requested && !counters_reserved) {
+    if (result->cancel_observed) {
         showStatus(tr("Transaction signing canceled."), StatusLevel::INFO);
         m_sign_unlock_context.reset();
         setSigningControlsEnabled(true);

--- a/src/qt/psbtoperationsdialog.cpp
+++ b/src/qt/psbtoperationsdialog.cpp
@@ -323,7 +323,7 @@ void PSBTOperationsDialog::signTransactionFinished(uint64_t generation, std::sha
         setSigningControlsEnabled(true);
         return;
     }
-    if (result->cancel_observed) {
+    if (result->cancel_observed && result->error == common::PSBTError::INCOMPLETE) {
         show_result_status(tr("Transaction signing canceled."), StatusLevel::INFO);
         m_sign_unlock_context.reset();
         setSigningControlsEnabled(true);

--- a/src/qt/psbtoperationsdialog.h
+++ b/src/qt/psbtoperationsdialog.h
@@ -6,11 +6,23 @@
 #define QBIT_QT_PSBTOPERATIONSDIALOG_H
 
 #include <QDialog>
+#include <QPointer>
 #include <QString>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
 
 #include <psbt.h>
 #include <qt/clientmodel.h>
 #include <qt/walletmodel.h>
+
+class QProgressBar;
+class QProgressDialog;
+class QThread;
+namespace wallet {
+struct PQCUsageReport;
+} // namespace wallet
 
 namespace Ui {
 class PSBTOperationsDialog;
@@ -34,10 +46,20 @@ public Q_SLOTS:
     void saveTransaction();
 
 private:
+    struct SignResult;
+
     Ui::PSBTOperationsDialog* m_ui;
     PartiallySignedTransaction m_transaction_data;
-    WalletModel* m_wallet_model;
+    QPointer<WalletModel> m_wallet_model;
     ClientModel* m_client_model;
+    std::unique_ptr<WalletModel::UnlockContext> m_sign_unlock_context;
+    QPointer<QProgressDialog> m_sign_progress_dialog;
+    QPointer<QProgressBar> m_sign_progress_bar;
+    QThread* m_sign_thread{nullptr};
+    uint64_t m_sign_generation{0};
+    std::atomic_bool m_sign_cancel_requested{false};
+    std::atomic_bool m_sign_counters_reserved{false};
+    std::shared_ptr<const wallet::PQCUsageReport> m_last_sign_pqc_usage;
 
     enum class StatusLevel {
         INFO,
@@ -50,6 +72,15 @@ private:
     QString renderTransaction(const PartiallySignedTransaction &psbtx);
     void showStatus(const QString &msg, StatusLevel level);
     void showTransactionStatus(const PartiallySignedTransaction &psbtx);
+    void signTransactionProgress(uint64_t generation, SigningProgress progress);
+    void signTransactionFinished(uint64_t generation, std::shared_ptr<SignResult> result);
+
+private Q_SLOTS:
+    void cancelSignTransaction();
+
+private:
+    void clearSignProgressDialog();
+    void setSigningControlsEnabled(bool enabled);
 };
 
 #endif // QBIT_QT_PSBTOPERATIONSDIALOG_H

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -626,6 +626,7 @@ void SendCoinsDialog::startPrepareTransaction(std::unique_ptr<WalletModelTransac
                     .total = progress.total,
                 }, cancellable);
             case SigningProgressPhase::FINALIZING_TRANSACTION:
+            case SigningProgressPhase::VERIFYING_TRANSACTION:
                 return post_progress(PrepareProgress{
                     .phase = PrepareProgressPhase::Finalizing,
                     .completed = progress.completed,

--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -32,6 +32,7 @@ if(ENABLE_WALLET)
   target_sources(test_bitcoin-qt
     PRIVATE
       addressbooktests.cpp
+      psbtoperationsdialogtests.cpp
       syntheticwallet.cpp
       walletcontrollertests.cpp
       walletactivitytests.cpp

--- a/src/qt/test/psbtoperationsdialogtests.cpp
+++ b/src/qt/test/psbtoperationsdialogtests.cpp
@@ -23,9 +23,11 @@
 #include <chrono>
 #include <functional>
 #include <memory>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 
 #include <QApplication>
 #include <QClipboard>
@@ -82,15 +84,35 @@ std::string SerializePSBT(const PartiallySignedTransaction& psbt)
     return stream.str();
 }
 
+wallet::PQCUsageReport MakePQCUsageReport(const CPQCPubKey& pubkey, uint32_t signature_count)
+{
+    wallet::PQCUsageReport report;
+    report.key_states.push_back({
+        .pubkey = pubkey,
+        .signature_count = signature_count,
+        .signature_limit = PQC_MAX_SIGNATURES,
+        .signatures_remaining = PQC_MAX_SIGNATURES - signature_count,
+        .limit_state = wallet::PQCSignatureLimitState::NORMAL,
+    });
+    report.overall_state = wallet::PQCSignatureLimitState::NORMAL;
+    return report;
+}
+
+QString PQCPubKeyHex(const CPQCPubKey& pubkey)
+{
+    return QString::fromStdString(HexStr(std::span<const unsigned char>{pubkey.begin(), pubkey.end()}));
+}
+
 class DialogFixture
 {
 public:
     DialogFixture(ClientModel& client_model,
                   const PlatformStyle* platform_style,
-                  std::shared_ptr<qt_test::SyntheticWalletState> state)
+                  std::shared_ptr<qt_test::SyntheticWalletState> state,
+                  wallet::PQCUsageReport pqc_usage = {})
         : state{std::move(state)},
           original_psbt{MakeUnsignedPSBT()},
-          wallet_model{std::make_unique<WalletModel>(qt_test::MakeSyntheticWallet({}, this->state), client_model, platform_style)},
+          wallet_model{std::make_unique<WalletModel>(qt_test::MakeSyntheticWallet(std::move(pqc_usage), this->state), client_model, platform_style)},
           dialog{std::make_unique<PSBTOperationsDialog>(nullptr, wallet_model.get(), &client_model)}
     {
         dialog->openWithPSBT(original_psbt);
@@ -208,7 +230,11 @@ void PSBTOperationsDialogTests::successfulCompletionUpdatesDisplayOnce()
 {
     auto state{std::make_shared<qt_test::SyntheticWalletState>()};
     state->allow_psbt_reservation = false;
-    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    state->psbt_simulate_pqc_reservation = true;
+    CPQCKey key;
+    key.MakeNewKey();
+    const wallet::PQCUsageReport pqc_usage{MakePQCUsageReport(key.GetPubKey(), 1)};
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state, pqc_usage};
     QVERIFY(fixture.description());
     QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
     QVERIFY(display_updates.isValid());
@@ -220,6 +246,9 @@ void PSBTOperationsDialogTests::successfulCompletionUpdatesDisplayOnce()
 
     QCOMPARE(display_updates.count(), 1);
     QVERIFY(!fixture.description()->toPlainText().contains(QStringLiteral("unsigned input")));
+    QVERIFY(fixture.statusLabel()->text().contains(QStringLiteral("PQC signature capacity was consumed")));
+    QVERIFY(fixture.statusLabel()->text().contains(PQCPubKeyHex(key.GetPubKey())));
+    QVERIFY(fixture.statusLabel()->text().contains(QStringLiteral("1 of %1 signatures used").arg(PQC_MAX_SIGNATURES)));
     QCOMPARE(ReadState(state, [](const auto& value) { return value.psbt_sign_calls; }), 1);
 }
 
@@ -323,13 +352,22 @@ void PSBTOperationsDialogTests::walletUnloadDuringSigning()
 void PSBTOperationsDialogTests::signingFailurePreservesOriginalPSBT()
 {
     auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->psbt_simulate_pqc_reservation = true;
     state->psbt_fail = true;
-    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    CPQCKey key;
+    key.MakeNewKey();
+    const wallet::PQCUsageReport pqc_usage{MakePQCUsageReport(key.GetPubKey(), 2)};
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state, pqc_usage};
     const std::string original{SerializePSBT(fixture.original_psbt)};
     QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
 
     fixture.dialog->signTransaction();
     QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().startsWith(QStringLiteral("Failed to sign transaction")); }));
+    QVERIFY(ReadState(state, [](const auto& value) { return value.psbt_counters_reserved; }));
+    QVERIFY(fixture.statusLabel()->text().contains(QStringLiteral("PQC signature capacity was consumed")));
+    QVERIFY(fixture.statusLabel()->text().contains(PQCPubKeyHex(key.GetPubKey())));
+    QVERIFY(fixture.statusLabel()->text().contains(QStringLiteral("2 of %1 signatures used").arg(PQC_MAX_SIGNATURES)));
+    QVERIFY(fixture.statusLabel()->text().contains(QStringLiteral("%1 remaining").arg(PQC_MAX_SIGNATURES - 2)));
     QCOMPARE(display_updates.count(), 0);
 
     fixture.dialog->copyToClipboard();

--- a/src/qt/test/psbtoperationsdialogtests.cpp
+++ b/src/qt/test/psbtoperationsdialogtests.cpp
@@ -215,6 +215,27 @@ void PSBTOperationsDialogTests::cancellationBeforeCounterReservation()
     QCOMPARE(display_updates.count(), 0);
 }
 
+void PSBTOperationsDialogTests::lateCancellationDoesNotDropCompletedPSBT()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
+
+    fixture.dialog->signTransaction();
+    {
+        std::unique_lock lock{state->mutex};
+        QVERIFY(state->condition.wait_for(lock, std::chrono::milliseconds{WAIT_TIMEOUT_MS}, [&] {
+            return state->psbt_sign_finished;
+        }));
+    }
+
+    QVERIFY(QMetaObject::invokeMethod(fixture.dialog.get(), "cancelSignTransaction"));
+    QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().contains(QStringLiteral("ready to broadcast")); }));
+
+    QVERIFY(!ReadState(state, [](const auto& value) { return value.psbt_cancel_observed; }));
+    QCOMPARE(display_updates.count(), 1);
+}
+
 void PSBTOperationsDialogTests::cancellationAfterCounterReservationIsIgnored()
 {
     auto state{std::make_shared<qt_test::SyntheticWalletState>()};

--- a/src/qt/test/psbtoperationsdialogtests.cpp
+++ b/src/qt/test/psbtoperationsdialogtests.cpp
@@ -1,0 +1,296 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/psbtoperationsdialogtests.h>
+
+#include <consensus/amount.h>
+#include <interfaces/node.h>
+#include <key.h>
+#include <outputtype.h>
+#include <psbt.h>
+#include <qt/clientmodel.h>
+#include <qt/optionsmodel.h>
+#include <qt/platformstyle.h>
+#include <qt/psbtoperationsdialog.h>
+#include <qt/test/syntheticwallet.h>
+#include <qt/walletmodel.h>
+#include <script/script.h>
+#include <streams.h>
+#include <test/util/setup_common.h>
+#include <util/strencodings.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <QApplication>
+#include <QClipboard>
+#include <QCoreApplication>
+#include <QElapsedTimer>
+#include <QEventLoop>
+#include <QLabel>
+#include <QMetaObject>
+#include <QPointer>
+#include <QProgressDialog>
+#include <QSignalSpy>
+#include <QTextEdit>
+#include <QTimer>
+
+namespace {
+constexpr int WAIT_TIMEOUT_MS{5'000};
+
+template <typename Predicate>
+bool WaitUntil(Predicate&& predicate, int timeout_ms = WAIT_TIMEOUT_MS)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < timeout_ms) {
+        if (predicate()) return true;
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        QTest::qWait(10);
+    }
+    return predicate();
+}
+
+template <typename Predicate>
+bool ReadState(const std::shared_ptr<qt_test::SyntheticWalletState>& state, Predicate&& predicate)
+{
+    std::lock_guard lock{state->mutex};
+    return predicate(*state);
+}
+
+PartiallySignedTransaction MakeUnsignedPSBT()
+{
+    CMutableTransaction tx;
+    tx.vin.emplace_back(COutPoint{Txid{}, 0});
+    tx.vout.emplace_back(COIN - 1'000, CScript{} << OP_TRUE);
+
+    PartiallySignedTransaction psbt{tx};
+    const CKey key{GenerateRandomKey()};
+    psbt.inputs.front().witness_utxo = CTxOut{COIN, GetScriptForDestination(WitnessV0KeyHash{key.GetPubKey()})};
+    return psbt;
+}
+
+std::string SerializePSBT(const PartiallySignedTransaction& psbt)
+{
+    DataStream stream;
+    stream << psbt;
+    return stream.str();
+}
+
+class DialogFixture
+{
+public:
+    DialogFixture(ClientModel& client_model,
+                  const PlatformStyle* platform_style,
+                  std::shared_ptr<qt_test::SyntheticWalletState> state)
+        : state{std::move(state)},
+          original_psbt{MakeUnsignedPSBT()},
+          wallet_model{std::make_unique<WalletModel>(qt_test::MakeSyntheticWallet({}, this->state), client_model, platform_style)},
+          dialog{std::make_unique<PSBTOperationsDialog>(nullptr, wallet_model.get(), &client_model)}
+    {
+        dialog->openWithPSBT(original_psbt);
+    }
+
+    ~DialogFixture()
+    {
+        releaseWorker();
+        dialog.reset();
+        wallet_model.reset();
+    }
+
+    void releaseWorker()
+    {
+        {
+            std::lock_guard lock{state->mutex};
+            state->allow_psbt_reservation = true;
+            state->allow_psbt_completion = true;
+        }
+        state->condition.notify_all();
+    }
+
+    QLabel* statusLabel() const { return dialog->findChild<QLabel*>(QStringLiteral("statusBar")); }
+    QTextEdit* description() const { return dialog->findChild<QTextEdit*>(QStringLiteral("transactionDescription")); }
+
+    std::shared_ptr<qt_test::SyntheticWalletState> state;
+    PartiallySignedTransaction original_psbt;
+    std::unique_ptr<WalletModel> wallet_model;
+    std::unique_ptr<PSBTOperationsDialog> dialog;
+};
+} // namespace
+
+struct PSBTOperationsDialogTests::Context {
+    Context(interfaces::Node& node)
+        : chain{ChainType::REGTEST, {.extra_args = {"-p2mronly=0"}}},
+          platform_style{PlatformStyle::instantiate("other")}
+    {
+        node.setContext(&chain.m_node);
+        options_model = std::make_unique<OptionsModel>(node);
+        bilingual_str error;
+        if (!options_model->Init(error)) throw std::runtime_error{error.original};
+        client_model = std::make_unique<ClientModel>(node, options_model.get());
+    }
+
+    TestChain100Setup chain;
+    std::unique_ptr<const PlatformStyle> platform_style;
+    std::unique_ptr<OptionsModel> options_model;
+    std::unique_ptr<ClientModel> client_model;
+};
+
+PSBTOperationsDialogTests::PSBTOperationsDialogTests(interfaces::Node& node)
+    : m_node{node}
+{
+}
+
+PSBTOperationsDialogTests::~PSBTOperationsDialogTests() = default;
+
+void PSBTOperationsDialogTests::initTestCase()
+{
+    m_context = std::make_unique<Context>(m_node);
+    QVERIFY(m_context->platform_style);
+}
+
+void PSBTOperationsDialogTests::cleanupTestCase()
+{
+    m_context.reset();
+}
+
+void PSBTOperationsDialogTests::eventLoopResponsiveWhileSigningPaused()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->allow_psbt_reservation = false;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+
+    const std::thread::id gui_thread{std::this_thread::get_id()};
+    fixture.dialog->signTransaction();
+    QVERIFY(WaitUntil([&] { return ReadState(state, [](const auto& value) { return value.psbt_sign_entered; }); }));
+    QVERIFY(ReadState(state, [&](const auto& value) { return value.psbt_sign_thread != gui_thread; }));
+
+    bool event_delivered{false};
+    QTimer::singleShot(0, [&] { event_delivered = true; });
+    QVERIFY(WaitUntil([&] { return event_delivered; }));
+    QVERIFY(!ReadState(state, [](const auto& value) { return value.psbt_sign_finished; }));
+
+    fixture.releaseWorker();
+    QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().contains(QStringLiteral("ready to broadcast")); }));
+}
+
+void PSBTOperationsDialogTests::successfulCompletionUpdatesDisplayOnce()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->allow_psbt_reservation = false;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    QVERIFY(fixture.description());
+    QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
+    QVERIFY(display_updates.isValid());
+
+    fixture.dialog->signTransaction();
+    QVERIFY(WaitUntil([&] { return ReadState(state, [](const auto& value) { return value.psbt_sign_entered; }); }));
+    fixture.releaseWorker();
+    QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().contains(QStringLiteral("ready to broadcast")); }));
+
+    QCOMPARE(display_updates.count(), 1);
+    QVERIFY(!fixture.description()->toPlainText().contains(QStringLiteral("unsigned input")));
+    QCOMPARE(ReadState(state, [](const auto& value) { return value.psbt_sign_calls; }), 1);
+}
+
+void PSBTOperationsDialogTests::cancellationBeforeCounterReservation()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->allow_psbt_reservation = false;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
+
+    fixture.dialog->signTransaction();
+    QVERIFY(WaitUntil([&] { return ReadState(state, [](const auto& value) { return value.psbt_sign_entered; }); }));
+    QVERIFY(QMetaObject::invokeMethod(fixture.dialog.get(), "cancelSignTransaction"));
+    QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().contains(QStringLiteral("canceled")); }));
+
+    QVERIFY(ReadState(state, [](const auto& value) { return value.psbt_cancel_observed; }));
+    QVERIFY(!ReadState(state, [](const auto& value) { return value.psbt_counters_reserved; }));
+    QCOMPARE(display_updates.count(), 0);
+}
+
+void PSBTOperationsDialogTests::cancellationAfterCounterReservationIsIgnored()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->psbt_simulate_pqc_reservation = true;
+    state->allow_psbt_completion = false;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
+
+    fixture.dialog->signTransaction();
+    QVERIFY(WaitUntil([&] { return ReadState(state, [](const auto& value) { return value.psbt_counters_reserved; }); }));
+    QCoreApplication::processEvents();
+    QVERIFY(QMetaObject::invokeMethod(fixture.dialog.get(), "cancelSignTransaction"));
+    QVERIFY(!ReadState(state, [](const auto& value) { return value.psbt_cancel_observed; }));
+
+    fixture.releaseWorker();
+    QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().contains(QStringLiteral("ready to broadcast")); }));
+    QVERIFY(!ReadState(state, [](const auto& value) { return value.psbt_cancel_observed; }));
+    QCOMPARE(display_updates.count(), 1);
+}
+
+void PSBTOperationsDialogTests::dialogDestructionBeforeCompletion()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->allow_psbt_reservation = false;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    QPointer<PSBTOperationsDialog> dialog_guard{fixture.dialog.get()};
+
+    fixture.dialog->signTransaction();
+    QVERIFY(WaitUntil([&] { return ReadState(state, [](const auto& value) { return value.psbt_sign_entered; }); }));
+    QElapsedTimer destruction_timer;
+    destruction_timer.start();
+    fixture.dialog.reset();
+
+    QVERIFY(dialog_guard.isNull());
+    QVERIFY(destruction_timer.elapsed() < WAIT_TIMEOUT_MS);
+    QVERIFY(ReadState(state, [](const auto& value) { return value.psbt_cancel_observed && value.psbt_sign_finished; }));
+    QVERIFY(ReadState(state, [](const auto& value) { return value.background_clone_destroyed; }));
+    QCoreApplication::processEvents();
+}
+
+void PSBTOperationsDialogTests::walletUnloadDuringSigning()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->allow_psbt_completion = false;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
+
+    fixture.dialog->signTransaction();
+    QVERIFY(WaitUntil([&] { return ReadState(state, [](const auto& value) { return value.psbt_sign_entered; }); }));
+    QPointer<WalletModel> model_guard{fixture.wallet_model.get()};
+    fixture.wallet_model.reset();
+    QVERIFY(model_guard.isNull());
+
+    fixture.releaseWorker();
+    QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().contains(QStringLiteral("no longer loaded")); }));
+    QCOMPARE(display_updates.count(), 0);
+    QVERIFY(WaitUntil([&] { return ReadState(state, [](const auto& value) { return value.background_clone_destroyed; }); }));
+}
+
+void PSBTOperationsDialogTests::signingFailurePreservesOriginalPSBT()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->psbt_fail = true;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    const std::string original{SerializePSBT(fixture.original_psbt)};
+    QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
+
+    fixture.dialog->signTransaction();
+    QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().startsWith(QStringLiteral("Failed to sign transaction")); }));
+    QCOMPARE(display_updates.count(), 0);
+
+    fixture.dialog->copyToClipboard();
+    const auto decoded{DecodeBase64(QApplication::clipboard()->text().toStdString())};
+    QVERIFY(decoded);
+    PartiallySignedTransaction clipboard_psbt;
+    std::string error;
+    QVERIFY(DecodeRawPSBT(clipboard_psbt, MakeByteSpan(*decoded), error));
+    QCOMPARE(SerializePSBT(clipboard_psbt), original);
+}

--- a/src/qt/test/psbtoperationsdialogtests.cpp
+++ b/src/qt/test/psbtoperationsdialogtests.cpp
@@ -159,6 +159,31 @@ void PSBTOperationsDialogTests::cleanupTestCase()
     m_context.reset();
 }
 
+void PSBTOperationsDialogTests::canceledUnlockDoesNotStartSigning()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->encrypted = true;
+    state->locked = true;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    const std::string original{SerializePSBT(fixture.original_psbt)};
+    QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
+
+    fixture.dialog->signTransaction();
+
+    QVERIFY(fixture.statusLabel()->text().contains(QStringLiteral("wallet is locked")));
+    QCOMPARE(ReadState(state, [](const auto& value) { return value.psbt_sign_calls; }), 0);
+    QCOMPARE(display_updates.count(), 0);
+    QVERIFY(!fixture.dialog->findChild<QProgressDialog*>(QStringLiteral("psbtSigningProgressDialog")));
+
+    fixture.dialog->copyToClipboard();
+    const auto decoded{DecodeBase64(QApplication::clipboard()->text().toStdString())};
+    QVERIFY(decoded);
+    PartiallySignedTransaction clipboard_psbt;
+    std::string error;
+    QVERIFY(DecodeRawPSBT(clipboard_psbt, MakeByteSpan(*decoded), error));
+    QCOMPARE(SerializePSBT(clipboard_psbt), original);
+}
+
 void PSBTOperationsDialogTests::eventLoopResponsiveWhileSigningPaused()
 {
     auto state{std::make_shared<qt_test::SyntheticWalletState>()};

--- a/src/qt/test/psbtoperationsdialogtests.cpp
+++ b/src/qt/test/psbtoperationsdialogtests.cpp
@@ -131,6 +131,7 @@ public:
             std::lock_guard lock{state->mutex};
             state->allow_psbt_reservation = true;
             state->allow_psbt_completion = true;
+            state->allow_psbt_post_signing = true;
         }
         state->condition.notify_all();
     }
@@ -267,6 +268,31 @@ void PSBTOperationsDialogTests::cancellationBeforeCounterReservation()
     QVERIFY(ReadState(state, [](const auto& value) { return value.psbt_cancel_observed; }));
     QVERIFY(!ReadState(state, [](const auto& value) { return value.psbt_counters_reserved; }));
     QCOMPARE(display_updates.count(), 0);
+}
+
+void PSBTOperationsDialogTests::acceptedCancellationAfterSigningPreservesOriginalPSBT()
+{
+    auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+    state->allow_psbt_post_signing = false;
+    DialogFixture fixture{*m_context->client_model, m_context->platform_style.get(), state};
+    const std::string original{SerializePSBT(fixture.original_psbt)};
+    QSignalSpy display_updates{fixture.description(), &QTextEdit::textChanged};
+
+    fixture.dialog->signTransaction();
+    QVERIFY(WaitUntil([&] { return ReadState(state, [](const auto& value) { return value.psbt_input_signed; }); }));
+    QVERIFY(QMetaObject::invokeMethod(fixture.dialog.get(), "cancelSignTransaction"));
+    QVERIFY(WaitUntil([&] { return fixture.statusLabel()->text().contains(QStringLiteral("canceled")); }));
+
+    QVERIFY(ReadState(state, [](const auto& value) { return value.psbt_cancel_observed; }));
+    QCOMPARE(display_updates.count(), 0);
+
+    fixture.dialog->copyToClipboard();
+    const auto decoded{DecodeBase64(QApplication::clipboard()->text().toStdString())};
+    QVERIFY(decoded);
+    PartiallySignedTransaction clipboard_psbt;
+    std::string error;
+    QVERIFY(DecodeRawPSBT(clipboard_psbt, MakeByteSpan(*decoded), error));
+    QCOMPARE(SerializePSBT(clipboard_psbt), original);
 }
 
 void PSBTOperationsDialogTests::lateCancellationDoesNotDropCompletedPSBT()

--- a/src/qt/test/psbtoperationsdialogtests.h
+++ b/src/qt/test/psbtoperationsdialogtests.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef QBIT_QT_TEST_PSBTOPERATIONSDIALOGTESTS_H
+#define QBIT_QT_TEST_PSBTOPERATIONSDIALOGTESTS_H
+
+#include <memory>
+
+#include <QObject>
+#include <QTest>
+
+namespace interfaces {
+class Node;
+} // namespace interfaces
+
+class PSBTOperationsDialogTests : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit PSBTOperationsDialogTests(interfaces::Node& node);
+    ~PSBTOperationsDialogTests();
+
+private Q_SLOTS:
+    void initTestCase();
+    void cleanupTestCase();
+    void eventLoopResponsiveWhileSigningPaused();
+    void successfulCompletionUpdatesDisplayOnce();
+    void cancellationBeforeCounterReservation();
+    void cancellationAfterCounterReservationIsIgnored();
+    void dialogDestructionBeforeCompletion();
+    void walletUnloadDuringSigning();
+    void signingFailurePreservesOriginalPSBT();
+
+private:
+    struct Context;
+    interfaces::Node& m_node;
+    std::unique_ptr<Context> m_context;
+};
+
+#endif // QBIT_QT_TEST_PSBTOPERATIONSDIALOGTESTS_H

--- a/src/qt/test/psbtoperationsdialogtests.h
+++ b/src/qt/test/psbtoperationsdialogtests.h
@@ -28,6 +28,7 @@ private Q_SLOTS:
     void eventLoopResponsiveWhileSigningPaused();
     void successfulCompletionUpdatesDisplayOnce();
     void cancellationBeforeCounterReservation();
+    void lateCancellationDoesNotDropCompletedPSBT();
     void cancellationAfterCounterReservationIsIgnored();
     void dialogDestructionBeforeCompletion();
     void walletUnloadDuringSigning();

--- a/src/qt/test/psbtoperationsdialogtests.h
+++ b/src/qt/test/psbtoperationsdialogtests.h
@@ -25,6 +25,7 @@ public:
 private Q_SLOTS:
     void initTestCase();
     void cleanupTestCase();
+    void canceledUnlockDoesNotStartSigning();
     void eventLoopResponsiveWhileSigningPaused();
     void successfulCompletionUpdatesDisplayOnce();
     void cancellationBeforeCounterReservation();

--- a/src/qt/test/psbtoperationsdialogtests.h
+++ b/src/qt/test/psbtoperationsdialogtests.h
@@ -29,6 +29,7 @@ private Q_SLOTS:
     void eventLoopResponsiveWhileSigningPaused();
     void successfulCompletionUpdatesDisplayOnce();
     void cancellationBeforeCounterReservation();
+    void acceptedCancellationAfterSigningPreservesOriginalPSBT();
     void lateCancellationDoesNotDropCompletedPSBT();
     void cancellationAfterCounterReservationIsIgnored();
     void dialogDestructionBeforeCompletion();

--- a/src/qt/test/syntheticwallet.cpp
+++ b/src/qt/test/syntheticwallet.cpp
@@ -4,6 +4,7 @@
 
 #include <qt/test/syntheticwallet.h>
 
+#include <common/types.h>
 #include <interfaces/handler.h>
 #include <outputtype.h>
 #include <policy/fees.h>
@@ -192,7 +193,116 @@ public:
     std::set<interfaces::WalletTx> getWalletTxs() override { return {}; }
     bool tryGetTxStatus(const Txid&, interfaces::WalletTxStatus&, int&, int64_t&) override { return false; }
     interfaces::WalletTx getWalletTxDetails(const Txid&, interfaces::WalletTxStatus&, interfaces::WalletOrderForm&, bool&, int&) override { return {}; }
-    std::optional<common::PSBTError> fillPSBT(std::optional<int>, bool, bool, size_t*, PartiallySignedTransaction&, bool&, wallet::PQCUsageReport*) override { return std::nullopt; }
+    std::optional<common::PSBTError> fillPSBT(std::optional<int>,
+        bool sign,
+        bool,
+        size_t* n_signed,
+        PartiallySignedTransaction& psbtx,
+        bool& complete,
+        wallet::PQCUsageReport* pqc_usage,
+        const SigningProgressCallback& progress_callback) override
+    {
+        if (!sign) {
+            if (n_signed) *n_signed = 1;
+            complete = false;
+            if (pqc_usage) *pqc_usage = {};
+            return std::nullopt;
+        }
+
+        {
+            std::lock_guard lock{m_state->mutex};
+            m_state->psbt_sign_entered = true;
+            m_state->psbt_sign_thread = std::this_thread::get_id();
+            ++m_state->psbt_sign_calls;
+        }
+        m_state->condition.notify_all();
+
+        const auto finish = [this](bool cancel_observed) {
+            {
+                std::lock_guard lock{m_state->mutex};
+                m_state->psbt_cancel_observed = cancel_observed;
+                m_state->psbt_sign_finished = true;
+            }
+            m_state->condition.notify_all();
+        };
+        const auto wait_for_stage = [this, &progress_callback](bool SyntheticWalletState::*allow,
+                                                               SigningProgress progress) {
+            while (true) {
+                {
+                    std::lock_guard lock{m_state->mutex};
+                    if (m_state.get()->*allow) return true;
+                }
+                if (progress_callback && !progress_callback(progress) && progress.cancellable) return false;
+                std::unique_lock lock{m_state->mutex};
+                m_state->condition.wait_for(lock, 10ms, [this, allow] { return m_state.get()->*allow; });
+            }
+        };
+
+        if (!wait_for_stage(&SyntheticWalletState::allow_psbt_reservation, SigningProgress{
+                .phase = SigningProgressPhase::PREPARING_TRANSACTION,
+                .completed = 0,
+                .total = 1,
+                .cancellable = true,
+            })) {
+            finish(/*cancel_observed=*/true);
+            return common::PSBTError::INCOMPLETE;
+        }
+
+        bool simulate_reservation{false};
+        {
+            std::lock_guard lock{m_state->mutex};
+            simulate_reservation = m_state->psbt_simulate_pqc_reservation;
+        }
+        if (simulate_reservation) {
+            if (progress_callback && !progress_callback(SigningProgress{
+                    .phase = SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                    .completed = 0,
+                    .total = 1,
+                    .cancellable = true,
+                })) {
+                finish(/*cancel_observed=*/true);
+                return common::PSBTError::INCOMPLETE;
+            }
+            {
+                std::lock_guard lock{m_state->mutex};
+                m_state->psbt_counters_reserved = true;
+            }
+            m_state->condition.notify_all();
+            if (progress_callback) {
+                progress_callback(SigningProgress{
+                    .phase = SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                    .completed = 1,
+                    .total = 1,
+                    .cancellable = false,
+                });
+            }
+        }
+
+        if (!wait_for_stage(&SyntheticWalletState::allow_psbt_completion, SigningProgress{
+                .phase = SigningProgressPhase::SIGNING_INPUTS,
+                .completed = 0,
+                .total = 1,
+                .cancellable = !simulate_reservation,
+            })) {
+            finish(/*cancel_observed=*/true);
+            return common::PSBTError::INCOMPLETE;
+        }
+
+        if (!psbtx.inputs.empty()) {
+            psbtx.inputs.front().final_script_witness.stack = {{0x01}};
+        }
+        if (n_signed) *n_signed = psbtx.inputs.empty() ? 0 : 1;
+        if (pqc_usage) *pqc_usage = m_report;
+
+        bool fail{false};
+        {
+            std::lock_guard lock{m_state->mutex};
+            fail = m_state->psbt_fail;
+        }
+        complete = !fail;
+        finish(/*cancel_observed=*/false);
+        return fail ? std::make_optional(common::PSBTError::SIGHASH_MISMATCH) : std::nullopt;
+    }
     interfaces::WalletBalances getBalances() override { return {.balance = 50 * COIN}; }
     bool tryGetBalances(interfaces::WalletBalances& balances, uint256&) override
     {

--- a/src/qt/test/syntheticwallet.cpp
+++ b/src/qt/test/syntheticwallet.cpp
@@ -293,6 +293,21 @@ public:
         }
         if (n_signed) *n_signed = psbtx.inputs.empty() ? 0 : 1;
         if (pqc_usage) *pqc_usage = m_report;
+        {
+            std::lock_guard lock{m_state->mutex};
+            m_state->psbt_input_signed = true;
+        }
+        m_state->condition.notify_all();
+
+        if (!wait_for_stage(&SyntheticWalletState::allow_psbt_post_signing, SigningProgress{
+                .phase = SigningProgressPhase::SIGNING_INPUTS,
+                .completed = psbtx.inputs.empty() ? 0U : 1U,
+                .total = psbtx.inputs.empty() ? 0U : 1U,
+                .cancellable = !simulate_reservation,
+            })) {
+            finish(/*cancel_observed=*/true);
+            return common::PSBTError::INCOMPLETE;
+        }
 
         bool fail{false};
         {

--- a/src/qt/test/syntheticwallet.h
+++ b/src/qt/test/syntheticwallet.h
@@ -11,6 +11,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <thread>
 
 namespace qt_test {
 
@@ -27,6 +28,16 @@ struct SyntheticWalletState {
     bool watchdog_released{false};
     bool encrypted{false};
     bool locked{false};
+    bool psbt_sign_entered{false};
+    bool allow_psbt_reservation{true};
+    bool allow_psbt_completion{true};
+    bool psbt_simulate_pqc_reservation{false};
+    bool psbt_counters_reserved{false};
+    bool psbt_cancel_observed{false};
+    bool psbt_sign_finished{false};
+    bool psbt_fail{false};
+    int psbt_sign_calls{0};
+    std::thread::id psbt_sign_thread;
     int lock_calls{0};
     int unlock_calls{0};
 };

--- a/src/qt/test/syntheticwallet.h
+++ b/src/qt/test/syntheticwallet.h
@@ -31,8 +31,10 @@ struct SyntheticWalletState {
     bool psbt_sign_entered{false};
     bool allow_psbt_reservation{true};
     bool allow_psbt_completion{true};
+    bool allow_psbt_post_signing{true};
     bool psbt_simulate_pqc_reservation{false};
     bool psbt_counters_reserved{false};
+    bool psbt_input_signed{false};
     bool psbt_cancel_observed{false};
     bool psbt_sign_finished{false};
     bool psbt_fail{false};

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -19,6 +19,7 @@
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
+#include <qt/test/psbtoperationsdialogtests.h>
 #include <qt/test/walletcontrollertests.h>
 #include <qt/test/walletactivitytests.h>
 #include <qt/test/wallettests.h>
@@ -103,6 +104,9 @@ int main(int argc, char* argv[])
 #ifdef ENABLE_WALLET
         WalletTests test5(app.node());
         num_test_failures += QTest::qExec(&test5);
+
+        PSBTOperationsDialogTests psbt_operations_dialog_tests(app.node());
+        num_test_failures += QTest::qExec(&psbt_operations_dialog_tests);
 
         WalletControllerTests wallet_controller_tests(app.node());
         num_test_failures += QTest::qExec(&wallet_controller_tests);

--- a/src/script/signingprogress.h
+++ b/src/script/signingprogress.h
@@ -13,6 +13,7 @@ enum class SigningProgressPhase {
     RESERVING_PQC_COUNTERS,
     SIGNING_INPUTS,
     FINALIZING_TRANSACTION,
+    VERIFYING_TRANSACTION,
 };
 
 struct SigningProgress {

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -479,7 +479,8 @@ public:
         size_t* n_signed,
         PartiallySignedTransaction& psbtx,
         bool& complete,
-        wallet::PQCUsageReport* pqc_usage) override
+        wallet::PQCUsageReport* pqc_usage,
+        const SigningProgressCallback& progress_callback) override
     {
         if (sign) {
             if (GetPQCKeyValidationSigningError(*m_wallet)) {
@@ -497,7 +498,8 @@ public:
                                             bip32derivs,
                                             n_signed,
                                             /*finalize=*/true,
-                                            sign ? pqc_usage_recorder.GetObserver() : PQCSignatureCounterObserver{});
+                                            sign ? pqc_usage_recorder.GetObserver() : PQCSignatureCounterObserver{},
+                                            progress_callback);
         if (pqc_usage) {
             *pqc_usage = sign ? BuildSigningPQCUsageReport(pqc_usage_recorder) : PQCUsageReport{};
         }

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -17,6 +17,80 @@ using namespace util::hex_literals;
 namespace wallet {
 BOOST_FIXTURE_TEST_SUITE(psbt_wallet_tests, WalletTestingSetup)
 
+static PartiallySignedTransaction MakeSignableNonP2MRPSBT(CWallet& wallet)
+{
+    const CKey key{GenerateRandomKey()};
+    {
+        LOCK(wallet.cs_wallet);
+        wallet.SetWalletFlag(WALLET_FLAG_DESCRIPTORS);
+        FlatSigningProvider provider;
+        std::string error;
+        auto descriptors{Parse("wpkh(" + EncodeSecret(key) + ")", provider, error, /*require_checksum=*/false)};
+        BOOST_REQUIRE_EQUAL(descriptors.size(), 1U);
+        WalletDescriptor wallet_descriptor{std::move(descriptors.front()), 0, 0, 1, 1};
+        BOOST_REQUIRE(wallet.AddWalletDescriptor(wallet_descriptor, provider, "", /*internal=*/false));
+    }
+    const CScript script_pub_key{GetScriptForDestination(WitnessV0KeyHash{key.GetPubKey()})};
+
+    CMutableTransaction funding_mtx;
+    funding_mtx.vout.emplace_back(COIN, script_pub_key);
+    const CTransaction funding_tx{funding_mtx};
+
+    CMutableTransaction spend_tx;
+    spend_tx.vin.emplace_back(COutPoint{funding_tx.GetHash(), 0});
+    spend_tx.vout.emplace_back(COIN - 1'000, script_pub_key);
+
+    PartiallySignedTransaction psbt{spend_tx};
+    psbt.inputs.front().witness_utxo = funding_tx.vout.front();
+    return psbt;
+}
+
+static void CheckNonP2MRPSBTCancellation(CWallet& wallet, SigningProgressPhase cancel_phase)
+{
+    PartiallySignedTransaction psbt{MakeSignableNonP2MRPSBT(wallet)};
+    bool complete{false};
+    size_t n_signed{0};
+    bool cancellation_requested{false};
+
+    const auto error{wallet.FillPSBT(
+        psbt,
+        complete,
+        std::nullopt,
+        /*sign=*/true,
+        /*bip32derivs=*/true,
+        &n_signed,
+        /*finalize=*/true,
+        {},
+        [&](const SigningProgress& progress) {
+            if (progress.phase == cancel_phase && progress.completed == progress.total && progress.completed > 0) {
+                BOOST_CHECK(progress.cancellable);
+                cancellation_requested = true;
+                return false;
+            }
+            return true;
+        })};
+
+    BOOST_REQUIRE(error);
+    BOOST_CHECK_EQUAL(*error, PSBTError::INCOMPLETE);
+    BOOST_CHECK(cancellation_requested);
+    BOOST_CHECK(!complete);
+}
+
+BOOST_AUTO_TEST_CASE(non_p2mr_psbt_cancels_after_signing)
+{
+    CheckNonP2MRPSBTCancellation(m_wallet, SigningProgressPhase::SIGNING_INPUTS);
+}
+
+BOOST_AUTO_TEST_CASE(non_p2mr_psbt_cancels_after_finalization)
+{
+    CheckNonP2MRPSBTCancellation(m_wallet, SigningProgressPhase::FINALIZING_TRANSACTION);
+}
+
+BOOST_AUTO_TEST_CASE(non_p2mr_psbt_cancels_after_verification)
+{
+    CheckNonP2MRPSBTCancellation(m_wallet, SigningProgressPhase::VERIFYING_TRANSACTION);
+}
+
 static void import_descriptor(CWallet& wallet, const std::string& descriptor)
     EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {

--- a/src/wallet/test/wallet_p2mr_parallel_signing_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_parallel_signing_tests.cpp
@@ -9,6 +9,102 @@ using namespace wallet_p2mr_test;
 
 BOOST_FIXTURE_TEST_SUITE(wallet_p2mr_parallel_signing_tests, WalletTestingSetup)
 
+static PartiallySignedTransaction MakePSBT(const P2MRSigningWorkload& workload)
+{
+    PartiallySignedTransaction psbt{workload.spend_tx};
+    for (size_t i = 0; i < workload.spend_tx.vin.size(); ++i) {
+        psbt.inputs.at(i).witness_utxo = workload.coins.at(workload.spend_tx.vin.at(i).prevout).out;
+    }
+    return psbt;
+}
+
+BOOST_AUTO_TEST_CASE(P2MRWalletPSBTProgressCancelsBeforeReservation)
+{
+    static constexpr size_t INPUT_COUNT{2};
+    auto workload{MakeDistinctKeyP2MRSigningWorkload(*m_node.chain, INPUT_COUNT)};
+    PartiallySignedTransaction psbt{MakePSBT(workload)};
+
+    bool complete{false};
+    size_t n_signed{0};
+    bool saw_reserving{false};
+    std::vector<std::tuple<CPQCPubKey, uint32_t, uint32_t>> observed_ranges;
+    const auto error{workload.wallet->FillPSBT(
+        psbt,
+        complete,
+        std::nullopt,
+        /*sign=*/true,
+        /*bip32derivs=*/true,
+        &n_signed,
+        /*finalize=*/true,
+        [&](const CPQCPubKey& pubkey, uint32_t previous_counter, uint32_t reserved_counter) {
+            observed_ranges.emplace_back(pubkey, previous_counter, reserved_counter);
+        },
+        [&](const SigningProgress& progress) {
+            if (progress.phase == SigningProgressPhase::RESERVING_PQC_COUNTERS && progress.cancellable) {
+                saw_reserving = true;
+                return false;
+            }
+            return true;
+        })};
+
+    BOOST_REQUIRE(error);
+    BOOST_CHECK_EQUAL(*error, PSBTError::INCOMPLETE);
+    BOOST_CHECK(saw_reserving);
+    BOOST_CHECK(!complete);
+    BOOST_CHECK_EQUAL(n_signed, 0U);
+    BOOST_CHECK(observed_ranges.empty());
+    for (const auto& pubkeys : workload.pubkeys) {
+        BOOST_CHECK_EQUAL(GetProviderPQCCounter(*workload.p2mr_spk_man, pubkeys.descriptor_pubkey, pubkeys.pqc_pubkey), 0U);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(P2MRWalletPSBTProgressIgnoresCancelAfterReservation)
+{
+    static constexpr size_t INPUT_COUNT{2};
+    auto workload{MakeDistinctKeyP2MRSigningWorkload(*m_node.chain, INPUT_COUNT)};
+    PartiallySignedTransaction psbt{MakePSBT(workload)};
+
+    bool complete{false};
+    size_t n_signed{0};
+    bool saw_committed_reservation{false};
+    bool saw_signing_complete{false};
+    bool saw_verification_complete{false};
+    std::vector<std::tuple<CPQCPubKey, uint32_t, uint32_t>> observed_ranges;
+    const auto error{workload.wallet->FillPSBT(
+        psbt,
+        complete,
+        std::nullopt,
+        /*sign=*/true,
+        /*bip32derivs=*/true,
+        &n_signed,
+        /*finalize=*/true,
+        [&](const CPQCPubKey& pubkey, uint32_t previous_counter, uint32_t reserved_counter) {
+            observed_ranges.emplace_back(pubkey, previous_counter, reserved_counter);
+        },
+        [&](const SigningProgress& progress) {
+            if (!progress.cancellable) saw_committed_reservation = true;
+            if (progress.phase == SigningProgressPhase::SIGNING_INPUTS) {
+                BOOST_CHECK_EQUAL(progress.total, INPUT_COUNT);
+                saw_signing_complete |= progress.completed == INPUT_COUNT;
+            }
+            if (progress.phase == SigningProgressPhase::VERIFYING_TRANSACTION) {
+                saw_verification_complete |= progress.completed == INPUT_COUNT;
+            }
+            return progress.cancellable;
+        })};
+
+    BOOST_CHECK(!error);
+    BOOST_CHECK(complete);
+    BOOST_CHECK_EQUAL(n_signed, INPUT_COUNT);
+    BOOST_CHECK(saw_committed_reservation);
+    BOOST_CHECK(saw_signing_complete);
+    BOOST_CHECK(saw_verification_complete);
+    BOOST_REQUIRE_EQUAL(observed_ranges.size(), INPUT_COUNT);
+    for (const auto& pubkeys : workload.pubkeys) {
+        BOOST_CHECK_EQUAL(GetProviderPQCCounter(*workload.p2mr_spk_man, pubkeys.descriptor_pubkey, pubkeys.pqc_pubkey), 1U);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(P2MRWalletParallelSignsManyInputSpend)
 {
     static constexpr size_t INPUT_COUNT{10};

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2603,7 +2603,7 @@ bool CWallet::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint,
     return false;
 }
 
-std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& complete, std::optional<int> sighash_type, bool sign, bool bip32derivs, size_t * n_signed, bool finalize, const PQCSignatureCounterObserver& pqc_counter_observer) const
+std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bool& complete, std::optional<int> sighash_type, bool sign, bool bip32derivs, size_t * n_signed, bool finalize, const PQCSignatureCounterObserver& pqc_counter_observer, const SigningProgressCallback& progress_callback) const
 {
     const bool timing_enabled{util::signing_timing::Enabled()};
     const uint64_t timing_id{timing_enabled ? util::signing_timing::CurrentOrNextId() : 0};
@@ -2655,6 +2655,50 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
 
     if (n_signed) {
         *n_signed = 0;
+    }
+    complete = false;
+
+    std::set<unsigned int> unsigned_inputs;
+    for (unsigned int i = 0; i < psbtx.inputs.size(); ++i) {
+        if (!PSBTInputSigned(psbtx.inputs.at(i))) unsigned_inputs.insert(i);
+    }
+    const unsigned int input_total{static_cast<unsigned int>(unsigned_inputs.size())};
+    std::set<unsigned int> processed_inputs;
+    bool counters_reserved{false};
+    unsigned int reservations_completed{0};
+    std::optional<unsigned int> signing_input_index;
+    const auto notify_progress = [&](SigningProgressPhase phase,
+                                     unsigned int completed,
+                                     unsigned int total,
+                                     std::optional<unsigned int> input_index = std::nullopt,
+                                     bool cancellable = true) {
+        if (!sign || !progress_callback) return true;
+        const bool may_cancel{cancellable && !counters_reserved};
+        const bool should_continue{progress_callback(SigningProgress{
+            .phase = phase,
+            .completed = completed,
+            .total = total,
+            .input_index = input_index,
+            .cancellable = may_cancel,
+        })};
+        return should_continue || !may_cancel;
+    };
+    const PQCSignatureCounterObserver progress_counter_observer = sign
+        ? PQCSignatureCounterObserver{[&](const CPQCPubKey& pubkey, uint32_t previous_counter, uint32_t reserved_counter) {
+              counters_reserved = true;
+              ++reservations_completed;
+              notify_progress(SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                              reservations_completed,
+                              /*total=*/0,
+                              signing_input_index,
+                              /*cancellable=*/false);
+              if (pqc_counter_observer) pqc_counter_observer(pubkey, previous_counter, reserved_counter);
+          }}
+        : pqc_counter_observer;
+
+    if (!notify_progress(SigningProgressPhase::PREPARING_TRANSACTION, 0, input_total)) {
+        log_fillpsbt_timing(/*success=*/false, "cancelled_preparing");
+        return PSBTError::INCOMPLETE;
     }
 
     struct ActiveSigningProviderSnapshot {
@@ -2716,7 +2760,14 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
             if (sign) {
                 if (auto signer_spk_man = dynamic_cast<ExternalSignerScriptPubKeyMan*>(spk_man)) {
                     int n_signed_this_spkm = 0;
-                    const auto error{signer_spk_man->FillPSBT(psbtx, locked_txdata, sighash_type, sign, bip32derivs, &n_signed_this_spkm, finalize, pqc_counter_observer)};
+                    if (!notify_progress(SigningProgressPhase::SIGNING_INPUTS,
+                                         static_cast<unsigned int>(processed_inputs.size()),
+                                         input_total)) {
+                        provider_collect_time = SteadyClock::now() - provider_collect_start;
+                        log_fillpsbt_timing(/*success=*/false, "cancelled_external_signer");
+                        return PSBTError::INCOMPLETE;
+                    }
+                    const auto error{signer_spk_man->FillPSBT(psbtx, locked_txdata, sighash_type, sign, bip32derivs, &n_signed_this_spkm, finalize, progress_counter_observer)};
                     if (error) {
                         provider_collect_time = SteadyClock::now() - provider_collect_start;
                         log_fillpsbt_timing(/*success=*/false, "external_signer_failed");
@@ -2726,10 +2777,16 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
                         (*n_signed) += n_signed_this_spkm;
                     }
                     signed_count_metric += n_signed_this_spkm;
+                    for (unsigned int i : unsigned_inputs) {
+                        if (PSBTInputSigned(psbtx.inputs.at(i))) processed_inputs.insert(i);
+                    }
+                    notify_progress(SigningProgressPhase::SIGNING_INPUTS,
+                                    static_cast<unsigned int>(processed_inputs.size()),
+                                    input_total);
                     continue;
                 }
             }
-            if (auto provider = spk_man->GetSigningProviderForPSBT(psbtx, sign, pqc_counter_observer)) {
+            if (auto provider = spk_man->GetSigningProviderForPSBT(psbtx, sign, progress_counter_observer)) {
                 providers.push_back(std::move(*provider));
             }
         }
@@ -2762,7 +2819,32 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
                 return PSBTError::MISSING_INPUTS;
             }
 
+            signing_input_index = i;
+            if (sign) {
+                CTxOut utxo;
+                std::vector<std::vector<unsigned char>> solutions;
+                const bool is_p2mr{psbtx.GetInputUTXO(utxo, i) && Solver(utxo.scriptPubKey, solutions) == TxoutType::WITNESS_V2_P2MR};
+                if (is_p2mr && !notify_progress(SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                                                reservations_completed,
+                                                /*total=*/0,
+                                                i)) {
+                    signing_input_index.reset();
+                    sign_inputs_time += SteadyClock::now() - sign_inputs_start;
+                    log_fillpsbt_timing(/*success=*/false, "cancelled_before_reservation");
+                    return PSBTError::INCOMPLETE;
+                }
+                if (!notify_progress(SigningProgressPhase::SIGNING_INPUTS,
+                                     static_cast<unsigned int>(processed_inputs.size()),
+                                     input_total,
+                                     i)) {
+                    signing_input_index.reset();
+                    sign_inputs_time += SteadyClock::now() - sign_inputs_start;
+                    log_fillpsbt_timing(/*success=*/false, "cancelled_signing");
+                    return PSBTError::INCOMPLETE;
+                }
+            }
             PSBTError res = SignPSBTInput(input_provider, psbtx, i, &txdata, sighash_type, nullptr, finalize);
+            signing_input_index.reset();
             if (res != PSBTError::OK && res != PSBTError::INCOMPLETE) {
                 sign_inputs_time += SteadyClock::now() - sign_inputs_start;
                 log_fillpsbt_timing(/*success=*/false, "sign_input_failed");
@@ -2772,6 +2854,13 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
             const bool signed_one = PSBTInputSigned(input);
             if (signed_one || !sign) {
                 ++n_signed_this_spkm;
+            }
+            if (sign && signed_one && unsigned_inputs.contains(i)) {
+                processed_inputs.insert(i);
+                notify_progress(SigningProgressPhase::SIGNING_INPUTS,
+                                static_cast<unsigned int>(processed_inputs.size()),
+                                input_total,
+                                i);
             }
         }
         sign_inputs_time += SteadyClock::now() - sign_inputs_start;
@@ -2789,15 +2878,35 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
         signed_count_metric += n_signed_this_spkm;
     }
 
+    if (sign && finalize && !notify_progress(SigningProgressPhase::FINALIZING_TRANSACTION, 0, 1)) {
+        log_fillpsbt_timing(/*success=*/false, "cancelled_finalizing");
+        return PSBTError::INCOMPLETE;
+    }
     const auto remove_unnecessary_start{SteadyClock::now()};
     RemoveUnnecessaryTransactions(psbtx);
     remove_unnecessary_time = SteadyClock::now() - remove_unnecessary_start;
+    if (sign && finalize) {
+        notify_progress(SigningProgressPhase::FINALIZING_TRANSACTION, 1, 1);
+    }
 
     // Complete if every input is now signed
     const auto final_verify_start{SteadyClock::now()};
     complete = true;
     for (size_t i = 0; i < psbtx.inputs.size(); ++i) {
+        if (!notify_progress(SigningProgressPhase::VERIFYING_TRANSACTION,
+                             static_cast<unsigned int>(i),
+                             static_cast<unsigned int>(psbtx.inputs.size()),
+                             static_cast<unsigned int>(i))) {
+            complete = false;
+            final_verify_time = SteadyClock::now() - final_verify_start;
+            log_fillpsbt_timing(/*success=*/false, "cancelled_verifying");
+            return PSBTError::INCOMPLETE;
+        }
         complete &= PSBTInputSignedAndVerified(psbtx, i, &txdata);
+        notify_progress(SigningProgressPhase::VERIFYING_TRANSACTION,
+                        static_cast<unsigned int>(i + 1),
+                        static_cast<unsigned int>(psbtx.inputs.size()),
+                        static_cast<unsigned int>(i));
     }
     final_verify_time = SteadyClock::now() - final_verify_start;
     complete_metric = complete;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2780,9 +2780,13 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
                     for (unsigned int i : unsigned_inputs) {
                         if (PSBTInputSigned(psbtx.inputs.at(i))) processed_inputs.insert(i);
                     }
-                    notify_progress(SigningProgressPhase::SIGNING_INPUTS,
-                                    static_cast<unsigned int>(processed_inputs.size()),
-                                    input_total);
+                    if (!notify_progress(SigningProgressPhase::SIGNING_INPUTS,
+                                         static_cast<unsigned int>(processed_inputs.size()),
+                                         input_total)) {
+                        provider_collect_time = SteadyClock::now() - provider_collect_start;
+                        log_fillpsbt_timing(/*success=*/false, "cancelled_after_external_signer");
+                        return PSBTError::INCOMPLETE;
+                    }
                     continue;
                 }
             }
@@ -2857,10 +2861,14 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
             }
             if (sign && signed_one && unsigned_inputs.contains(i)) {
                 processed_inputs.insert(i);
-                notify_progress(SigningProgressPhase::SIGNING_INPUTS,
-                                static_cast<unsigned int>(processed_inputs.size()),
-                                input_total,
-                                i);
+                if (!notify_progress(SigningProgressPhase::SIGNING_INPUTS,
+                                     static_cast<unsigned int>(processed_inputs.size()),
+                                     input_total,
+                                     i)) {
+                    sign_inputs_time += SteadyClock::now() - sign_inputs_start;
+                    log_fillpsbt_timing(/*success=*/false, "cancelled_after_signing");
+                    return PSBTError::INCOMPLETE;
+                }
             }
         }
         sign_inputs_time += SteadyClock::now() - sign_inputs_start;
@@ -2886,7 +2894,10 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
     RemoveUnnecessaryTransactions(psbtx);
     remove_unnecessary_time = SteadyClock::now() - remove_unnecessary_start;
     if (sign && finalize) {
-        notify_progress(SigningProgressPhase::FINALIZING_TRANSACTION, 1, 1);
+        if (!notify_progress(SigningProgressPhase::FINALIZING_TRANSACTION, 1, 1)) {
+            log_fillpsbt_timing(/*success=*/false, "cancelled_after_finalizing");
+            return PSBTError::INCOMPLETE;
+        }
     }
 
     // Complete if every input is now signed
@@ -2903,10 +2914,15 @@ std::optional<PSBTError> CWallet::FillPSBT(PartiallySignedTransaction& psbtx, bo
             return PSBTError::INCOMPLETE;
         }
         complete &= PSBTInputSignedAndVerified(psbtx, i, &txdata);
-        notify_progress(SigningProgressPhase::VERIFYING_TRANSACTION,
-                        static_cast<unsigned int>(i + 1),
-                        static_cast<unsigned int>(psbtx.inputs.size()),
-                        static_cast<unsigned int>(i));
+        if (!notify_progress(SigningProgressPhase::VERIFYING_TRANSACTION,
+                             static_cast<unsigned int>(i + 1),
+                             static_cast<unsigned int>(psbtx.inputs.size()),
+                             static_cast<unsigned int>(i))) {
+            complete = false;
+            final_verify_time = SteadyClock::now() - final_verify_start;
+            log_fillpsbt_timing(/*success=*/false, "cancelled_after_verifying");
+            return PSBTError::INCOMPLETE;
+        }
     }
     final_verify_time = SteadyClock::now() - final_verify_start;
     complete_metric = complete;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -761,7 +761,8 @@ public:
                   bool bip32derivs = true,
                   size_t* n_signed = nullptr,
                   bool finalize = true,
-                  const PQCSignatureCounterObserver& pqc_counter_observer = {}) const;
+                  const PQCSignatureCounterObserver& pqc_counter_observer = {},
+                  const SigningProgressCallback& progress_callback = {}) const;
 
     /**
      * Submit the transaction to the node's mempool and then relay to peers.


### PR DESCRIPTION
## Summary

- Move PSBT signing initiated by `PSBTOperationsDialog` into a cloned-wallet worker context so multi-input P2MR signing no longer blocks the Qt event loop.
- Publish a worker-owned PSBT on the GUI thread only after successful completion, with queued progress for preparation, counter reservation, signing, finalization, and verification.
- Allow cancellation before durable PQC counter reservation and disable it after the existing post-commit reservation observer fires.
- Add deterministic Qt lifecycle/cancellation coverage and real-wallet P2MR counter-boundary regression tests.

Closes #140.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.

Commands and results:

- `cmake --build build --target bitcoin_wallet qbit-qt test_qbit-qt test_qbit -j"$(sysctl -n hw.ncpu)"` — passed.
- `build/bin/test_qbit '--run_test=wallet_p2mr_parallel_signing_tests,psbt_p2mr_tests,psbt_wallet_tests,wallet_p2mr_signing_tests' --log_level=test_suite` — 40/40 passed.
- `QT_QPA_PLATFORM=cocoa build/bin/test_qbit-qt` — the new `PSBTOperationsDialogTests` passed 9/9 and all other relevant wallet/Qt lifecycle classes passed. The binary still reports one unrelated failure in the unchanged `RPCNestedTests` stale genesis-transaction hash assertion.
- Repository Docker lint workflow — passed with exit code 0 (`All checks passed!`).
- `git diff --check` — passed.

## Target Branch

- [x] This PR targets the maintainer-requested `1.x.x` release branch.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- PSBT input signing remains serial; this change moves the existing signing flow off the GUI thread without changing provider ordering or introducing batch counter reservation.
- A cloned wallet and `QPointer`/generation guards prevent callbacks into destroyed dialogs or wallet models. Dialog destruction joins the worker, and wallet unload leaves the worker-owned clone valid until completion.
- External-signer calls run in the worker but cannot be interrupted after the external process call begins. Shutdown may therefore wait for an in-flight external signer or post-reservation cryptography to finish.
- PQC usage information is retained for callers, but presentation changes remain intentionally out of scope for #141.

## Docs / Process Impact

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: this changes Qt responsiveness, progress, cancellation, and lifetime handling without changing public integration or operator guidance.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; `src/libbitcoinpqc` is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet PSBT signing, PQC counter reservation, and async Qt lifetime; behavior changes are mostly UI threading but incorrect cancel or clone handling could affect signing outcomes.
> 
> **Overview**
> **PSBT signing in the Qt GUI no longer blocks the event loop.** `PSBTOperationsDialog` runs `fillPSBT` on a worker thread using a cloned wallet, shows phased progress (prepare, PQC counter reservation, signing, finalize, verify), and applies the signed PSBT on the GUI thread only after success.
> 
> **Cancellation** is honored via a new `SigningProgressCallback` on `interfaces::Wallet::fillPSBT` and `CWallet::FillPSBT`, with cancel disabled once PQC counters are durably reserved. The send flow maps the new **verifying** phase into its existing finalizing progress UI.
> 
> **Status UX** appends PQC usage details after signing attempts, and **nine Qt tests** cover responsiveness, cancel boundaries, dialog/wallet lifetime, and failure preserving the original PSBT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435fbba46116e9835bf525ed110d7df38cb17f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786896313&installation_id=141183937&pr_number=145&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F145&signature=a267e7729e2bb48e22a45f8ba25a2648ece63336569cf5a827cef3590a7277a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->