### PR TITLE
qt: move P2MR fee bump signing off the GUI thread

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -201,7 +201,9 @@ public:
         CMutableTransaction& mtx) = 0;
 
     //! Sign bump transaction.
-    virtual bool signBumpTransaction(CMutableTransaction& mtx) = 0;
+    virtual bool signBumpTransaction(CMutableTransaction& mtx,
+        wallet::PQCUsageReport* pqc_usage = nullptr,
+        const SigningProgressCallback& progress_callback = {}) = 0;
 
     //! Commit bump transaction.
     virtual bool commitBumpTransaction(const Txid& txid,

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -198,7 +198,8 @@ public:
         std::vector<bilingual_str>& errors,
         CAmount& old_fee,
         CAmount& new_fee,
-        CMutableTransaction& mtx) = 0;
+        CMutableTransaction& mtx,
+        const SigningProgressCallback& progress_callback = {}) = 0;
 
     //! Sign bump transaction.
     virtual bool signBumpTransaction(CMutableTransaction& mtx,

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -39,7 +39,9 @@
 #include <QDialogButtonBox>
 #include <QElapsedTimer>
 #include <QEvent>
+#include <QEventLoop>
 #include <QLineEdit>
+#include <QMessageBox>
 #include <QPushButton>
 #include <QRegularExpression>
 #include <QScopedPointer>
@@ -81,6 +83,43 @@ void AcceptWalletUnlock()
             return;
         }
     });
+}
+
+void AcceptFeeBumpConfirmation()
+{
+    auto* timer{new QTimer(qApp)};
+    timer->setInterval(10);
+    QObject::connect(timer, &QTimer::timeout, timer, [timer] {
+        for (QWidget* widget : QApplication::topLevelWidgets()) {
+            if (!widget->inherits("SendConfirmationDialog") || !widget->isVisible()) continue;
+            auto* dialog{qobject_cast<QMessageBox*>(widget)};
+            if (!dialog) return;
+            QAbstractButton* const yes_button{dialog->button(QMessageBox::Yes)};
+            if (!yes_button) return;
+            yes_button->setEnabled(true);
+            yes_button->click();
+            timer->stop();
+            timer->deleteLater();
+            return;
+        }
+    });
+    timer->start();
+}
+
+bool WaitForIrreversibleFeeBumpSigning(const std::shared_ptr<qt_test::SyntheticWalletState>& state, int timeout_ms)
+{
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < timeout_ms) {
+        {
+            std::lock_guard lock{state->mutex};
+            if (state->bump_sign_entered && state->bump_counters_reserved) return true;
+        }
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 50);
+        QTest::qWait(10);
+    }
+    std::lock_guard lock{state->mutex};
+    return state->bump_sign_entered && state->bump_counters_reserved;
 }
 #endif // ENABLE_WALLET
 
@@ -153,6 +192,14 @@ void AppTests::appTests()
             state->condition.notify_all();
         }
     }};
+    std::thread bump_signer_release{[state] {
+        std::this_thread::sleep_for(100ms);
+        {
+            std::lock_guard lock{state->mutex};
+            state->allow_bump_sign = true;
+        }
+        state->condition.notify_all();
+    }};
 
     QElapsedTimer shutdown_timer;
     shutdown_timer.start();
@@ -167,6 +214,7 @@ void AppTests::appTests()
     }
     state->condition.notify_all();
     watchdog.join();
+    bump_signer_release.join();
 
     bool worker_destroyed{false};
     {
@@ -184,6 +232,8 @@ void AppTests::appTests()
     bool cancel_observed{false};
     bool watchdog_released{false};
     bool locked{false};
+    bool bump_committed{false};
+    bool bump_cancel_observed{false};
     int lock_calls{0};
     int unlock_calls{0};
     {
@@ -191,6 +241,8 @@ void AppTests::appTests()
         cancel_observed = state->cancel_observed;
         watchdog_released = state->watchdog_released;
         locked = state->locked;
+        bump_committed = state->bump_committed;
+        bump_cancel_observed = state->bump_cancel_observed;
         lock_calls = state->lock_calls;
         unlock_calls = state->unlock_calls;
     }
@@ -198,6 +250,8 @@ void AppTests::appTests()
     QVERIFY2(m_shutdown_elapsed_ms < 5000, "Qt wallet shutdown exceeded the five-second bound");
     QVERIFY(!watchdog_released);
     QVERIFY(cancel_observed);
+    QVERIFY(bump_committed);
+    QVERIFY(!bump_cancel_observed);
     QVERIFY(worker_destroyed);
     QVERIFY(m_shutdown_wallet_model.isNull());
     QVERIFY(m_shutdown_wallet_view.isNull());
@@ -274,6 +328,8 @@ void AppTests::guiTests(BitcoinGUI* window)
         m_shutdown_wallet_state->wait_for_cancel = true;
         m_shutdown_wallet_state->encrypted = true;
         m_shutdown_wallet_state->locked = true;
+        m_shutdown_wallet_state->bump_enabled = true;
+        m_shutdown_wallet_state->allow_bump_sign = false;
     }
 
     QSignalSpy wallet_added_spy(controller, &WalletController::walletAdded);
@@ -329,6 +385,10 @@ void AppTests::guiTests(BitcoinGUI* window)
         QCOMPARE(m_shutdown_wallet_state->unlock_calls, 1);
         QVERIFY(!m_shutdown_wallet_state->locked);
     }
+
+    AcceptFeeBumpConfirmation();
+    QVERIFY(m_shutdown_wallet_model->bumpFee(Txid{}));
+    QVERIFY(WaitForIrreversibleFeeBumpSigning(m_shutdown_wallet_state, 5000));
 
     QCOMPARE(window->findChildren<WalletView*>().size(), 3);
 #endif // ENABLE_WALLET

--- a/src/qt/test/syntheticwallet.cpp
+++ b/src/qt/test/syntheticwallet.cpp
@@ -298,13 +298,22 @@ public:
                 })) {
                 return false;
             }
+            {
+                std::lock_guard lock{m_state->mutex};
+                m_state->external_bump_boundary_entered = true;
+            }
+            m_state->condition.notify_all();
+            std::unique_lock lock{m_state->mutex};
+            m_state->condition.wait(lock, [this] { return m_state->allow_external_bump_boundary; });
         }
-        report_progress({
+        if (!report_progress({
             .phase = SigningProgressPhase::SIGNING_INPUTS,
             .completed = 0,
             .total = 1,
             .cancellable = !use_counters && !external_signer,
-        });
+        })) {
+            return false;
+        }
         {
             std::unique_lock lock{m_state->mutex};
             m_state->condition.wait(lock, [this] { return m_state->allow_bump_sign; });

--- a/src/qt/test/syntheticwallet.cpp
+++ b/src/qt/test/syntheticwallet.cpp
@@ -277,6 +277,20 @@ public:
                 return false;
             }
             {
+                std::unique_lock lock{m_state->mutex};
+                m_state->bump_counter_boundary_entered = true;
+                m_state->condition.notify_all();
+                m_state->condition.wait(lock, [this] { return m_state->allow_bump_counter_boundary; });
+            }
+            if (!report_progress({
+                    .phase = SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                    .completed = 0,
+                    .total = 1,
+                    .cancellable = false,
+                })) {
+                return false;
+            }
+            {
                 std::lock_guard lock{m_state->mutex};
                 m_state->bump_counters_reserved = true;
             }

--- a/src/qt/test/syntheticwallet.cpp
+++ b/src/qt/test/syntheticwallet.cpp
@@ -193,12 +193,30 @@ public:
         std::vector<bilingual_str>& errors,
         CAmount& old_fee,
         CAmount& new_fee,
-        CMutableTransaction& mtx) override
+        CMutableTransaction& mtx,
+        const SigningProgressCallback& progress_callback) override
     {
         std::unique_lock lock{m_state->mutex};
         m_state->bump_prepare_entered = true;
         m_state->condition.notify_all();
-        m_state->condition.wait(lock, [this] { return m_state->allow_bump_prepare; });
+        const auto continue_preparation = [&] {
+            if (!progress_callback || progress_callback({
+                    .phase = SigningProgressPhase::PREPARING_TRANSACTION,
+                    .completed = 0,
+                    .total = 0,
+                    .cancellable = true,
+                })) {
+                return true;
+            }
+            m_state->bump_prepare_cancel_observed = true;
+            m_state->condition.notify_all();
+            return false;
+        };
+        while (!m_state->allow_bump_prepare) {
+            if (!continue_preparation()) return false;
+            m_state->condition.wait_for(lock, 10ms, [this] { return m_state->allow_bump_prepare; });
+        }
+        if (!continue_preparation()) return false;
         if (!m_state->bump_prepare_success) {
             errors.emplace_back(Untranslated("Synthetic fee-bump preparation failed"));
             return false;

--- a/src/qt/test/syntheticwallet.cpp
+++ b/src/qt/test/syntheticwallet.cpp
@@ -183,10 +183,153 @@ public:
     void commitTransaction(CTransactionRef, interfaces::WalletValueMap, interfaces::WalletOrderForm) override {}
     bool transactionCanBeAbandoned(const Txid&) override { return false; }
     bool abandonTransaction(const Txid&) override { return false; }
-    bool transactionCanBeBumped(const Txid&) override { return false; }
-    bool createBumpTransaction(const Txid&, const wallet::CCoinControl&, std::vector<bilingual_str>&, CAmount&, CAmount&, CMutableTransaction&) override { return false; }
-    bool signBumpTransaction(CMutableTransaction&) override { return false; }
-    bool commitBumpTransaction(const Txid&, CMutableTransaction&&, std::vector<bilingual_str>&, Txid&) override { return false; }
+    bool transactionCanBeBumped(const Txid&) override
+    {
+        std::lock_guard lock{m_state->mutex};
+        return m_state->bump_enabled;
+    }
+    bool createBumpTransaction(const Txid& txid,
+        const wallet::CCoinControl&,
+        std::vector<bilingual_str>& errors,
+        CAmount& old_fee,
+        CAmount& new_fee,
+        CMutableTransaction& mtx) override
+    {
+        std::unique_lock lock{m_state->mutex};
+        m_state->bump_prepare_entered = true;
+        m_state->condition.notify_all();
+        m_state->condition.wait(lock, [this] { return m_state->allow_bump_prepare; });
+        if (!m_state->bump_prepare_success) {
+            errors.emplace_back(Untranslated("Synthetic fee-bump preparation failed"));
+            return false;
+        }
+
+        old_fee = 1000;
+        new_fee = 2000;
+        mtx = CMutableTransaction{};
+        mtx.vin.emplace_back(COutPoint{txid, 0});
+        mtx.vout.emplace_back(COIN - new_fee, CScript{} << OP_TRUE);
+        return true;
+    }
+    bool signBumpTransaction(CMutableTransaction& mtx,
+        wallet::PQCUsageReport* pqc_usage,
+        const SigningProgressCallback& progress_callback) override
+    {
+        bool use_counters{false};
+        bool external_signer{false};
+        {
+            std::lock_guard lock{m_state->mutex};
+            m_state->bump_sign_entered = true;
+            use_counters = m_state->bump_use_counters;
+            external_signer = m_state->external_signer;
+        }
+        m_state->condition.notify_all();
+
+        const auto report_progress = [&](SigningProgress progress) {
+            if (!progress_callback || progress_callback(progress)) return true;
+            std::lock_guard lock{m_state->mutex};
+            m_state->bump_cancel_observed = true;
+            m_state->condition.notify_all();
+            return false;
+        };
+        while (true) {
+            {
+                std::lock_guard lock{m_state->mutex};
+                if (m_state->allow_bump_reservation) break;
+            }
+            if (!report_progress({
+                    .phase = SigningProgressPhase::PREPARING_TRANSACTION,
+                    .completed = 0,
+                    .total = 1,
+                    .cancellable = true,
+                })) {
+                return false;
+            }
+            std::unique_lock lock{m_state->mutex};
+            m_state->condition.wait_for(lock, 10ms, [this] { return m_state->allow_bump_reservation; });
+        }
+
+        if (use_counters) {
+            if (!report_progress({
+                    .phase = SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                    .completed = 0,
+                    .total = 1,
+                    .cancellable = true,
+                })) {
+                return false;
+            }
+            {
+                std::lock_guard lock{m_state->mutex};
+                m_state->bump_counters_reserved = true;
+            }
+            m_state->condition.notify_all();
+            report_progress({
+                .phase = SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                .completed = 1,
+                .total = 1,
+                .cancellable = false,
+            });
+        }
+
+        if (external_signer) {
+            if (!report_progress({
+                    .phase = SigningProgressPhase::SIGNING_INPUTS,
+                    .completed = 0,
+                    .total = 1,
+                    .cancellable = true,
+                })) {
+                return false;
+            }
+        }
+        report_progress({
+            .phase = SigningProgressPhase::SIGNING_INPUTS,
+            .completed = 0,
+            .total = 1,
+            .cancellable = !use_counters && !external_signer,
+        });
+        {
+            std::unique_lock lock{m_state->mutex};
+            m_state->condition.wait(lock, [this] { return m_state->allow_bump_sign; });
+        }
+        if (!use_counters && !external_signer && !report_progress({
+                .phase = SigningProgressPhase::SIGNING_INPUTS,
+                .completed = 0,
+                .total = 1,
+                .cancellable = true,
+            })) {
+            return false;
+        }
+
+        {
+            std::lock_guard lock{m_state->mutex};
+            if (!m_state->bump_sign_success) return false;
+        }
+        mtx.vin.front().scriptWitness.stack.emplace_back(1, 1);
+        if (pqc_usage) *pqc_usage = m_report;
+        report_progress({
+            .phase = SigningProgressPhase::FINALIZING_TRANSACTION,
+            .completed = 1,
+            .total = 1,
+            .cancellable = false,
+        });
+        return true;
+    }
+    bool commitBumpTransaction(const Txid&,
+        CMutableTransaction&& mtx,
+        std::vector<bilingual_str>& errors,
+        Txid& bumped_txid) override
+    {
+        std::lock_guard lock{m_state->mutex};
+        m_state->bump_commit_entered = true;
+        if (!m_state->bump_commit_success) {
+            errors.emplace_back(Untranslated("Original transaction changed while signing"));
+            return false;
+        }
+        bumped_txid = mtx.GetHash();
+        m_state->bump_committed = true;
+        m_state->condition.notify_all();
+        return true;
+    }
     CTransactionRef getTx(const Txid&) override { return {}; }
     interfaces::WalletTx getWalletTx(const Txid&) override { return {}; }
     std::set<interfaces::WalletTx> getWalletTxs() override { return {}; }
@@ -219,7 +362,11 @@ public:
     bool canGetAddresses() override { return true; }
     bool privateKeysDisabled() override { return false; }
     bool taprootEnabled() override { return false; }
-    bool hasExternalSigner() override { return false; }
+    bool hasExternalSigner() override
+    {
+        std::lock_guard lock{m_state->mutex};
+        return m_state->external_signer;
+    }
     OutputType getDefaultAddressType() override { return OutputType::P2MR; }
     CAmount getDefaultMaxTxFee() override { return MAX_MONEY; }
     wallet::PQCKeyValidationInfo getPQCKeyValidationInfo() const override { return {}; }

--- a/src/qt/test/syntheticwallet.h
+++ b/src/qt/test/syntheticwallet.h
@@ -29,6 +29,21 @@ struct SyntheticWalletState {
     bool locked{false};
     int lock_calls{0};
     int unlock_calls{0};
+    bool bump_enabled{false};
+    bool bump_prepare_entered{false};
+    bool bump_prepare_success{true};
+    bool allow_bump_prepare{true};
+    bool bump_sign_entered{false};
+    bool bump_sign_success{true};
+    bool bump_use_counters{true};
+    bool allow_bump_reservation{true};
+    bool bump_counters_reserved{false};
+    bool allow_bump_sign{true};
+    bool bump_cancel_observed{false};
+    bool bump_commit_entered{false};
+    bool bump_commit_success{true};
+    bool bump_committed{false};
+    bool external_signer{false};
 };
 
 std::unique_ptr<interfaces::Wallet> MakeSyntheticWallet(

--- a/src/qt/test/syntheticwallet.h
+++ b/src/qt/test/syntheticwallet.h
@@ -38,6 +38,8 @@ struct SyntheticWalletState {
     bool bump_sign_success{true};
     bool bump_use_counters{true};
     bool allow_bump_reservation{true};
+    bool bump_counter_boundary_entered{false};
+    bool allow_bump_counter_boundary{true};
     bool bump_counters_reserved{false};
     bool external_bump_boundary_entered{false};
     bool allow_external_bump_boundary{true};

--- a/src/qt/test/syntheticwallet.h
+++ b/src/qt/test/syntheticwallet.h
@@ -33,6 +33,7 @@ struct SyntheticWalletState {
     bool bump_prepare_entered{false};
     bool bump_prepare_success{true};
     bool allow_bump_prepare{true};
+    bool bump_prepare_cancel_observed{false};
     bool bump_sign_entered{false};
     bool bump_sign_success{true};
     bool bump_use_counters{true};

--- a/src/qt/test/syntheticwallet.h
+++ b/src/qt/test/syntheticwallet.h
@@ -39,6 +39,8 @@ struct SyntheticWalletState {
     bool bump_use_counters{true};
     bool allow_bump_reservation{true};
     bool bump_counters_reserved{false};
+    bool external_bump_boundary_entered{false};
+    bool allow_external_bump_boundary{true};
     bool allow_bump_sign{true};
     bool bump_cancel_observed{false};
     bool bump_commit_entered{false};

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -48,6 +48,7 @@
 
 #include <array>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <set>
 #include <span>
@@ -202,8 +203,8 @@ void ReleaseSyntheticBumpSigning(const std::shared_ptr<qt_test::SyntheticWalletS
 class SendConfirmationClicker : public QObject
 {
 public:
-    SendConfirmationClicker(QString* text, QMessageBox::StandardButton confirm_type)
-        : QObject(QApplication::instance()), m_text(text), m_confirm_type(confirm_type)
+    SendConfirmationClicker(QString* text, QMessageBox::StandardButton confirm_type, std::function<void()> before_click = {})
+        : QObject(QApplication::instance()), m_text(text), m_confirm_type(confirm_type), m_before_click(std::move(before_click))
     {
         QApplication::instance()->installEventFilter(this);
         m_timer.setInterval(50);
@@ -244,6 +245,7 @@ private:
         if (m_clicked || !dialog) return;
         m_clicked = true;
         if (m_text) *m_text = dialog->text();
+        if (m_before_click) m_before_click();
         QAbstractButton* button = dialog->button(m_confirm_type);
         button->setEnabled(true);
         button->click();
@@ -253,6 +255,7 @@ private:
 
     QString* const m_text;
     const QMessageBox::StandardButton m_confirm_type;
+    const std::function<void()> m_before_click;
     QTimer m_timer;
     QPointer<SendConfirmationDialog> m_dialog;
     bool m_clicked{false};
@@ -336,9 +339,9 @@ private:
 };
 
 //! Press "Yes" or "Cancel" buttons in modal send confirmation dialog.
-void ConfirmSend(QString* text = nullptr, QMessageBox::StandardButton confirm_type = QMessageBox::Yes)
+void ConfirmSend(QString* text = nullptr, QMessageBox::StandardButton confirm_type = QMessageBox::Yes, std::function<void()> before_click = {})
 {
-    new SendConfirmationClicker(text, confirm_type);
+    new SendConfirmationClicker(text, confirm_type, std::move(before_click));
 }
 
 //! Send coins to address and return txid.
@@ -1584,6 +1587,73 @@ void TestAsyncFeeBumpLifecycle(interfaces::Node& node)
         return model.bumpFee(Txid{});
     };
 
+    // Preparation cancellation is observed cooperatively while the cloned
+    // wallet is still preparing the replacement. Cleanup leaves the model
+    // ready for a later fee bump.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->allow_bump_prepare = false;
+        }
+        auto model{make_model(state)};
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        QVERIFY(model->bumpFee(Txid{}));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.bump_prepare_entered; });
+        }, 5000));
+
+        QPointer<QProgressDialog> progress;
+        QVERIFY(WaitUntil([&] {
+            progress = FindBumpFeeProgressDialog();
+            return progress && progress->isVisible() && !progress->findChildren<QPushButton*>().empty();
+        }, 5000));
+        progress->findChildren<QPushButton*>().front()->click();
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) {
+                return value.bump_prepare_cancel_observed && value.background_clone_destroyed;
+            });
+        }, 5000));
+        QCOMPARE(completed.count(), 0);
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return !value.bump_sign_entered && !value.bump_commit_entered;
+        }));
+
+        {
+            std::lock_guard lock{state->mutex};
+            state->allow_bump_prepare = true;
+        }
+        state->condition.notify_all();
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&completed] { return completed.count() == 1; }, 5000));
+    }
+
+    // Shutdown requested from the confirmation dialog must not be cleared by
+    // the transition to signing. The canceled activity is fully cleaned up and
+    // does not block a later fee bump.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+        }
+        auto model{make_model(state)};
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        ConfirmSend(nullptr, QMessageBox::Yes, [&] { model->prepareForShutdown(); });
+        QVERIFY(model->bumpFee(Txid{}));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.background_clone_destroyed; });
+        }, 5000));
+        QCOMPARE(completed.count(), 0);
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return !value.bump_sign_entered && !value.bump_commit_entered;
+        }));
+
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&completed] { return completed.count() == 1; }, 5000));
+    }
+
     // Internal P2MR signing stays off the GUI thread. Once counters are
     // durably reserved, an attempted cancellation is ignored and the
     // replacement proceeds to commit.
@@ -1629,6 +1699,35 @@ void TestAsyncFeeBumpLifecycle(interfaces::Node& node)
         }, 5000));
         QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
             return value.bump_commit_entered && value.bump_committed && !value.bump_cancel_observed;
+        }));
+    }
+
+    // Shutdown cannot invalidate the completion callback after counter
+    // reservation. The irreversible replacement commits and is still reported.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->allow_bump_sign = false;
+        }
+        auto model{make_model(state)};
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) {
+                return value.bump_sign_entered && value.bump_counters_reserved;
+            });
+        }, 5000));
+
+        model->prepareForShutdown();
+        ReleaseSyntheticBumpSigning(state);
+        QVERIFY(WaitUntil([&completed] { return completed.count() == 1; }, 5000));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.background_clone_destroyed; });
+        }, 5000));
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return value.bump_commit_entered && value.bump_committed;
         }));
     }
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -1707,6 +1707,45 @@ void TestAsyncFeeBumpLifecycle(interfaces::Node& node)
         }));
     }
 
+    // Cancellation that lands after the last cancellable progress update but
+    // before durable counter reservation wins the atomic boundary. No counter
+    // is consumed and no replacement is committed.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->allow_bump_counter_boundary = false;
+        }
+        auto model{make_model(state)};
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.bump_counter_boundary_entered; });
+        }, 5000));
+
+        QPointer<QProgressDialog> progress;
+        QVERIFY(WaitUntil([&] {
+            progress = FindBumpFeeProgressDialog();
+            return progress && progress->isVisible() && !progress->findChildren<QPushButton*>().empty();
+        }, 5000));
+        progress->findChildren<QPushButton*>().front()->click();
+        {
+            std::lock_guard lock{state->mutex};
+            state->allow_bump_counter_boundary = true;
+        }
+        state->condition.notify_all();
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) {
+                return value.bump_cancel_observed && value.background_clone_destroyed;
+            });
+        }, 5000));
+        QCOMPARE(completed.count(), 0);
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return !value.bump_counters_reserved && !value.bump_commit_entered && !value.bump_committed;
+        }));
+    }
+
     // Shutdown cannot invalidate the completion callback after counter
     // reservation. The irreversible replacement commits and is still reported.
     {

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -53,6 +53,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -69,6 +70,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QPlainTextEdit>
+#include <QProgressDialog>
 #include <QPushButton>
 #include <QSignalSpy>
 #include <QTabWidget>
@@ -171,6 +173,32 @@ bool WaitUntil(Predicate&& predicate, int timeout_ms)
     return predicate();
 }
 
+template <typename Predicate>
+bool SyntheticStateMatches(const std::shared_ptr<qt_test::SyntheticWalletState>& state, Predicate&& predicate)
+{
+    std::lock_guard lock{state->mutex};
+    return predicate(*state);
+}
+
+QProgressDialog* FindBumpFeeProgressDialog()
+{
+    for (QWidget* widget : QApplication::topLevelWidgets()) {
+        if (widget->objectName() == QStringLiteral("bumpFeeProgressDialog")) {
+            return qobject_cast<QProgressDialog*>(widget);
+        }
+    }
+    return nullptr;
+}
+
+void ReleaseSyntheticBumpSigning(const std::shared_ptr<qt_test::SyntheticWalletState>& state)
+{
+    {
+        std::lock_guard lock{state->mutex};
+        state->allow_bump_sign = true;
+    }
+    state->condition.notify_all();
+}
+
 class SendConfirmationClicker : public QObject
 {
 public:
@@ -191,7 +219,7 @@ public:
     bool eventFilter(QObject* watched, QEvent* event) override
     {
         if (event->type() == QEvent::Show && watched->inherits("SendConfirmationDialog")) {
-            click(qobject_cast<SendConfirmationDialog*>(watched));
+            m_dialog = qobject_cast<SendConfirmationDialog*>(watched);
         }
         return QObject::eventFilter(watched, event);
     }
@@ -199,8 +227,12 @@ public:
 private:
     void tryClickVisibleDialog()
     {
+        if (m_dialog) {
+            click(m_dialog);
+            return;
+        }
         for (QWidget* widget : QApplication::topLevelWidgets()) {
-            if (widget->inherits("SendConfirmationDialog")) {
+            if (widget->inherits("SendConfirmationDialog") && widget->isVisible()) {
                 click(qobject_cast<SendConfirmationDialog*>(widget));
                 return;
             }
@@ -214,7 +246,7 @@ private:
         if (m_text) *m_text = dialog->text();
         QAbstractButton* button = dialog->button(m_confirm_type);
         button->setEnabled(true);
-        QMetaObject::invokeMethod(dialog, "done", Qt::QueuedConnection, Q_ARG(int, static_cast<int>(m_confirm_type)));
+        button->click();
         m_timer.stop();
         deleteLater();
     }
@@ -222,14 +254,15 @@ private:
     QString* const m_text;
     const QMessageBox::StandardButton m_confirm_type;
     QTimer m_timer;
+    QPointer<SendConfirmationDialog> m_dialog;
     bool m_clicked{false};
 };
 
 class MessageBoxClicker : public QObject
 {
 public:
-    MessageBoxClicker(QString object_name, QMessageBox::StandardButton button)
-        : QObject(QApplication::instance()), m_object_name(std::move(object_name)), m_button(button)
+    MessageBoxClicker(QString object_name, QMessageBox::StandardButton button, QString* text = nullptr)
+        : QObject(QApplication::instance()), m_object_name(std::move(object_name)), m_button(button), m_text(text)
     {
         QApplication::instance()->installEventFilter(this);
         m_timer.setInterval(50);
@@ -245,16 +278,28 @@ public:
     bool eventFilter(QObject* watched, QEvent* event) override
     {
         if (event->type() == QEvent::Show && watched->inherits("QMessageBox")) {
-            click(qobject_cast<QMessageBox*>(watched));
+            QMessageBox* const dialog{qobject_cast<QMessageBox*>(watched)};
+            if (matches(dialog)) m_dialog = dialog;
         }
         return QObject::eventFilter(watched, event);
     }
 
 private:
+    bool matches(QMessageBox* dialog) const
+    {
+        if (!dialog) return false;
+        if (m_object_name.isEmpty()) return !dialog->inherits("SendConfirmationDialog");
+        return dialog->objectName() == m_object_name;
+    }
+
     void tryClickVisibleDialog()
     {
+        if (m_dialog) {
+            click(m_dialog);
+            return;
+        }
         for (QWidget* widget : QApplication::topLevelWidgets()) {
-            if (widget->inherits("QMessageBox")) {
+            if (widget->inherits("QMessageBox") && widget->isVisible()) {
                 click(qobject_cast<QMessageBox*>(widget));
                 if (m_clicked) return;
             }
@@ -263,9 +308,10 @@ private:
 
     void click(QMessageBox* dialog)
     {
-        if (m_clicked || m_click_pending || !dialog || dialog->objectName() != m_object_name) return;
+        if (m_clicked || m_click_pending || !matches(dialog)) return;
         QAbstractButton* button = dialog->button(m_button);
         if (!button) return;
+        if (m_text) *m_text = dialog->text();
         if (!m_finished_connected) {
             m_finished_connected = true;
             connect(dialog, &QMessageBox::finished, this, [this] {
@@ -275,18 +321,15 @@ private:
             });
         }
         m_click_pending = true;
-        QPointer<QAbstractButton> button_ptr{button};
-        QTimer::singleShot(50, this, [this, button_ptr] {
-            m_click_pending = false;
-            if (m_clicked || !button_ptr) return;
-            button_ptr->setEnabled(true);
-            button_ptr->click();
-        });
+        button->setEnabled(true);
+        button->click();
     }
 
     const QString m_object_name;
     const QMessageBox::StandardButton m_button;
+    QString* const m_text;
     QTimer m_timer;
+    QPointer<QMessageBox> m_dialog;
     bool m_clicked{false};
     bool m_click_pending{false};
     bool m_finished_connected{false};
@@ -379,12 +422,19 @@ void BumpFee(TransactionView& view, const Txid& txid, bool expectDisabled, std::
 
     action->setEnabled(true);
     QString text;
+    QSignalSpy bumped{&view, &TransactionView::bumpedFee};
+    QVERIFY(bumped.isValid());
     if (expectError.empty()) {
         ConfirmSend(&text, cancel ? QMessageBox::Cancel : QMessageBox::Yes);
     } else {
-        ConfirmMessage(&text, 0ms);
+        new MessageBoxClicker({}, QMessageBox::Ok, &text);
     }
     action->trigger();
+    if (!expectError.empty() || cancel) {
+        QVERIFY2(WaitUntil([&text] { return !text.isEmpty(); }, 60000), "Timed out waiting for fee-bump dialog");
+    } else {
+        QVERIFY2(WaitUntil([&bumped] { return bumped.count() == 1; }, 60000), "Timed out waiting for fee-bump completion");
+    }
     QVERIFY(text.indexOf(QString::fromStdString(expectError)) != -1);
 }
 
@@ -1512,6 +1562,202 @@ void TestSendPQCReportPropagation(interfaces::Node& node)
     QCOMPARE(pqc_usage.key_states.front().signatures_remaining, PQC_MAX_SIGNATURES - 7);
 }
 
+void TestAsyncFeeBumpLifecycle(interfaces::Node& node)
+{
+    TestChain100Setup test{ChainType::REGTEST, {.extra_args = {"-p2mronly=0"}}};
+    node.setContext(&test.m_node);
+
+    std::unique_ptr<const PlatformStyle> platform_style{PlatformStyle::instantiate("other")};
+    OptionsModel options_model{node};
+    bilingual_str error;
+    QVERIFY(options_model.Init(error));
+    ClientModel client_model{node, &options_model};
+
+    const auto make_model = [&](const std::shared_ptr<qt_test::SyntheticWalletState>& state) {
+        return std::make_unique<WalletModel>(
+            qt_test::MakeSyntheticWallet(wallet::PQCUsageReport{}, state),
+            client_model,
+            platform_style.get());
+    };
+    const auto start_bump = [](WalletModel& model) {
+        ConfirmSend(nullptr, QMessageBox::Yes);
+        return model.bumpFee(Txid{});
+    };
+
+    // Internal P2MR signing stays off the GUI thread. Once counters are
+    // durably reserved, an attempted cancellation is ignored and the
+    // replacement proceeds to commit.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->allow_bump_sign = false;
+        }
+        auto model{make_model(state)};
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        QVERIFY(completed.isValid());
+
+        int gui_ticks{0};
+        QTimer gui_latch;
+        QObject::connect(&gui_latch, &QTimer::timeout, [&gui_ticks] { ++gui_ticks; });
+        gui_latch.start(0);
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) {
+                return value.bump_sign_entered && value.bump_counters_reserved;
+            });
+        }, 5000));
+
+        QPointer<QProgressDialog> progress;
+        QVERIFY(WaitUntil([&] {
+            progress = FindBumpFeeProgressDialog();
+            return progress && progress->isVisible() && progress->findChildren<QPushButton*>().empty();
+        }, 5000));
+        QVERIFY(WaitUntil([&gui_ticks] { return gui_ticks >= 3; }, 5000));
+
+        // Exercise the cancel/reservation race from the UI side. Escape can
+        // still produce a cancel event after the button has disappeared.
+        Q_EMIT progress->canceled();
+        QCoreApplication::processEvents();
+        QVERIFY(!SyntheticStateMatches(state, [](const auto& value) { return value.bump_cancel_observed; }));
+
+        ReleaseSyntheticBumpSigning(state);
+        QVERIFY(WaitUntil([&completed] { return completed.count() == 1; }, 5000));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.background_clone_destroyed; });
+        }, 5000));
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return value.bump_commit_entered && value.bump_committed && !value.bump_cancel_observed;
+        }));
+    }
+
+    // Before counter reservation, cancellation reaches the signer and no
+    // commit is attempted.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->allow_bump_reservation = false;
+        }
+        auto model{make_model(state)};
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.bump_sign_entered; });
+        }, 5000));
+
+        QPointer<QProgressDialog> progress;
+        QVERIFY(WaitUntil([&] {
+            progress = FindBumpFeeProgressDialog();
+            return progress && progress->isVisible() && !progress->findChildren<QPushButton*>().empty();
+        }, 5000));
+        const QList<QPushButton*> cancel_buttons{progress->findChildren<QPushButton*>()};
+        QVERIFY(!cancel_buttons.empty());
+        cancel_buttons.front()->click();
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.bump_cancel_observed; });
+        }, 5000));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.background_clone_destroyed; });
+        }, 5000));
+        QCOMPARE(completed.count(), 0);
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return !value.bump_commit_entered && !value.bump_committed;
+        }));
+    }
+
+    // A state change discovered by the worker's final commit revalidation is
+    // surfaced, and a signed-but-stale replacement is not reported as bumped.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->bump_commit_success = false;
+        }
+        auto model{make_model(state)};
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        QString commit_error;
+        new MessageBoxClicker({}, QMessageBox::Ok, &commit_error);
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&commit_error] { return commit_error.contains("Original transaction changed while signing"); }, 5000));
+        QCOMPARE(completed.count(), 0);
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return value.bump_commit_entered && !value.bump_committed;
+        }));
+    }
+
+    // The model owns the activity, so deleting a view and the progress dialog
+    // during an external-signer command does not invalidate the worker.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->external_signer = true;
+            state->bump_use_counters = false;
+            state->allow_bump_sign = false;
+        }
+        auto model{make_model(state)};
+        auto view{std::make_unique<TransactionView>(platform_style.get())};
+        view->setModel(model.get());
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.bump_sign_entered; });
+        }, 5000));
+
+        QPointer<QProgressDialog> progress;
+        QVERIFY(WaitUntil([&] {
+            progress = FindBumpFeeProgressDialog();
+            return progress && progress->isVisible() && progress->findChildren<QPushButton*>().empty();
+        }, 5000));
+        progress->deleteLater();
+        view.reset();
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        QVERIFY(progress.isNull());
+
+        ReleaseSyntheticBumpSigning(state);
+        QVERIFY(WaitUntil([&completed] { return completed.count() == 1; }, 5000));
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) { return value.bump_committed; }));
+    }
+
+    // Wallet-model teardown waits for an irreversible signing operation and
+    // destroys the cloned wallet before returning, preventing queued callbacks
+    // from observing an unloaded wallet.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->allow_bump_sign = false;
+        }
+        auto model{make_model(state)};
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) {
+                return value.bump_sign_entered && value.bump_counters_reserved;
+            });
+        }, 5000));
+
+        std::thread signer_release{[state] {
+            std::this_thread::sleep_for(100ms);
+            ReleaseSyntheticBumpSigning(state);
+        }};
+        QPointer<WalletModel> model_guard{model.get()};
+        model.reset();
+        signer_release.join();
+        QVERIFY(model_guard.isNull());
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return value.background_clone_destroyed && value.bump_committed;
+        }));
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::MetaCall);
+        QCoreApplication::processEvents();
+    }
+}
+
 void TestSendCompletionAfterModelDestruction(interfaces::Node& node)
 {
     TestChain100Setup test{ChainType::REGTEST, {.extra_args = {"-p2mronly=0"}}};
@@ -1653,6 +1899,9 @@ void TestGUI(interfaces::Node& node)
 
 void WalletTests::walletTests()
 {
+    // Modal test clickers need Qt dialogs so their timers remain active while
+    // the Cocoa platform plugin is running a nested dialog event loop.
+    QApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
 #ifdef Q_OS_MACOS
     if (QApplication::platformName() == "minimal") {
         // Disable for mac on "minimal" platform to avoid crashes inside the Qt
@@ -1667,6 +1916,7 @@ void WalletTests::walletTests()
     TestGUI(m_node);
     TestP2MRReceiveAddressTypes(m_node);
     TestSendPQCReportPropagation(m_node);
+    TestAsyncFeeBumpLifecycle(m_node);
     TestSendCompletionAfterModelDestruction(m_node);
     TestUnlockContextModelLifetime(m_node);
     TestSendPQCWarningFormatting();

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -1625,8 +1625,13 @@ void TestAsyncFeeBumpLifecycle(interfaces::Node& node)
             state->allow_bump_prepare = true;
         }
         state->condition.notify_all();
+        TransactionView view{platform_style.get()};
+        view.setModel(model.get());
+        view.setModel(model.get());
+        QSignalSpy view_completed{&view, &TransactionView::bumpedFee};
         QVERIFY(start_bump(*model));
         QVERIFY(WaitUntil([&completed] { return completed.count() == 1; }, 5000));
+        QCOMPARE(view_completed.count(), 1);
     }
 
     // Shutdown requested from the confirmation dialog must not be cleared by
@@ -1760,6 +1765,47 @@ void TestAsyncFeeBumpLifecycle(interfaces::Node& node)
         }, 5000));
         QVERIFY(WaitUntil([&] {
             return SyntheticStateMatches(state, [](const auto& value) { return value.background_clone_destroyed; });
+        }, 5000));
+        QCOMPARE(completed.count(), 0);
+        QVERIFY(SyntheticStateMatches(state, [](const auto& value) {
+            return !value.bump_commit_entered && !value.bump_committed;
+        }));
+    }
+
+    // Cancellation and the external-signer command boundary race through one
+    // atomic state transition. If cancellation wins, the command is not run
+    // and no replacement is committed.
+    {
+        auto state{std::make_shared<qt_test::SyntheticWalletState>()};
+        {
+            std::lock_guard lock{state->mutex};
+            state->bump_enabled = true;
+            state->external_signer = true;
+            state->bump_use_counters = false;
+            state->allow_external_bump_boundary = false;
+        }
+        auto model{make_model(state)};
+        QSignalSpy completed{model.get(), &WalletModel::feeBumped};
+        QVERIFY(start_bump(*model));
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) { return value.external_bump_boundary_entered; });
+        }, 5000));
+
+        QPointer<QProgressDialog> progress;
+        QVERIFY(WaitUntil([&] {
+            progress = FindBumpFeeProgressDialog();
+            return progress && progress->isVisible() && !progress->findChildren<QPushButton*>().empty();
+        }, 5000));
+        progress->findChildren<QPushButton*>().front()->click();
+        {
+            std::lock_guard lock{state->mutex};
+            state->allow_external_bump_boundary = true;
+        }
+        state->condition.notify_all();
+        QVERIFY(WaitUntil([&] {
+            return SyntheticStateMatches(state, [](const auto& value) {
+                return value.bump_cancel_observed && value.background_clone_destroyed;
+            });
         }, 5000));
         QCOMPARE(completed.count(), 0);
         QVERIFY(SyntheticStateMatches(state, [](const auto& value) {

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -209,6 +209,12 @@ void TransactionView::setModel(WalletModel *_model)
         transactionProxyModel->setSortRole(Qt::EditRole);
         transactionView->setModel(transactionProxyModel);
         transactionView->sortByColumn(TransactionTableModel::Date, Qt::DescendingOrder);
+        connect(_model, &WalletModel::feeBumped, this, [this](const Txid& original_txid, const Txid& bumped_txid) {
+            transactionView->selectionModel()->clearSelection();
+            model->getTransactionTableModel()->updateTransaction(
+                QString::fromStdString(original_txid.ToString()), CT_UPDATED, true);
+            Q_EMIT bumpedFee(bumped_txid);
+        });
 
         if (_model->getOptionsModel())
         {
@@ -402,16 +408,9 @@ void TransactionView::bumpFee([[maybe_unused]] bool checked)
     QString hashQStr = selection.at(0).data(TransactionTableModel::TxHashRole).toString();
     Txid hash = Txid::FromHex(hashQStr.toStdString()).value();
 
-    // Bump tx fee over the walletModel
-    Txid newHash;
-    if (model->bumpFee(hash, newHash)) {
-        // Update the table
-        transactionView->selectionModel()->clearSelection();
-        model->getTransactionTableModel()->updateTransaction(hashQStr, CT_UPDATED, true);
-
-        qApp->processEvents();
-        Q_EMIT bumpedFee(newHash);
-    }
+    // Preparation, signing, and commit run asynchronously. The feeBumped
+    // signal updates the table after the replacement has been committed.
+    model->bumpFee(hash);
 }
 
 void TransactionView::copyAddress()

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -198,6 +198,7 @@ TransactionView::~TransactionView()
 
 void TransactionView::setModel(WalletModel *_model)
 {
+    QObject::disconnect(m_fee_bumped_connection);
     this->model = _model;
     if(_model)
     {
@@ -209,9 +210,9 @@ void TransactionView::setModel(WalletModel *_model)
         transactionProxyModel->setSortRole(Qt::EditRole);
         transactionView->setModel(transactionProxyModel);
         transactionView->sortByColumn(TransactionTableModel::Date, Qt::DescendingOrder);
-        connect(_model, &WalletModel::feeBumped, this, [this](const Txid& original_txid, const Txid& bumped_txid) {
+        m_fee_bumped_connection = connect(_model, &WalletModel::feeBumped, this, [this, _model](const Txid& original_txid, const Txid& bumped_txid) {
             transactionView->selectionModel()->clearSelection();
-            model->getTransactionTableModel()->updateTransaction(
+            _model->getTransactionTableModel()->updateTransaction(
                 QString::fromStdString(original_txid.ToString()), CT_UPDATED, true);
             Q_EMIT bumpedFee(bumped_txid);
         });

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -12,6 +12,7 @@
 
 #include <QWidget>
 #include <QKeyEvent>
+#include <QMetaObject>
 
 class PlatformStyle;
 class TransactionDescDialog;
@@ -68,6 +69,7 @@ private:
     WalletModel *model{nullptr};
     TransactionFilterProxy *transactionProxyModel{nullptr};
     QTableView *transactionView{nullptr};
+    QMetaObject::Connection m_fee_bumped_connection;
 
     QComboBox *dateWidget;
     QComboBox *typeWidget;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -95,7 +95,6 @@ WalletModel::~WalletModel()
 
 void WalletModel::prepareForShutdown()
 {
-    ++m_bump_fee_generation;
     m_bump_fee_cancel_requested = true;
     clearBumpFeeProgressDialog();
 }
@@ -656,9 +655,10 @@ void WalletModel::startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces:
     m_bump_fee_progress_dialog->setWindowModality(Qt::ApplicationModal);
     GUIUtil::PolishProgressDialog(m_bump_fee_progress_dialog);
     connect(m_bump_fee_progress_dialog, &QProgressDialog::canceled, this, &WalletModel::cancelBumpFee);
-    QTimer::singleShot(250, this, [this, generation] {
-        if (generation == m_bump_fee_generation && m_bump_fee_progress_dialog) {
-            m_bump_fee_progress_dialog->show();
+    QPointer<QProgressDialog> progress_dialog{m_bump_fee_progress_dialog};
+    QTimer::singleShot(250, this, [this, generation, progress_dialog] {
+        if (generation == m_bump_fee_generation && progress_dialog && progress_dialog == m_bump_fee_progress_dialog) {
+            progress_dialog->show();
         }
     });
 
@@ -668,6 +668,9 @@ void WalletModel::startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces:
     QPointer<WalletModel> model{this};
     std::atomic_bool* cancel_flag{&m_bump_fee_cancel_requested};
     m_bump_fee_thread = QThread::create([model, generation, result, coin_control, cancel_flag] {
+        const SigningProgressCallback progress_callback = [cancel_flag](const SigningProgress&) {
+            return !cancel_flag->load();
+        };
         try {
             result->prepared = result->wallet->createBumpTransaction(
                 result->original_txid,
@@ -675,7 +678,8 @@ void WalletModel::startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces:
                 result->errors,
                 result->old_fee,
                 result->new_fee,
-                result->mtx);
+                result->mtx,
+                progress_callback);
         } catch (const std::exception& e) {
             result->errors.emplace_back(Untranslated(e.what()));
         }
@@ -737,6 +741,11 @@ void WalletModel::bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeRe
     // TODO: Replace QDialog::exec() with safer QDialog::show().
     const auto retval = static_cast<QMessageBox::StandardButton>(confirmationDialog->exec());
 
+    if (generation != m_bump_fee_generation || m_bump_fee_cancel_requested.load()) {
+        resetBumpFeeState();
+        return;
+    }
+
     // cancel sign&broadcast if user doesn't want to bump the fee
     if (retval != QMessageBox::Yes && retval != QMessageBox::Save) {
         resetBumpFeeState();
@@ -768,17 +777,23 @@ void WalletModel::bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeRe
         resetBumpFeeState();
         return;
     }
+    if (generation != m_bump_fee_generation || m_bump_fee_cancel_requested.load()) {
+        resetBumpFeeState();
+        return;
+    }
 
     assert(!m_wallet->privateKeysDisabled() || wallet().hasExternalSigner());
 
-    startBumpFeeSigning(std::move(result));
+    startBumpFeeSigning(generation, std::move(result));
 }
 
-void WalletModel::startBumpFeeSigning(std::shared_ptr<BumpFeeResult> result)
+void WalletModel::startBumpFeeSigning(uint64_t generation, std::shared_ptr<BumpFeeResult> result)
 {
+    if (generation != m_bump_fee_generation || m_bump_fee_cancel_requested.load()) {
+        resetBumpFeeState();
+        return;
+    }
     clearBumpFeeProgressDialog();
-    const uint64_t generation{++m_bump_fee_generation};
-    m_bump_fee_cancel_requested = false;
     m_bump_fee_counters_reserved = false;
 
     m_bump_fee_progress_dialog = new QProgressDialog(nullptr);
@@ -795,9 +810,10 @@ void WalletModel::startBumpFeeSigning(std::shared_ptr<BumpFeeResult> result)
     m_bump_fee_progress_dialog->setWindowModality(Qt::ApplicationModal);
     GUIUtil::PolishProgressDialog(m_bump_fee_progress_dialog);
     connect(m_bump_fee_progress_dialog, &QProgressDialog::canceled, this, &WalletModel::cancelBumpFee);
-    QTimer::singleShot(250, this, [this, generation] {
-        if (generation == m_bump_fee_generation && m_bump_fee_progress_dialog) {
-            m_bump_fee_progress_dialog->show();
+    QPointer<QProgressDialog> progress_dialog{m_bump_fee_progress_dialog};
+    QTimer::singleShot(250, this, [this, generation, progress_dialog] {
+        if (generation == m_bump_fee_generation && progress_dialog && progress_dialog == m_bump_fee_progress_dialog) {
+            progress_dialog->show();
         }
     });
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -834,10 +834,12 @@ void WalletModel::startBumpFeeSigning(uint64_t generation, std::shared_ptr<BumpF
         const SigningProgressCallback progress_callback = [post_progress, cancellation_state, enter_irreversible](const SigningProgress& progress) {
             bool cancellable{progress.cancellable};
             if (!progress.cancellable) {
-                if (progress.phase == SigningProgressPhase::SIGNING_INPUTS) {
-                    // This notification is the external signer's pre-command
-                    // boundary. Whichever side wins the atomic transition --
-                    // cancellation or signing -- determines whether it starts.
+                if (progress.phase == SigningProgressPhase::SIGNING_INPUTS ||
+                    (progress.phase == SigningProgressPhase::RESERVING_PQC_COUNTERS && progress.completed == 0)) {
+                    // These notifications are the pre-command and pre-counter-
+                    // reservation boundaries. Whichever side wins the atomic
+                    // transition -- cancellation or signing -- determines
+                    // whether the irreversible operation starts.
                     if (!enter_irreversible()) return false;
                 } else {
                     // Reservation notifications arrive after the counters are

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -95,7 +95,8 @@ WalletModel::~WalletModel()
 
 void WalletModel::prepareForShutdown()
 {
-    m_bump_fee_cancel_requested = true;
+    BumpFeeCancellationState expected{BumpFeeCancellationState::Cancellable};
+    m_bump_fee_cancellation_state.compare_exchange_strong(expected, BumpFeeCancellationState::Canceled);
     clearBumpFeeProgressDialog();
 }
 
@@ -638,8 +639,7 @@ void WalletModel::startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces:
 
     clearBumpFeeProgressDialog();
     const uint64_t generation{++m_bump_fee_generation};
-    m_bump_fee_cancel_requested = false;
-    m_bump_fee_counters_reserved = false;
+    m_bump_fee_cancellation_state = BumpFeeCancellationState::Cancellable;
 
     m_bump_fee_progress_dialog = new QProgressDialog(nullptr);
     m_bump_fee_progress_dialog->setObjectName(QStringLiteral("bumpFeeProgressDialog"));
@@ -666,10 +666,10 @@ void WalletModel::startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces:
     result->wallet = std::move(wallet);
     result->original_txid = txid;
     QPointer<WalletModel> model{this};
-    std::atomic_bool* cancel_flag{&m_bump_fee_cancel_requested};
-    m_bump_fee_thread = QThread::create([model, generation, result, coin_control, cancel_flag] {
-        const SigningProgressCallback progress_callback = [cancel_flag](const SigningProgress&) {
-            return !cancel_flag->load();
+    std::atomic<BumpFeeCancellationState>* cancellation_state{&m_bump_fee_cancellation_state};
+    m_bump_fee_thread = QThread::create([model, generation, result, coin_control, cancellation_state] {
+        const SigningProgressCallback progress_callback = [cancellation_state](const SigningProgress&) {
+            return cancellation_state->load() != BumpFeeCancellationState::Canceled;
         };
         try {
             result->prepared = result->wallet->createBumpTransaction(
@@ -683,7 +683,7 @@ void WalletModel::startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces:
         } catch (const std::exception& e) {
             result->errors.emplace_back(Untranslated(e.what()));
         }
-        result->canceled = cancel_flag->load();
+        result->canceled = cancellation_state->load() == BumpFeeCancellationState::Canceled;
         if (!model) return;
         QMetaObject::invokeMethod(model, [model, generation, result] {
             if (model) model->bumpFeePrepared(generation, result);
@@ -698,7 +698,7 @@ void WalletModel::bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeRe
     finishBumpFeeThread();
     clearBumpFeeProgressDialog();
 
-    if (result->canceled || m_bump_fee_cancel_requested.load()) {
+    if (result->canceled || m_bump_fee_cancellation_state.load() == BumpFeeCancellationState::Canceled) {
         resetBumpFeeState();
         return;
     }
@@ -741,7 +741,7 @@ void WalletModel::bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeRe
     // TODO: Replace QDialog::exec() with safer QDialog::show().
     const auto retval = static_cast<QMessageBox::StandardButton>(confirmationDialog->exec());
 
-    if (generation != m_bump_fee_generation || m_bump_fee_cancel_requested.load()) {
+    if (generation != m_bump_fee_generation || m_bump_fee_cancellation_state.load() == BumpFeeCancellationState::Canceled) {
         resetBumpFeeState();
         return;
     }
@@ -777,7 +777,7 @@ void WalletModel::bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeRe
         resetBumpFeeState();
         return;
     }
-    if (generation != m_bump_fee_generation || m_bump_fee_cancel_requested.load()) {
+    if (generation != m_bump_fee_generation || m_bump_fee_cancellation_state.load() == BumpFeeCancellationState::Canceled) {
         resetBumpFeeState();
         return;
     }
@@ -789,12 +789,11 @@ void WalletModel::bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeRe
 
 void WalletModel::startBumpFeeSigning(uint64_t generation, std::shared_ptr<BumpFeeResult> result)
 {
-    if (generation != m_bump_fee_generation || m_bump_fee_cancel_requested.load()) {
+    if (generation != m_bump_fee_generation || m_bump_fee_cancellation_state.load() == BumpFeeCancellationState::Canceled) {
         resetBumpFeeState();
         return;
     }
     clearBumpFeeProgressDialog();
-    m_bump_fee_counters_reserved = false;
 
     m_bump_fee_progress_dialog = new QProgressDialog(nullptr);
     m_bump_fee_progress_dialog->setObjectName(QStringLiteral("bumpFeeProgressDialog"));
@@ -818,19 +817,35 @@ void WalletModel::startBumpFeeSigning(uint64_t generation, std::shared_ptr<BumpF
     });
 
     QPointer<WalletModel> model{this};
-    std::atomic_bool* cancel_flag{&m_bump_fee_cancel_requested};
-    std::atomic_bool* counters_reserved_flag{&m_bump_fee_counters_reserved};
-    m_bump_fee_thread = QThread::create([model, generation, result, cancel_flag, counters_reserved_flag] {
-        const auto post_progress = [model, generation, cancel_flag](BumpFeeProgress progress, bool cancellable) {
-            if (!model || (cancellable && cancel_flag->load())) return false;
+    std::atomic<BumpFeeCancellationState>* cancellation_state{&m_bump_fee_cancellation_state};
+    m_bump_fee_thread = QThread::create([model, generation, result, cancellation_state] {
+        const auto enter_irreversible = [cancellation_state] {
+            BumpFeeCancellationState expected{BumpFeeCancellationState::Cancellable};
+            if (cancellation_state->compare_exchange_strong(expected, BumpFeeCancellationState::Irreversible)) return true;
+            return expected == BumpFeeCancellationState::Irreversible;
+        };
+        const auto post_progress = [model, generation, cancellation_state](BumpFeeProgress progress, bool cancellable) {
+            if (!model || (cancellable && cancellation_state->load() == BumpFeeCancellationState::Canceled)) return false;
             QMetaObject::invokeMethod(model, [model, generation, progress] {
                 if (model) model->bumpFeeProgress(generation, progress);
             }, Qt::QueuedConnection);
-            return !cancellable || !cancel_flag->load();
+            return !cancellable || cancellation_state->load() != BumpFeeCancellationState::Canceled;
         };
-        const SigningProgressCallback progress_callback = [post_progress, counters_reserved_flag](const SigningProgress& progress) {
-            if (!progress.cancellable) counters_reserved_flag->store(true);
-            bool cancellable{progress.cancellable && !counters_reserved_flag->load()};
+        const SigningProgressCallback progress_callback = [post_progress, cancellation_state, enter_irreversible](const SigningProgress& progress) {
+            bool cancellable{progress.cancellable};
+            if (!progress.cancellable) {
+                if (progress.phase == SigningProgressPhase::SIGNING_INPUTS) {
+                    // This notification is the external signer's pre-command
+                    // boundary. Whichever side wins the atomic transition --
+                    // cancellation or signing -- determines whether it starts.
+                    if (!enter_irreversible()) return false;
+                } else {
+                    // Reservation notifications arrive after the counters are
+                    // durably committed, so cancellation can no longer win.
+                    cancellation_state->store(BumpFeeCancellationState::Irreversible);
+                }
+                cancellable = false;
+            }
             BumpFeeProgress mapped;
             mapped.completed = progress.completed;
             mapped.total = progress.total;
@@ -841,7 +856,7 @@ void WalletModel::startBumpFeeSigning(uint64_t generation, std::shared_ptr<BumpF
             case SigningProgressPhase::RESERVING_PQC_COUNTERS:
                 mapped.phase = BumpFeeProgressPhase::Reserving;
                 if (progress.total > 0 && progress.completed >= progress.total) {
-                    counters_reserved_flag->store(true);
+                    cancellation_state->store(BumpFeeCancellationState::Irreversible);
                     cancellable = false;
                 }
                 break;
@@ -857,12 +872,14 @@ void WalletModel::startBumpFeeSigning(uint64_t generation, std::shared_ptr<BumpF
 
         try {
             result->signed_ok = result->wallet->signBumpTransaction(result->mtx, &result->pqc_usage, progress_callback);
-            if (cancel_flag->load() && !counters_reserved_flag->load()) {
+            if (cancellation_state->load() == BumpFeeCancellationState::Canceled) {
                 result->canceled = true;
-            } else if (result->signed_ok) {
+            } else if (result->signed_ok && enter_irreversible()) {
                 post_progress(BumpFeeProgress{.phase = BumpFeeProgressPhase::Committing}, /*cancellable=*/false);
                 result->committed = result->wallet->commitBumpTransaction(
                     result->original_txid, std::move(result->mtx), result->errors, result->bumped_txid);
+            } else if (cancellation_state->load() == BumpFeeCancellationState::Canceled) {
+                result->canceled = true;
             }
         } catch (const std::exception& e) {
             result->errors.emplace_back(Untranslated(e.what()));
@@ -883,7 +900,7 @@ void WalletModel::bumpFeeProgress(uint64_t generation, BumpFeeProgress progress)
     QPointer<QProgressDialog> dialog{m_bump_fee_progress_dialog};
     QPointer<QProgressBar> bar{m_bump_fee_progress_bar};
     if (!dialog || !bar) return;
-    if (m_bump_fee_counters_reserved.load()) {
+    if (m_bump_fee_cancellation_state.load() == BumpFeeCancellationState::Irreversible) {
         dialog->setCancelButton(nullptr);
         if (!dialog || !bar) return;
     }
@@ -957,15 +974,15 @@ void WalletModel::bumpFeeFinished(uint64_t generation, std::shared_ptr<BumpFeeRe
 
 void WalletModel::cancelBumpFee()
 {
-    if (m_bump_fee_counters_reserved.load()) {
-        m_bump_fee_cancel_requested = false;
+    BumpFeeCancellationState expected{BumpFeeCancellationState::Cancellable};
+    if (!m_bump_fee_cancellation_state.compare_exchange_strong(expected, BumpFeeCancellationState::Canceled)) {
+        if (expected != BumpFeeCancellationState::Irreversible) return;
         if (m_bump_fee_progress_dialog) {
             m_bump_fee_progress_dialog->setCancelButton(nullptr);
             m_bump_fee_progress_dialog->setLabelText(tr("Finalizing transaction..."));
         }
         return;
     }
-    m_bump_fee_cancel_requested = true;
     if (m_bump_fee_progress_dialog) {
         m_bump_fee_progress_dialog->setCancelButton(nullptr);
         m_bump_fee_progress_dialog->setLabelText(tr("Canceling fee bump..."));
@@ -997,8 +1014,7 @@ void WalletModel::resetBumpFeeState()
 {
     ++m_bump_fee_generation;
     m_bump_fee_active = false;
-    m_bump_fee_cancel_requested = false;
-    m_bump_fee_counters_reserved = false;
+    m_bump_fee_cancellation_state = BumpFeeCancellationState::Cancellable;
     clearBumpFeeProgressDialog();
     m_bump_fee_unlock_context.reset();
 }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -26,21 +26,49 @@
 #include <util/time.h>
 #include <util/translation.h>
 #include <wallet/coincontrol.h>
+#include <wallet/pqc_usage.h>
 #include <wallet/wallet.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <vector>
 
 #include <QDebug>
+#include <QMetaObject>
 #include <QMessageBox>
+#include <QProgressBar>
+#include <QProgressDialog>
 #include <QSet>
+#include <QThread>
 #include <QTimer>
 
 using wallet::CCoinControl;
 using wallet::CRecipient;
 using wallet::DEFAULT_DISABLE_WALLET;
+
+struct WalletModel::BumpFeeResult {
+    std::unique_ptr<interfaces::Wallet> wallet;
+    Txid original_txid;
+    Txid bumped_txid;
+    std::vector<bilingual_str> errors;
+    CAmount old_fee{0};
+    CAmount new_fee{0};
+    CMutableTransaction mtx;
+    wallet::PQCUsageReport pqc_usage;
+    bool prepared{false};
+    bool signed_ok{false};
+    bool committed{false};
+    bool canceled{false};
+};
+
+struct WalletModel::BumpFeeProgress {
+    BumpFeeProgressPhase phase{BumpFeeProgressPhase::Preparing};
+    unsigned int completed{0};
+    unsigned int total{0};
+};
 
 WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel& client_model, const PlatformStyle *platformStyle, QObject *parent) :
     QObject(parent),
@@ -59,6 +87,10 @@ WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel
 
 WalletModel::~WalletModel()
 {
+    m_bump_fee_cancel_requested = true;
+    clearBumpFeeProgressDialog();
+    finishBumpFeeThread();
+    m_bump_fee_unlock_context.reset();
     unsubscribeFromCoreSignals();
 }
 
@@ -576,18 +608,95 @@ WalletModel::UnlockContext::~UnlockContext()
     }
 }
 
-bool WalletModel::bumpFee(Txid hash, Txid& new_hash)
+bool WalletModel::bumpFee(Txid hash)
+{
+    if (m_bump_fee_active) {
+        Q_EMIT message(tr("Fee bump in progress"), tr("Wait for the current fee bump to finish."), CClientUIInterface::MSG_WARNING);
+        return false;
+    }
+
+    std::unique_ptr<interfaces::Wallet> wallet{m_wallet->clone()};
+    if (!wallet) {
+        QMessageBox::critical(nullptr, tr("Fee bump error"), tr("Wallet is no longer loaded."));
+        return false;
+    }
+
+    m_bump_fee_active = true;
+    startBumpFeePreparation(hash, std::move(wallet));
+    return true;
+}
+
+void WalletModel::startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces::Wallet> wallet)
 {
     CCoinControl coin_control;
     coin_control.m_signal_bip125_rbf = true;
-    std::vector<bilingual_str> errors;
-    CAmount old_fee;
-    CAmount new_fee;
-    CMutableTransaction mtx;
-    if (!m_wallet->createBumpTransaction(hash, coin_control, errors, old_fee, new_fee, mtx)) {
-        QMessageBox::critical(nullptr, tr("Fee bump error"), tr("Increasing transaction fee failed") + "<br />(" +
-            (errors.size() ? QString::fromStdString(errors[0].translated) : "") +")");
-        return false;
+
+    clearBumpFeeProgressDialog();
+    const uint64_t generation{++m_bump_fee_generation};
+    m_bump_fee_cancel_requested = false;
+    m_bump_fee_counters_reserved = false;
+
+    m_bump_fee_progress_dialog = new QProgressDialog(nullptr);
+    m_bump_fee_progress_dialog->setObjectName(QStringLiteral("bumpFeeProgressDialog"));
+    m_bump_fee_progress_dialog->setWindowTitle(tr("Increasing Transaction Fee"));
+    m_bump_fee_progress_dialog->setLabelText(tr("Preparing fee-bump transaction..."));
+    m_bump_fee_progress_dialog->setCancelButtonText(tr("Cancel"));
+    m_bump_fee_progress_bar = new QProgressBar(m_bump_fee_progress_dialog);
+    m_bump_fee_progress_bar->setRange(0, 0);
+    m_bump_fee_progress_dialog->setBar(m_bump_fee_progress_bar);
+    m_bump_fee_progress_dialog->setMinimumDuration(250);
+    m_bump_fee_progress_dialog->setAutoClose(false);
+    m_bump_fee_progress_dialog->setAutoReset(false);
+    m_bump_fee_progress_dialog->setWindowModality(Qt::ApplicationModal);
+    GUIUtil::PolishProgressDialog(m_bump_fee_progress_dialog);
+    connect(m_bump_fee_progress_dialog, &QProgressDialog::canceled, this, &WalletModel::cancelBumpFee);
+    QTimer::singleShot(250, m_bump_fee_progress_dialog, [this, generation] {
+        if (generation == m_bump_fee_generation && m_bump_fee_progress_dialog) {
+            m_bump_fee_progress_dialog->show();
+        }
+    });
+
+    auto result{std::make_shared<BumpFeeResult>()};
+    result->wallet = std::move(wallet);
+    result->original_txid = txid;
+    QPointer<WalletModel> model{this};
+    std::atomic_bool* cancel_flag{&m_bump_fee_cancel_requested};
+    m_bump_fee_thread = QThread::create([model, generation, result, coin_control, cancel_flag] {
+        try {
+            result->prepared = result->wallet->createBumpTransaction(
+                result->original_txid,
+                coin_control,
+                result->errors,
+                result->old_fee,
+                result->new_fee,
+                result->mtx);
+        } catch (const std::exception& e) {
+            result->errors.emplace_back(Untranslated(e.what()));
+        }
+        result->canceled = cancel_flag->load();
+        if (!model) return;
+        QMetaObject::invokeMethod(model, [model, generation, result] {
+            if (model) model->bumpFeePrepared(generation, result);
+        }, Qt::QueuedConnection);
+    });
+    m_bump_fee_thread->start();
+}
+
+void WalletModel::bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeResult> result)
+{
+    if (generation != m_bump_fee_generation) return;
+    finishBumpFeeThread();
+    clearBumpFeeProgressDialog();
+
+    if (result->canceled || m_bump_fee_cancel_requested.load()) {
+        resetBumpFeeState();
+        return;
+    }
+    if (!result->prepared) {
+        const QString error{result->errors.empty() ? QString{} : QString::fromStdString(result->errors.front().translated)};
+        QMessageBox::critical(nullptr, tr("Fee bump error"), tr("Increasing transaction fee failed") + "<br />(" + error + ")");
+        resetBumpFeeState();
+        return;
     }
 
     // allow a user based fee verification
@@ -598,15 +707,15 @@ bool WalletModel::bumpFee(Txid hash, Txid& new_hash)
     questionString.append("<tr><td>");
     questionString.append(tr("Current fee:"));
     questionString.append("</td><td>");
-    questionString.append(QbitUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), old_fee));
+    questionString.append(QbitUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), result->old_fee));
     questionString.append("</td></tr><tr><td>");
     questionString.append(tr("Increase:"));
     questionString.append("</td><td>");
-    questionString.append(QbitUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), new_fee - old_fee));
+    questionString.append(QbitUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), result->new_fee - result->old_fee));
     questionString.append("</td></tr><tr><td>");
     questionString.append(tr("New fee:"));
     questionString.append("</td><td>");
-    questionString.append(QbitUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), new_fee));
+    questionString.append(QbitUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), result->new_fee));
     questionString.append("</td></tr></table>");
 
     // Display warning in the "Confirm fee bump" window if the "Coin Control Features" option is enabled
@@ -624,46 +733,246 @@ bool WalletModel::bumpFee(Txid hash, Txid& new_hash)
 
     // cancel sign&broadcast if user doesn't want to bump the fee
     if (retval != QMessageBox::Yes && retval != QMessageBox::Save) {
-        return false;
+        resetBumpFeeState();
+        return;
     }
 
     // Short-circuit if we are returning a bumped transaction PSBT to clipboard
     if (retval == QMessageBox::Save) {
         // "Create Unsigned" clicked
-        PartiallySignedTransaction psbtx(mtx);
+        PartiallySignedTransaction psbtx(result->mtx);
         bool complete = false;
-        const auto err{wallet().fillPSBT(std::nullopt, /*sign=*/false, /*bip32derivs=*/true, nullptr, psbtx, complete)};
+        const auto err{result->wallet->fillPSBT(std::nullopt, /*sign=*/false, /*bip32derivs=*/true, nullptr, psbtx, complete)};
         if (err || complete) {
             QMessageBox::critical(nullptr, tr("Fee bump error"), tr("Can't draft transaction."));
-            return false;
+            resetBumpFeeState();
+            return;
         }
         // Serialize the PSBT
         DataStream ssTx{};
         ssTx << psbtx;
         GUIUtil::setClipboard(EncodeBase64(ssTx.str()).c_str());
         Q_EMIT message(tr("PSBT copied"), tr("Fee-bump PSBT copied to clipboard"), CClientUIInterface::MSG_INFORMATION | CClientUIInterface::MODAL);
-        return true;
+        resetBumpFeeState();
+        return;
     }
 
-    WalletModel::UnlockContext ctx(requestUnlock());
-    if (!ctx.isValid()) {
-        return false;
+    m_bump_fee_unlock_context = std::make_unique<WalletModel::UnlockContext>(requestUnlock());
+    if (!m_bump_fee_unlock_context->isValid()) {
+        resetBumpFeeState();
+        return;
     }
 
     assert(!m_wallet->privateKeysDisabled() || wallet().hasExternalSigner());
 
-    // sign bumped transaction
-    if (!m_wallet->signBumpTransaction(mtx)) {
+    startBumpFeeSigning(std::move(result));
+}
+
+void WalletModel::startBumpFeeSigning(std::shared_ptr<BumpFeeResult> result)
+{
+    clearBumpFeeProgressDialog();
+    const uint64_t generation{++m_bump_fee_generation};
+    m_bump_fee_cancel_requested = false;
+    m_bump_fee_counters_reserved = false;
+
+    m_bump_fee_progress_dialog = new QProgressDialog(nullptr);
+    m_bump_fee_progress_dialog->setObjectName(QStringLiteral("bumpFeeProgressDialog"));
+    m_bump_fee_progress_dialog->setWindowTitle(tr("Increasing Transaction Fee"));
+    m_bump_fee_progress_dialog->setLabelText(tr("Preparing transaction for signing..."));
+    m_bump_fee_progress_dialog->setCancelButtonText(tr("Cancel"));
+    m_bump_fee_progress_bar = new QProgressBar(m_bump_fee_progress_dialog);
+    m_bump_fee_progress_bar->setRange(0, 0);
+    m_bump_fee_progress_dialog->setBar(m_bump_fee_progress_bar);
+    m_bump_fee_progress_dialog->setMinimumDuration(250);
+    m_bump_fee_progress_dialog->setAutoClose(false);
+    m_bump_fee_progress_dialog->setAutoReset(false);
+    m_bump_fee_progress_dialog->setWindowModality(Qt::ApplicationModal);
+    GUIUtil::PolishProgressDialog(m_bump_fee_progress_dialog);
+    connect(m_bump_fee_progress_dialog, &QProgressDialog::canceled, this, &WalletModel::cancelBumpFee);
+    QTimer::singleShot(250, m_bump_fee_progress_dialog, [this, generation] {
+        if (generation == m_bump_fee_generation && m_bump_fee_progress_dialog) {
+            m_bump_fee_progress_dialog->show();
+        }
+    });
+
+    QPointer<WalletModel> model{this};
+    std::atomic_bool* cancel_flag{&m_bump_fee_cancel_requested};
+    std::atomic_bool* counters_reserved_flag{&m_bump_fee_counters_reserved};
+    m_bump_fee_thread = QThread::create([model, generation, result, cancel_flag, counters_reserved_flag] {
+        const auto post_progress = [model, generation, cancel_flag](BumpFeeProgress progress, bool cancellable) {
+            if (!model || (cancellable && cancel_flag->load())) return false;
+            QMetaObject::invokeMethod(model, [model, generation, progress] {
+                if (model) model->bumpFeeProgress(generation, progress);
+            }, Qt::QueuedConnection);
+            return !cancellable || !cancel_flag->load();
+        };
+        const SigningProgressCallback progress_callback = [post_progress, counters_reserved_flag](const SigningProgress& progress) {
+            if (!progress.cancellable) counters_reserved_flag->store(true);
+            bool cancellable{progress.cancellable && !counters_reserved_flag->load()};
+            BumpFeeProgress mapped;
+            mapped.completed = progress.completed;
+            mapped.total = progress.total;
+            switch (progress.phase) {
+            case SigningProgressPhase::PREPARING_TRANSACTION:
+                mapped.phase = BumpFeeProgressPhase::Preparing;
+                break;
+            case SigningProgressPhase::RESERVING_PQC_COUNTERS:
+                mapped.phase = BumpFeeProgressPhase::Reserving;
+                if (progress.total > 0 && progress.completed >= progress.total) {
+                    counters_reserved_flag->store(true);
+                    cancellable = false;
+                }
+                break;
+            case SigningProgressPhase::SIGNING_INPUTS:
+                mapped.phase = BumpFeeProgressPhase::Signing;
+                break;
+            case SigningProgressPhase::FINALIZING_TRANSACTION:
+                mapped.phase = BumpFeeProgressPhase::Finalizing;
+                break;
+            }
+            return post_progress(mapped, cancellable);
+        };
+
+        try {
+            result->signed_ok = result->wallet->signBumpTransaction(result->mtx, &result->pqc_usage, progress_callback);
+            if (cancel_flag->load() && !counters_reserved_flag->load()) {
+                result->canceled = true;
+            } else if (result->signed_ok) {
+                post_progress(BumpFeeProgress{.phase = BumpFeeProgressPhase::Committing}, /*cancellable=*/false);
+                result->committed = result->wallet->commitBumpTransaction(
+                    result->original_txid, std::move(result->mtx), result->errors, result->bumped_txid);
+            }
+        } catch (const std::exception& e) {
+            result->errors.emplace_back(Untranslated(e.what()));
+        }
+
+        if (!model) return;
+        QMetaObject::invokeMethod(model, [model, generation, result] {
+            if (model) model->bumpFeeFinished(generation, result);
+        }, Qt::QueuedConnection);
+    });
+    m_bump_fee_thread->start();
+}
+
+void WalletModel::bumpFeeProgress(uint64_t generation, BumpFeeProgress progress)
+{
+    if (generation != m_bump_fee_generation || !m_bump_fee_progress_dialog || !m_bump_fee_progress_bar) return;
+
+    QPointer<QProgressDialog> dialog{m_bump_fee_progress_dialog};
+    QPointer<QProgressBar> bar{m_bump_fee_progress_bar};
+    if (m_bump_fee_counters_reserved.load()) {
+        dialog->setCancelButton(nullptr);
+        if (!dialog || !bar) return;
+    }
+
+    switch (progress.phase) {
+    case BumpFeeProgressPhase::Preparing:
+        dialog->setLabelText(tr("Preparing transaction for signing..."));
+        if (bar) bar->setRange(0, 0);
+        break;
+    case BumpFeeProgressPhase::Reserving:
+        dialog->setLabelText(tr("Reserving signing counters..."));
+        if (bar) bar->setRange(0, 0);
+        break;
+    case BumpFeeProgressPhase::Signing:
+        if (progress.total == 0) {
+            dialog->setLabelText(tr("Signing inputs..."));
+            if (bar) bar->setRange(0, 0);
+        } else {
+            progress.completed = std::min(progress.completed, progress.total);
+            dialog->setLabelText(tr("Signing inputs: %1 of %2 complete...").arg(progress.completed).arg(progress.total));
+            if (bar) {
+                bar->setRange(0, static_cast<int>(progress.total));
+                bar->setValue(static_cast<int>(progress.completed));
+            }
+        }
+        break;
+    case BumpFeeProgressPhase::Finalizing:
+        dialog->setLabelText(tr("Finalizing transaction..."));
+        if (bar) bar->setRange(0, 0);
+        break;
+    case BumpFeeProgressPhase::Committing:
+        dialog->setLabelText(tr("Committing fee-bump transaction..."));
+        if (bar) bar->setRange(0, 0);
+        break;
+    }
+}
+
+void WalletModel::bumpFeeFinished(uint64_t generation, std::shared_ptr<BumpFeeResult> result)
+{
+    if (generation != m_bump_fee_generation) return;
+    finishBumpFeeThread();
+    clearBumpFeeProgressDialog();
+    m_bump_fee_unlock_context.reset();
+
+    if (result->canceled) {
+        resetBumpFeeState();
+        return;
+    }
+    if (!result->signed_ok) {
         QMessageBox::critical(nullptr, tr("Fee bump error"), tr("Can't sign transaction."));
-        return false;
+        resetBumpFeeState();
+        return;
     }
-    // commit the bumped transaction
-    if(!m_wallet->commitBumpTransaction(hash, std::move(mtx), errors, new_hash)) {
-        QMessageBox::critical(nullptr, tr("Fee bump error"), tr("Could not commit transaction") + "<br />(" +
-            QString::fromStdString(errors[0].translated)+")");
-        return false;
+    if (!result->committed) {
+        const QString error{result->errors.empty() ? QString{} : QString::fromStdString(result->errors.front().translated)};
+        QMessageBox::critical(nullptr, tr("Fee bump error"), tr("Could not commit transaction") + "<br />(" + error + ")");
+        resetBumpFeeState();
+        return;
     }
-    return true;
+
+    const Txid original_txid{result->original_txid};
+    const Txid bumped_txid{result->bumped_txid};
+    resetBumpFeeState();
+    Q_EMIT feeBumped(original_txid, bumped_txid);
+}
+
+void WalletModel::cancelBumpFee()
+{
+    if (m_bump_fee_counters_reserved.load()) {
+        m_bump_fee_cancel_requested = false;
+        if (m_bump_fee_progress_dialog) {
+            m_bump_fee_progress_dialog->setCancelButton(nullptr);
+            m_bump_fee_progress_dialog->setLabelText(tr("Finalizing transaction..."));
+        }
+        return;
+    }
+    m_bump_fee_cancel_requested = true;
+    if (m_bump_fee_progress_dialog) {
+        m_bump_fee_progress_dialog->setCancelButton(nullptr);
+        m_bump_fee_progress_dialog->setLabelText(tr("Canceling fee bump..."));
+        if (m_bump_fee_progress_bar) m_bump_fee_progress_bar->setRange(0, 0);
+    }
+}
+
+void WalletModel::clearBumpFeeProgressDialog()
+{
+    if (!m_bump_fee_progress_dialog) return;
+    QProgressDialog* dialog{m_bump_fee_progress_dialog};
+    m_bump_fee_progress_dialog = nullptr;
+    m_bump_fee_progress_bar = nullptr;
+    disconnect(dialog, nullptr, this, nullptr);
+    dialog->close();
+    dialog->deleteLater();
+}
+
+void WalletModel::finishBumpFeeThread()
+{
+    if (!m_bump_fee_thread) return;
+    QThread* thread{m_bump_fee_thread};
+    m_bump_fee_thread = nullptr;
+    thread->wait();
+    delete thread;
+}
+
+void WalletModel::resetBumpFeeState()
+{
+    ++m_bump_fee_generation;
+    m_bump_fee_active = false;
+    m_bump_fee_cancel_requested = false;
+    m_bump_fee_counters_reserved = false;
+    clearBumpFeeProgressDialog();
+    m_bump_fee_unlock_context.reset();
 }
 
 void WalletModel::displayAddress(std::string sAddress) const

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -87,11 +87,17 @@ WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, ClientModel
 
 WalletModel::~WalletModel()
 {
-    m_bump_fee_cancel_requested = true;
-    clearBumpFeeProgressDialog();
+    prepareForShutdown();
     finishBumpFeeThread();
     m_bump_fee_unlock_context.reset();
     unsubscribeFromCoreSignals();
+}
+
+void WalletModel::prepareForShutdown()
+{
+    ++m_bump_fee_generation;
+    m_bump_fee_cancel_requested = true;
+    clearBumpFeeProgressDialog();
 }
 
 void WalletModel::startPollBalance()
@@ -650,7 +656,7 @@ void WalletModel::startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces:
     m_bump_fee_progress_dialog->setWindowModality(Qt::ApplicationModal);
     GUIUtil::PolishProgressDialog(m_bump_fee_progress_dialog);
     connect(m_bump_fee_progress_dialog, &QProgressDialog::canceled, this, &WalletModel::cancelBumpFee);
-    QTimer::singleShot(250, m_bump_fee_progress_dialog, [this, generation] {
+    QTimer::singleShot(250, this, [this, generation] {
         if (generation == m_bump_fee_generation && m_bump_fee_progress_dialog) {
             m_bump_fee_progress_dialog->show();
         }
@@ -789,7 +795,7 @@ void WalletModel::startBumpFeeSigning(std::shared_ptr<BumpFeeResult> result)
     m_bump_fee_progress_dialog->setWindowModality(Qt::ApplicationModal);
     GUIUtil::PolishProgressDialog(m_bump_fee_progress_dialog);
     connect(m_bump_fee_progress_dialog, &QProgressDialog::canceled, this, &WalletModel::cancelBumpFee);
-    QTimer::singleShot(250, m_bump_fee_progress_dialog, [this, generation] {
+    QTimer::singleShot(250, this, [this, generation] {
         if (generation == m_bump_fee_generation && m_bump_fee_progress_dialog) {
             m_bump_fee_progress_dialog->show();
         }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -882,6 +882,7 @@ void WalletModel::bumpFeeProgress(uint64_t generation, BumpFeeProgress progress)
 
     QPointer<QProgressDialog> dialog{m_bump_fee_progress_dialog};
     QPointer<QProgressBar> bar{m_bump_fee_progress_bar};
+    if (!dialog || !bar) return;
     if (m_bump_fee_counters_reserved.load()) {
         dialog->setCancelButton(nullptr);
         if (!dialog || !bar) return;
@@ -890,32 +891,37 @@ void WalletModel::bumpFeeProgress(uint64_t generation, BumpFeeProgress progress)
     switch (progress.phase) {
     case BumpFeeProgressPhase::Preparing:
         dialog->setLabelText(tr("Preparing transaction for signing..."));
-        if (bar) bar->setRange(0, 0);
+        if (!dialog || !bar) return;
+        bar->setRange(0, 0);
         break;
     case BumpFeeProgressPhase::Reserving:
         dialog->setLabelText(tr("Reserving signing counters..."));
-        if (bar) bar->setRange(0, 0);
+        if (!dialog || !bar) return;
+        bar->setRange(0, 0);
         break;
     case BumpFeeProgressPhase::Signing:
         if (progress.total == 0) {
             dialog->setLabelText(tr("Signing inputs..."));
-            if (bar) bar->setRange(0, 0);
+            if (!dialog || !bar) return;
+            bar->setRange(0, 0);
         } else {
             progress.completed = std::min(progress.completed, progress.total);
             dialog->setLabelText(tr("Signing inputs: %1 of %2 complete...").arg(progress.completed).arg(progress.total));
-            if (bar) {
-                bar->setRange(0, static_cast<int>(progress.total));
-                bar->setValue(static_cast<int>(progress.completed));
-            }
+            if (!dialog || !bar) return;
+            bar->setRange(0, static_cast<int>(progress.total));
+            if (!bar) return;
+            bar->setValue(static_cast<int>(progress.completed));
         }
         break;
     case BumpFeeProgressPhase::Finalizing:
         dialog->setLabelText(tr("Finalizing transaction..."));
-        if (bar) bar->setRange(0, 0);
+        if (!dialog || !bar) return;
+        bar->setRange(0, 0);
         break;
     case BumpFeeProgressPhase::Committing:
         dialog->setLabelText(tr("Committing fee-bump transaction..."));
-        if (bar) bar->setRange(0, 0);
+        if (!dialog || !bar) return;
+        bar->setRange(0, 0);
         break;
     }
 }

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -198,7 +198,7 @@ private:
 
     void startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces::Wallet> wallet);
     void bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeResult> result);
-    void startBumpFeeSigning(std::shared_ptr<BumpFeeResult> result);
+    void startBumpFeeSigning(uint64_t generation, std::shared_ptr<BumpFeeResult> result);
     void bumpFeeProgress(uint64_t generation, BumpFeeProgress progress);
     void bumpFeeFinished(uint64_t generation, std::shared_ptr<BumpFeeResult> result);
     void cancelBumpFee();

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -147,6 +147,7 @@ public:
     interfaces::Wallet& wallet() const { return *m_wallet; }
     ClientModel& clientModel() const { return *m_client_model; }
     void setClientModel(ClientModel* client_model);
+    void prepareForShutdown();
 
     QString getWalletName() const;
     QString getDisplayName() const;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -13,6 +13,9 @@
 #include <primitives/transaction_identifier.h>
 #include <support/allocators/secure.h>
 
+#include <atomic>
+#include <cstdint>
+#include <memory>
 #include <vector>
 
 #include <QObject>
@@ -43,6 +46,9 @@ class CCoinControl;
 
 QT_BEGIN_NAMESPACE
 class QTimer;
+class QProgressBar;
+class QProgressDialog;
+class QThread;
 QT_END_NAMESPACE
 
 /** Interface to Bitcoin wallet from Qt view code. */
@@ -132,7 +138,7 @@ public:
 
     UnlockContext requestUnlock();
 
-    bool bumpFee(Txid hash, Txid& new_hash);
+    bool bumpFee(Txid hash);
     void displayAddress(std::string sAddress) const;
 
     static bool isWalletEnabled();
@@ -170,6 +176,34 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_can_get_addrs_changed;
     ClientModel* m_client_model;
     interfaces::Node& m_node;
+
+    struct BumpFeeResult;
+    enum class BumpFeeProgressPhase {
+        Preparing,
+        Reserving,
+        Signing,
+        Finalizing,
+        Committing,
+    };
+    struct BumpFeeProgress;
+    QThread* m_bump_fee_thread{nullptr};
+    QPointer<QProgressDialog> m_bump_fee_progress_dialog;
+    QPointer<QProgressBar> m_bump_fee_progress_bar;
+    std::unique_ptr<UnlockContext> m_bump_fee_unlock_context;
+    uint64_t m_bump_fee_generation{0};
+    bool m_bump_fee_active{false};
+    std::atomic_bool m_bump_fee_cancel_requested{false};
+    std::atomic_bool m_bump_fee_counters_reserved{false};
+
+    void startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces::Wallet> wallet);
+    void bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeResult> result);
+    void startBumpFeeSigning(std::shared_ptr<BumpFeeResult> result);
+    void bumpFeeProgress(uint64_t generation, BumpFeeProgress progress);
+    void bumpFeeFinished(uint64_t generation, std::shared_ptr<BumpFeeResult> result);
+    void cancelBumpFee();
+    void clearBumpFeeProgressDialog();
+    void finishBumpFeeThread();
+    void resetBumpFeeState();
 
     bool fForceCheckBalanceChanged{false};
 
@@ -222,6 +256,9 @@ Q_SIGNALS:
 
     // Notify that there are now keys in the keypool
     void canGetAddressesChanged();
+
+    // A fee-bump replacement was committed by the background worker.
+    void feeBumped(const Txid& original_txid, const Txid& bumped_txid);
 
     void timerTimeout();
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -186,6 +186,11 @@ private:
         Finalizing,
         Committing,
     };
+    enum class BumpFeeCancellationState : uint8_t {
+        Cancellable,
+        Canceled,
+        Irreversible,
+    };
     struct BumpFeeProgress;
     QThread* m_bump_fee_thread{nullptr};
     QPointer<QProgressDialog> m_bump_fee_progress_dialog;
@@ -193,8 +198,7 @@ private:
     std::unique_ptr<UnlockContext> m_bump_fee_unlock_context;
     uint64_t m_bump_fee_generation{0};
     bool m_bump_fee_active{false};
-    std::atomic_bool m_bump_fee_cancel_requested{false};
-    std::atomic_bool m_bump_fee_counters_reserved{false};
+    std::atomic<BumpFeeCancellationState> m_bump_fee_cancellation_state{BumpFeeCancellationState::Cancellable};
 
     void startBumpFeePreparation(Txid txid, std::unique_ptr<interfaces::Wallet> wallet);
     void bumpFeePrepared(uint64_t generation, std::shared_ptr<BumpFeeResult> result);

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -115,6 +115,7 @@ WalletView::~WalletView() = default;
 
 void WalletView::prepareForShutdown()
 {
+    walletModel->prepareForShutdown();
     sendCoinsPage->prepareForShutdown();
 }
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -1011,6 +1011,10 @@ static std::optional<bool> TrySignTransactionPQCParallel(
         input_errors[0] = _("Signing cancelled");
         return false;
     }
+    if (provider.pqc_counter_reservation_guard && !provider.pqc_counter_reservation_guard(reservation_total)) {
+        input_errors[0] = _("Signing cancelled");
+        return false;
+    }
 
     std::map<CPQCPubKey, PQCSignatureCounterRange> ranges;
     if (!provider.pqc_counter_batch_reserver(counts, ranges)) {
@@ -1656,6 +1660,28 @@ bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, 
         return should_continue || !cancellable;
     };
 
+    bool pqc_reservation_canceled{false};
+    bool pqc_reservation_irreversible{false};
+    std::optional<FlatSigningProvider> guarded_provider;
+    if (const auto* flat_provider{dynamic_cast<const FlatSigningProvider*>(keystore)}; flat_provider && progress_callback) {
+        guarded_provider.emplace(*flat_provider);
+        const auto previous_guard{guarded_provider->pqc_counter_reservation_guard};
+        guarded_provider->pqc_counter_reservation_guard = [previous_guard, progress_callback, &pqc_reservation_canceled, &pqc_reservation_irreversible](unsigned int range_count) {
+            if (previous_guard && !previous_guard(range_count)) return false;
+            const bool should_continue{progress_callback({
+                .phase = SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                .completed = 0,
+                .total = range_count,
+                .cancellable = false,
+            })};
+            if (pqc_reservation_irreversible) return true;
+            pqc_reservation_canceled = !should_continue;
+            pqc_reservation_irreversible = should_continue;
+            return should_continue;
+        };
+        keystore = &*guarded_provider;
+    }
+
     if (const auto* flat_provider{dynamic_cast<const FlatSigningProvider*>(keystore)}) {
         if (std::optional<bool> parallel_result = TrySignTransactionPQCParallel(mtx, *flat_provider, coins, nHashType, txdata, input_errors, progress_callback)) {
             return *parallel_result;
@@ -1704,6 +1730,10 @@ bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, 
             ProduceSignature(*keystore, MutableTransactionSignatureCreator(mtx, i, amount, &txdata, nHashType), prevPubKey, sigdata);
             produce_time += SteadyClock::now() - produce_start;
             ++produce_attempts;
+        }
+        if (pqc_reservation_canceled) {
+            input_errors[i] = _("Signing cancelled");
+            return false;
         }
         pqc_counter_committed |= sigdata.p2mr_script_sigs.size() > p2mr_sigs_before;
 

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -199,6 +199,10 @@ bool FlatSigningProvider::SignPQC(const CPQCPubKey& pubkey, const uint256& hash,
     }
 
     if (pqc_counter_reserver) {
+        if (pqc_counter_reservation_guard && !pqc_counter_reservation_guard(/*range_count=*/1)) {
+            log_pqc_sign_timing(/*success=*/false, "reservation_canceled");
+            return false;
+        }
         const auto reserve_start{SteadyClock::now()};
         const bool reserved{pqc_counter_reserver(pubkey, /*count=*/1, reserved_previous_counter, reserved_counter)};
         reserve_time = SteadyClock::now() - reserve_start;
@@ -219,6 +223,10 @@ bool FlatSigningProvider::SignPQC(const CPQCPubKey& pubkey, const uint256& hash,
         // signer fails below; reusing it would be less safe than overcounting.
         observe_counter_advance(reserved_previous_counter, reserved_counter);
     } else if (pqc_counter_writer) {
+        if (pqc_counter_reservation_guard && !pqc_counter_reservation_guard(/*range_count=*/1)) {
+            log_pqc_sign_timing(/*success=*/false, "reservation_canceled");
+            return false;
+        }
         // Reserve exactly one counter value in authoritative storage first.
         const auto reserve_start{SteadyClock::now()};
         const bool reserved{pqc_counter_writer(pubkey, previous_counter, reserved_counter)};
@@ -323,6 +331,9 @@ FlatSigningProvider& FlatSigningProvider::Merge(FlatSigningProvider&& b)
     }
     if (!pqc_counter_batch_reserver && b.pqc_counter_batch_reserver) {
         pqc_counter_batch_reserver = std::move(b.pqc_counter_batch_reserver);
+    }
+    if (!pqc_counter_reservation_guard && b.pqc_counter_reservation_guard) {
+        pqc_counter_reservation_guard = std::move(b.pqc_counter_reservation_guard);
     }
     if (!pqc_counter_observer && b.pqc_counter_observer) {
         pqc_counter_observer = std::move(b.pqc_counter_observer);

--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -32,6 +32,7 @@ struct ShortestVectorFirstComparator
 
 using PQCSignatureCounterObserver = std::function<void(const CPQCPubKey&, uint32_t, uint32_t)>;
 using PQCSignatureCounterReserver = std::function<bool(const CPQCPubKey&, uint32_t, uint32_t&, uint32_t&)>;
+using PQCSignatureCounterReservationGuard = std::function<bool(unsigned int)>;
 using PQCRawSigner = std::function<bool(const CPQCKey&, const uint256&, std::vector<unsigned char>&, uint32_t&)>;
 
 struct PQCSignatureCounterRange {
@@ -290,6 +291,8 @@ struct FlatSigningProvider final : public SigningProvider
     std::function<bool(const CPQCPubKey&, uint32_t, uint32_t)> pqc_counter_writer;
     PQCSignatureCounterReserver pqc_counter_reserver;
     PQCSignatureCounterBatchReserver pqc_counter_batch_reserver;
+    /** Called immediately before durable reservation. Returning false aborts without consuming a counter. */
+    PQCSignatureCounterReservationGuard pqc_counter_reservation_guard;
     PQCSignatureCounterObserver pqc_counter_observer;
     PQCRawSigner pqc_raw_signer;
     std::map<uint32_t, CPQCPubKey> p2mr_pubkeys; /** Map key expression index -> derived P2MR pubkey */

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -174,8 +174,19 @@ bool TransactionCanBeBumped(const CWallet& wallet, const Txid& txid)
 }
 
 Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinControl& coin_control, std::vector<bilingual_str>& errors,
-                                 CAmount& old_fee, CAmount& new_fee, CMutableTransaction& mtx, bool require_mine, const std::vector<CTxOut>& outputs, std::optional<uint32_t> original_change_index)
+                                 CAmount& old_fee, CAmount& new_fee, CMutableTransaction& mtx, bool require_mine, const std::vector<CTxOut>& outputs, std::optional<uint32_t> original_change_index,
+                                 const SigningProgressCallback& progress_callback)
 {
+    const auto continue_preparation = [&] {
+        return !progress_callback || progress_callback({
+            .phase = SigningProgressPhase::PREPARING_TRANSACTION,
+            .completed = 0,
+            .total = 0,
+            .cancellable = true,
+        });
+    };
+    if (!continue_preparation()) return Result::MISC_ERROR;
+
     // For now, cannot specify both new outputs to use and an output index to send change
     if (!outputs.empty() && original_change_index.has_value()) {
         errors.emplace_back(Untranslated("The options 'outputs' and 'original_change_index' are incompatible. You can only either specify a new set of outputs, or designate a change output to be recycled."));
@@ -209,6 +220,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
         coins[txin.prevout]; // Create empty map entry keyed by prevout.
     }
     wallet.chain().findCoins(coins);
+    if (!continue_preparation()) return Result::MISC_ERROR;
     for (const CTxIn& txin : wtx.tx->vin) {
         const Coin& coin = coins.at(txin.prevout);
         if (coin.out.IsNull()) {
@@ -251,6 +263,7 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     if (result != Result::OK) {
         return result;
     }
+    if (!continue_preparation()) return Result::MISC_ERROR;
 
     // Calculate the old output amount.
     CAmount output_value = 0;
@@ -328,11 +341,13 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     // We cannot source new unconfirmed inputs(bip125 rule 2)
     new_coin_control.m_min_depth = 1;
 
+    if (!continue_preparation()) return Result::MISC_ERROR;
     auto res = CreateTransaction(wallet, recipients, /*change_pos=*/std::nullopt, new_coin_control, false);
     if (!res) {
         errors.emplace_back(Untranslated("Unable to create transaction.") + Untranslated(" ") + util::ErrorString(res));
         return Result::WALLET_ERROR;
     }
+    if (!continue_preparation()) return Result::MISC_ERROR;
 
     const auto& txr = *res;
     // Write back new fee if successful

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -420,11 +420,40 @@ bool SignTransaction(CWallet& wallet,
     return signed_ok && SigningOnlyModifiedInputSignatures(unsigned_tx, mtx);
 }
 
+static std::set<Txid> GetReplacementAncestors(const CWallet& wallet, const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    std::set<Txid> replacement_ancestors;
+    const CWalletTx* replacement{&wtx};
+    while (true) {
+        const auto replaces_it{replacement->mapValue.find("replaces_txid")};
+        if (replaces_it == replacement->mapValue.end()) break;
+
+        const auto replaced_txid{Txid::FromHex(replaces_it->second)};
+        if (!replaced_txid || replacement_ancestors.contains(*replaced_txid)) break;
+
+        const auto replaced_it{wallet.mapWallet.find(*replaced_txid)};
+        if (replaced_it == wallet.mapWallet.end()) break;
+
+        const auto replaced_by_it{replaced_it->second.mapValue.find("replaced_by_txid")};
+        if (replaced_by_it == replaced_it->second.mapValue.end() ||
+            replaced_by_it->second != replacement->GetHash().ToString()) {
+            break;
+        }
+
+        replacement_ancestors.insert(*replaced_txid);
+        replacement = &replaced_it->second;
+    }
+    return replacement_ancestors;
+}
+
 static Result RevalidateReplacement(const CWallet& wallet,
     const CWalletTx& old_wtx,
     const CMutableTransaction& mtx,
     std::vector<bilingual_str>& errors) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
 {
+    // Replacement metadata is updated synchronously, unlike mempool conflict
+    // state which may lag behind validation interface notifications.
+    const std::set<Txid> replacement_ancestors{GetReplacementAncestors(wallet, old_wtx)};
     std::set<COutPoint> original_inputs;
     for (const CTxIn& input : old_wtx.tx->vin) {
         original_inputs.insert(input.prevout);
@@ -444,7 +473,8 @@ static Result RevalidateReplacement(const CWallet& wallet,
         replacement_input_value += coin_it->second.tx->vout[input.prevout.n].nValue;
 
         for (const auto& [candidate_txid, candidate_wtx] : wallet.mapWallet) {
-            if (candidate_txid == old_wtx.GetHash() || candidate_wtx.isAbandoned() ||
+            if (candidate_txid == old_wtx.GetHash() ||
+                replacement_ancestors.contains(candidate_txid) || candidate_wtx.isAbandoned() ||
                 candidate_wtx.isBlockConflicted() || candidate_wtx.isMempoolConflicted()) {
                 continue;
             }

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -465,6 +465,21 @@ static std::set<Txid> GetReplacementAncestors(const CWallet& wallet, const CWall
     return replacement_ancestors;
 }
 
+static const CTxOut* GetReplacementInputTxOut(
+    const CWallet& wallet,
+    const std::map<COutPoint, Coin>& external_coins,
+    const COutPoint& outpoint) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    const auto wallet_tx{wallet.mapWallet.find(outpoint.hash)};
+    if (wallet_tx != wallet.mapWallet.end()) {
+        if (outpoint.n >= wallet_tx->second.tx->vout.size()) return nullptr;
+        return &wallet_tx->second.tx->vout[outpoint.n];
+    }
+    const auto external_coin{external_coins.find(outpoint)};
+    if (external_coin == external_coins.end() || external_coin->second.IsSpent()) return nullptr;
+    return &external_coin->second.out;
+}
+
 static Result RevalidateReplacement(const CWallet& wallet,
     const CWalletTx& old_wtx,
     const CMutableTransaction& mtx,
@@ -478,18 +493,27 @@ static Result RevalidateReplacement(const CWallet& wallet,
         original_inputs.insert(input.prevout);
     }
     std::set<COutPoint> replacement_inputs;
+    std::map<COutPoint, Coin> external_coins;
+    for (const CTxIn& input : old_wtx.tx->vin) {
+        if (!wallet.mapWallet.contains(input.prevout.hash)) external_coins[input.prevout];
+    }
+    for (const CTxIn& input : mtx.vin) {
+        if (!wallet.mapWallet.contains(input.prevout.hash)) external_coins[input.prevout];
+    }
+    wallet.chain().findCoins(external_coins);
+
     CAmount replacement_input_value{0};
     for (const CTxIn& input : mtx.vin) {
         if (!replacement_inputs.insert(input.prevout).second) {
             errors.emplace_back(Untranslated("Replacement transaction contains duplicate inputs"));
             return Result::WALLET_ERROR;
         }
-        const auto coin_it{wallet.mapWallet.find(input.prevout.hash)};
-        if (coin_it == wallet.mapWallet.end() || input.prevout.n >= coin_it->second.tx->vout.size()) {
-            errors.emplace_back(Untranslated(strprintf("Replacement input %s:%u is no longer available in the wallet", input.prevout.hash.GetHex(), input.prevout.n)));
+        const CTxOut* txout{GetReplacementInputTxOut(wallet, external_coins, input.prevout)};
+        if (!txout) {
+            errors.emplace_back(Untranslated(strprintf("Replacement input %s:%u is no longer available", input.prevout.hash.GetHex(), input.prevout.n)));
             return Result::WALLET_ERROR;
         }
-        replacement_input_value += coin_it->second.tx->vout[input.prevout.n].nValue;
+        replacement_input_value += txout->nValue;
 
         for (const Txid& candidate_txid : wallet.GetWalletSpenders(input.prevout)) {
             const auto candidate_it{wallet.mapWallet.find(candidate_txid)};
@@ -511,12 +535,12 @@ static Result RevalidateReplacement(const CWallet& wallet,
 
     CAmount original_input_value{0};
     for (const CTxIn& input : old_wtx.tx->vin) {
-        const auto coin_it{wallet.mapWallet.find(input.prevout.hash)};
-        if (coin_it == wallet.mapWallet.end() || input.prevout.n >= coin_it->second.tx->vout.size()) {
-            errors.emplace_back(Untranslated("Original transaction inputs are no longer available in the wallet"));
+        const CTxOut* txout{GetReplacementInputTxOut(wallet, external_coins, input.prevout)};
+        if (!txout) {
+            errors.emplace_back(Untranslated("Original transaction inputs are no longer available"));
             return Result::WALLET_ERROR;
         }
-        original_input_value += coin_it->second.tx->vout[input.prevout.n].nValue;
+        original_input_value += txout->nValue;
     }
     const CAmount old_fee{original_input_value - CalculateOutputValue(*old_wtx.tx)};
     const CAmount new_fee{replacement_input_value - CalculateOutputValue(mtx)};

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <common/args.h>
 #include <common/system.h>
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
@@ -16,6 +17,9 @@
 #include <wallet/receive.h>
 #include <wallet/spend.h>
 #include <wallet/wallet.h>
+
+#include <algorithm>
+#include <set>
 
 namespace wallet {
 //! Check whether transaction has descendant in wallet or mempool, or has been
@@ -143,6 +147,20 @@ static CFeeRate EstimateFeeRate(const CWallet& wallet, const CWalletTx& wtx, con
 }
 
 namespace feebumper {
+
+static bool SigningOnlyModifiedInputSignatures(const CMutableTransaction& before, const CMutableTransaction& after)
+{
+    if (before.version != after.version || before.nLockTime != after.nLockTime ||
+        before.vin.size() != after.vin.size() || before.vout != after.vout) {
+        return false;
+    }
+    for (size_t i = 0; i < before.vin.size(); ++i) {
+        if (before.vin[i].prevout != after.vin[i].prevout || before.vin[i].nSequence != after.vin[i].nSequence) {
+            return false;
+        }
+    }
+    return true;
+}
 
 bool TransactionCanBeBumped(const CWallet& wallet, const Txid& txid)
 {
@@ -326,10 +344,40 @@ Result CreateRateBumpTransaction(CWallet& wallet, const Txid& txid, const CCoinC
     return Result::OK;
 }
 
-bool SignTransaction(CWallet& wallet, CMutableTransaction& mtx) {
-    LOCK(wallet.cs_wallet);
+bool SignTransaction(CWallet& wallet,
+    CMutableTransaction& mtx,
+    const PQCSignatureCounterObserver& pqc_counter_observer,
+    const SigningProgressCallback& progress_callback)
+{
+    const CMutableTransaction unsigned_tx{mtx};
+    bool signed_ok{false};
+    PQCSignatureCounterObserver reservation_observer{pqc_counter_observer};
+    if (progress_callback) {
+        reservation_observer = [pqc_counter_observer, progress_callback](const CPQCPubKey& pubkey, uint32_t previous_counter, uint32_t reserved_counter) {
+            if (pqc_counter_observer) {
+                pqc_counter_observer(pubkey, previous_counter, reserved_counter);
+            }
+            // The observer runs after the wallet has durably committed the
+            // counter range and before serial PQC signature generation.
+            progress_callback({
+                .phase = SigningProgressPhase::RESERVING_PQC_COUNTERS,
+                .completed = 1,
+                .total = 1,
+                .cancellable = false,
+            });
+        };
+    }
 
     if (wallet.IsWalletFlagSet(WALLET_FLAG_EXTERNAL_SIGNER)) {
+        if (progress_callback && !progress_callback({
+                .phase = SigningProgressPhase::PREPARING_TRANSACTION,
+                .completed = 0,
+                .total = static_cast<unsigned int>(mtx.vin.size()),
+                .cancellable = true,
+            })) {
+            return false;
+        }
+
         // Make a blank psbt
         PartiallySignedTransaction psbtx(mtx);
 
@@ -337,13 +385,123 @@ bool SignTransaction(CWallet& wallet, CMutableTransaction& mtx) {
         // so external signers are not asked to sign more than once.
         bool complete;
         wallet.FillPSBT(psbtx, complete, std::nullopt, /*sign=*/false, /*bip32derivs=*/true);
-        auto err{wallet.FillPSBT(psbtx, complete, std::nullopt, /*sign=*/true, /*bip32derivs=*/false)};
+        if (progress_callback && !progress_callback({
+                .phase = SigningProgressPhase::SIGNING_INPUTS,
+                .completed = 0,
+                .total = static_cast<unsigned int>(mtx.vin.size()),
+                .cancellable = true,
+            })) {
+            return false;
+        }
+        // External signer commands cannot be interrupted safely once started.
+        if (progress_callback) {
+            progress_callback({
+                .phase = SigningProgressPhase::SIGNING_INPUTS,
+                .completed = 0,
+                .total = static_cast<unsigned int>(mtx.vin.size()),
+                .cancellable = false,
+            });
+        }
+        auto err{wallet.FillPSBT(psbtx, complete, std::nullopt, /*sign=*/true, /*bip32derivs=*/false, /*n_signed=*/nullptr, /*finalize=*/true, reservation_observer)};
         if (err) return false;
-        complete = FinalizeAndExtractPSBT(psbtx, mtx);
-        return complete;
+        signed_ok = FinalizeAndExtractPSBT(psbtx, mtx);
+        if (progress_callback) {
+            progress_callback({
+                .phase = SigningProgressPhase::FINALIZING_TRANSACTION,
+                .completed = static_cast<unsigned int>(mtx.vin.size()),
+                .total = static_cast<unsigned int>(mtx.vin.size()),
+                .cancellable = false,
+            });
+        }
     } else {
-        return wallet.SignTransaction(mtx);
+        signed_ok = wallet.SignTransaction(mtx, reservation_observer, progress_callback);
     }
+
+    return signed_ok && SigningOnlyModifiedInputSignatures(unsigned_tx, mtx);
+}
+
+static Result RevalidateReplacement(const CWallet& wallet,
+    const CWalletTx& old_wtx,
+    const CMutableTransaction& mtx,
+    std::vector<bilingual_str>& errors) EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    std::set<COutPoint> original_inputs;
+    for (const CTxIn& input : old_wtx.tx->vin) {
+        original_inputs.insert(input.prevout);
+    }
+    std::set<COutPoint> replacement_inputs;
+    CAmount replacement_input_value{0};
+    for (const CTxIn& input : mtx.vin) {
+        if (!replacement_inputs.insert(input.prevout).second) {
+            errors.emplace_back(Untranslated("Replacement transaction contains duplicate inputs"));
+            return Result::WALLET_ERROR;
+        }
+        const auto coin_it{wallet.mapWallet.find(input.prevout.hash)};
+        if (coin_it == wallet.mapWallet.end() || input.prevout.n >= coin_it->second.tx->vout.size()) {
+            errors.emplace_back(Untranslated(strprintf("Replacement input %s:%u is no longer available in the wallet", input.prevout.hash.GetHex(), input.prevout.n)));
+            return Result::WALLET_ERROR;
+        }
+        replacement_input_value += coin_it->second.tx->vout[input.prevout.n].nValue;
+
+        for (const auto& [candidate_txid, candidate_wtx] : wallet.mapWallet) {
+            if (candidate_txid == old_wtx.GetHash() || candidate_wtx.isAbandoned() ||
+                candidate_wtx.isBlockConflicted() || candidate_wtx.isMempoolConflicted()) {
+                continue;
+            }
+            if (std::ranges::any_of(candidate_wtx.tx->vin, [&](const CTxIn& candidate_input) {
+                    return candidate_input.prevout == input.prevout;
+                })) {
+                errors.emplace_back(Untranslated(strprintf("Replacement input %s:%u is already spent by wallet transaction %s", input.prevout.hash.GetHex(), input.prevout.n, candidate_txid.GetHex())));
+                return Result::WALLET_ERROR;
+            }
+        }
+    }
+    if (!std::ranges::all_of(original_inputs, [&](const COutPoint& input) { return replacement_inputs.contains(input); })) {
+        errors.emplace_back(Untranslated("Replacement transaction no longer spends every original input"));
+        return Result::WALLET_ERROR;
+    }
+
+    CAmount original_input_value{0};
+    for (const CTxIn& input : old_wtx.tx->vin) {
+        const auto coin_it{wallet.mapWallet.find(input.prevout.hash)};
+        if (coin_it == wallet.mapWallet.end() || input.prevout.n >= coin_it->second.tx->vout.size()) {
+            errors.emplace_back(Untranslated("Original transaction inputs are no longer available in the wallet"));
+            return Result::WALLET_ERROR;
+        }
+        original_input_value += coin_it->second.tx->vout[input.prevout.n].nValue;
+    }
+    const CAmount old_fee{original_input_value - CalculateOutputValue(*old_wtx.tx)};
+    const CAmount new_fee{replacement_input_value - CalculateOutputValue(mtx)};
+    if (new_fee <= old_fee) {
+        errors.emplace_back(Untranslated("Replacement transaction fee is no longer higher than the original fee"));
+        return Result::WALLET_ERROR;
+    }
+
+    const CTransactionRef replacement{MakeTransactionRef(mtx)};
+    if (GetTransactionWeight(*replacement) > MAX_STANDARD_TX_WEIGHT) {
+        errors.emplace_back(Untranslated("Replacement transaction is too large"));
+        return Result::WALLET_ERROR;
+    }
+    const int32_t vsize{static_cast<int32_t>(GetVirtualTransactionSize(*replacement))};
+    if (new_fee < old_fee + wallet.chain().relayIncrementalFee().GetFee(vsize)) {
+        errors.emplace_back(Untranslated("Replacement transaction no longer pays the current incremental relay fee"));
+        return Result::WALLET_ERROR;
+    }
+    if (CFeeRate{new_fee, vsize}.GetFeePerK() < wallet.chain().mempoolMinFee().GetFeePerK()) {
+        errors.emplace_back(Untranslated("Replacement transaction fee rate is below the current mempool minimum"));
+        return Result::WALLET_ERROR;
+    }
+    if (new_fee < GetRequiredFee(wallet, vsize) || new_fee > wallet.m_default_max_tx_fee) {
+        errors.emplace_back(Untranslated("Replacement transaction fee no longer satisfies wallet fee policy"));
+        return Result::WALLET_ERROR;
+    }
+    if (gArgs.GetBoolArg("-walletrejectlongchains", DEFAULT_WALLET_REJECT_LONG_CHAINS)) {
+        if (const auto chain_result{wallet.chain().checkChainLimits(replacement)}; !chain_result) {
+            errors.emplace_back(Untranslated("Replacement transaction no longer satisfies mempool chain limits") + Untranslated(": ") + util::ErrorString(chain_result));
+            return Result::WALLET_ERROR;
+        }
+    }
+    return Result::OK;
 }
 
 Result CommitTransaction(CWallet& wallet, const Txid& txid, CMutableTransaction&& mtx, std::vector<bilingual_str>& errors, Txid& bumped_txid)
@@ -361,6 +519,11 @@ Result CommitTransaction(CWallet& wallet, const Txid& txid, CMutableTransaction&
 
     // make sure the transaction still has no descendants and hasn't been mined in the meantime
     Result result = PreconditionChecks(wallet, oldWtx, /* require_mine=*/ false, errors);
+    if (result != Result::OK) {
+        return result;
+    }
+
+    result = RevalidateReplacement(wallet, oldWtx, mtx, errors);
     if (result != Result::OK) {
         return result;
     }

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -450,7 +450,11 @@ static std::set<Txid> GetReplacementAncestors(const CWallet& wallet, const CWall
         if (replaced_it == wallet.mapWallet.end()) break;
 
         const auto replaced_by_it{replaced_it->second.mapValue.find("replaced_by_txid")};
-        if (replaced_by_it == replaced_it->second.mapValue.end() ||
+        // CommitTransaction stores the replacement before MarkReplaced writes
+        // the reciprocal link. If that second write fails or the process exits
+        // between them, the backwards link is still sufficient to establish
+        // lineage. A conflicting forward link, however, is not.
+        if (replaced_by_it != replaced_it->second.mapValue.end() &&
             replaced_by_it->second != replacement->GetHash().ToString()) {
             break;
         }

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -409,13 +409,13 @@ bool SignTransaction(CWallet& wallet,
             return false;
         }
         // External signer commands cannot be interrupted safely once started.
-        if (progress_callback) {
-            progress_callback({
+        if (progress_callback && !progress_callback({
                 .phase = SigningProgressPhase::SIGNING_INPUTS,
                 .completed = 0,
                 .total = static_cast<unsigned int>(mtx.vin.size()),
                 .cancellable = false,
-            });
+            })) {
+            return false;
         }
         auto err{wallet.FillPSBT(psbtx, complete, std::nullopt, /*sign=*/true, /*bip32derivs=*/false, /*n_signed=*/nullptr, /*finalize=*/true, reservation_observer)};
         if (err) return false;

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -487,18 +487,17 @@ static Result RevalidateReplacement(const CWallet& wallet,
         }
         replacement_input_value += coin_it->second.tx->vout[input.prevout.n].nValue;
 
-        for (const auto& [candidate_txid, candidate_wtx] : wallet.mapWallet) {
+        for (const Txid& candidate_txid : wallet.GetWalletSpenders(input.prevout)) {
+            const auto candidate_it{wallet.mapWallet.find(candidate_txid)};
+            if (candidate_it == wallet.mapWallet.end()) continue;
+            const CWalletTx& candidate_wtx{candidate_it->second};
             if (candidate_txid == old_wtx.GetHash() ||
                 replacement_ancestors.contains(candidate_txid) || candidate_wtx.isAbandoned() ||
                 candidate_wtx.isBlockConflicted() || candidate_wtx.isMempoolConflicted()) {
                 continue;
             }
-            if (std::ranges::any_of(candidate_wtx.tx->vin, [&](const CTxIn& candidate_input) {
-                    return candidate_input.prevout == input.prevout;
-                })) {
-                errors.emplace_back(Untranslated(strprintf("Replacement input %s:%u is already spent by wallet transaction %s", input.prevout.hash.GetHex(), input.prevout.n, candidate_txid.GetHex())));
-                return Result::WALLET_ERROR;
-            }
+            errors.emplace_back(Untranslated(strprintf("Replacement input %s:%u is already spent by wallet transaction %s", input.prevout.hash.GetHex(), input.prevout.n, candidate_txid.GetHex())));
+            return Result::WALLET_ERROR;
         }
     }
     if (!std::ranges::all_of(original_inputs, [&](const COutPoint& input) { return replacement_inputs.contains(input); })) {

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -47,6 +47,7 @@ bool TransactionCanBeBumped(const CWallet& wallet, const Txid& txid);
  * @param[in] require_mine Whether the original transaction must consist of inputs that can be spent by the wallet
  * @param[in] outputs Vector of new outputs to replace the bumped transaction's outputs
  * @param[in] original_change_index The position of the change output to deduct the fee from in the transaction being bumped
+ * @param[in] progress_callback Reports preparation progress and permits cooperative cancellation
  */
 Result CreateRateBumpTransaction(CWallet& wallet,
     const Txid& txid,
@@ -57,7 +58,8 @@ Result CreateRateBumpTransaction(CWallet& wallet,
     CMutableTransaction& mtx,
     bool require_mine,
     const std::vector<CTxOut>& outputs,
-    std::optional<uint32_t> original_change_index = std::nullopt);
+    std::optional<uint32_t> original_change_index = std::nullopt,
+    const SigningProgressCallback& progress_callback = {});
 
 //! Sign the new transaction,
 //! @return false if the tx couldn't be found or if it was

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -6,8 +6,10 @@
 #define QBIT_WALLET_FEEBUMPER_H
 
 #include <consensus/consensus.h>
-#include <script/interpreter.h>
 #include <primitives/transaction.h>
+#include <script/interpreter.h>
+#include <script/signingprogress.h>
+#include <script/signingprovider.h>
 
 class uint256;
 enum class FeeEstimateMode;
@@ -60,7 +62,10 @@ Result CreateRateBumpTransaction(CWallet& wallet,
 //! Sign the new transaction,
 //! @return false if the tx couldn't be found or if it was
 //! impossible to create the signature(s)
-bool SignTransaction(CWallet& wallet, CMutableTransaction& mtx);
+bool SignTransaction(CWallet& wallet,
+    CMutableTransaction& mtx,
+    const PQCSignatureCounterObserver& pqc_counter_observer = {},
+    const SigningProgressCallback& progress_callback = {});
 
 //! Commit the bumpfee transaction.
 //! @return success in case of CWallet::CommitTransaction was successful,

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -392,10 +392,11 @@ public:
         std::vector<bilingual_str>& errors,
         CAmount& old_fee,
         CAmount& new_fee,
-        CMutableTransaction& mtx) override
+        CMutableTransaction& mtx,
+        const SigningProgressCallback& progress_callback) override
     {
         std::vector<CTxOut> outputs; // just an empty list of new recipients for now
-        return feebumper::CreateRateBumpTransaction(*m_wallet.get(), txid, coin_control, errors, old_fee, new_fee, mtx, /* require_mine= */ true, outputs) == feebumper::Result::OK;
+        return feebumper::CreateRateBumpTransaction(*m_wallet.get(), txid, coin_control, errors, old_fee, new_fee, mtx, /* require_mine= */ true, outputs, /*original_change_index=*/std::nullopt, progress_callback) == feebumper::Result::OK;
     }
     bool signBumpTransaction(CMutableTransaction& mtx,
         wallet::PQCUsageReport* pqc_usage,

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -397,10 +397,17 @@ public:
         std::vector<CTxOut> outputs; // just an empty list of new recipients for now
         return feebumper::CreateRateBumpTransaction(*m_wallet.get(), txid, coin_control, errors, old_fee, new_fee, mtx, /* require_mine= */ true, outputs) == feebumper::Result::OK;
     }
-    bool signBumpTransaction(CMutableTransaction& mtx) override
+    bool signBumpTransaction(CMutableTransaction& mtx,
+        wallet::PQCUsageReport* pqc_usage,
+        const SigningProgressCallback& progress_callback) override
     {
         if (GetPQCKeyValidationSigningError(*m_wallet)) return false;
-        return feebumper::SignTransaction(*m_wallet.get(), mtx);
+        PQCUsageRecorder pqc_usage_recorder;
+        const bool success{feebumper::SignTransaction(*m_wallet.get(), mtx, pqc_usage_recorder.GetObserver(), progress_callback)};
+        if (pqc_usage) {
+            *pqc_usage = BuildSigningPQCUsageReport(pqc_usage_recorder);
+        }
+        return success;
     }
     bool commitBumpTransaction(const Txid& txid,
         CMutableTransaction&& mtx,

--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -120,7 +120,8 @@ BOOST_AUTO_TEST_CASE(commit_revalidates_fee_after_signing)
     CMutableTransaction stale_replacement{original};
     std::vector<bilingual_str> errors;
     Txid bumped_txid;
-    BOOST_CHECK(CommitTransaction(m_wallet, original.GetHash(), std::move(stale_replacement), errors, bumped_txid) == Result::WALLET_ERROR);
+    const Result commit_result{CommitTransaction(m_wallet, original.GetHash(), std::move(stale_replacement), errors, bumped_txid)};
+    BOOST_CHECK(commit_result == Result::WALLET_ERROR);
     BOOST_REQUIRE_EQUAL(errors.size(), 1U);
     BOOST_CHECK_EQUAL(errors.front().original, "Replacement transaction fee is no longer higher than the original fee");
     BOOST_CHECK(bumped_txid.IsNull());
@@ -147,7 +148,8 @@ BOOST_AUTO_TEST_CASE(commit_revalidates_competing_wallet_spend)
 
     std::vector<bilingual_str> errors;
     Txid bumped_txid;
-    BOOST_CHECK(CommitTransaction(m_wallet, original.GetHash(), std::move(replacement), errors, bumped_txid) == Result::WALLET_ERROR);
+    const Result commit_result{CommitTransaction(m_wallet, original.GetHash(), std::move(replacement), errors, bumped_txid)};
+    BOOST_CHECK(commit_result == Result::WALLET_ERROR);
     BOOST_REQUIRE_EQUAL(errors.size(), 1U);
     BOOST_CHECK(errors.front().original.find("is already spent by wallet transaction") != std::string::npos);
     BOOST_CHECK(bumped_txid.IsNull());

--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -9,9 +9,14 @@
 #include <util/strencodings.h>
 #include <wallet/feebumper.h>
 #include <wallet/test/util.h>
+#include <wallet/test/wallet_p2mr_test_util.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <future>
 
 namespace wallet {
 namespace feebumper {
@@ -49,6 +54,103 @@ BOOST_AUTO_TEST_CASE(external_max_weight_test)
     CheckMaxWeightComputation("", {"3042021f0f8906f0394979d5b737134773e5b88bf036c7d63542301d600ab677ba5a59021f0e9fe07e62c113045fa1c1532e2914720e8854d189c4f5b8c88f57956b704401", "0359edba11ed1a0568094a6296a16c4d5ee4c8cfe2f5e2e6826871b5ecf8188f79"}, "00149961a78658030cc824af4c54fbf5294bec0cabdd", 149);
     // P2WSH HTLC
     CheckMaxWeightComputation("", {"3042021f5c4c29e6b686aae5b6d0751e90208592ea96d26bc81d78b0d3871a94a21fa8021f74dc2f971e438ccece8699c8fd15704c41df219ab37b63264f2147d15c34d801", "01", "6321024cf55e52ec8af7866617dc4e7ff8433758e98799906d80e066c6f32033f685f967029000b275210214827893e2dcbe4ad6c20bd743288edad21100404eb7f52ccd6062fd0e7808f268ac"}, "002089e84892873c679b1129edea246e484fd914c2601f776d4f2f4a001eb8059703", 195);
+}
+
+BOOST_AUTO_TEST_CASE(p2mr_signing_releases_wallet_lock)
+{
+    using namespace std::chrono_literals;
+    using namespace wallet_p2mr_test;
+    struct AbortBeforeCryptographicSigning {};
+
+    m_node.args->ForceSetArg("-walletpqcparallel", "1");
+    m_node.args->ForceSetArg("-walletpqcsignthreads", "1");
+    auto workload{MakeDistinctKeyP2MRSigningWorkload(*m_node.chain, /*input_count=*/1)};
+
+    CMutableTransaction funding_tx;
+    funding_tx.vout.resize(workload.coins.size());
+    Txid funding_txid;
+    for (const auto& [outpoint, coin] : workload.coins) {
+        funding_txid = outpoint.hash;
+        funding_tx.vout.at(outpoint.n) = coin.out;
+    }
+    BOOST_REQUIRE(funding_tx.GetHash() == funding_txid);
+    BOOST_REQUIRE(workload.wallet->AddToWallet(MakeTransactionRef(funding_tx), TxStateInactive{}));
+
+    std::promise<void> signing_paused;
+    std::future<void> paused_future{signing_paused.get_future()};
+    std::promise<void> resume_signing;
+    std::shared_future<void> resume_future{resume_signing.get_future()};
+    std::atomic_bool pause_reported{false};
+    auto sign_future{std::async(std::launch::async, [&] {
+        return feebumper::SignTransaction(*workload.wallet, workload.spend_tx, {}, [&](const SigningProgress& progress) {
+            if (progress.phase == SigningProgressPhase::RESERVING_PQC_COUNTERS && !progress.cancellable &&
+                !pause_reported.exchange(true)) {
+                signing_paused.set_value();
+                resume_future.wait();
+                throw AbortBeforeCryptographicSigning{};
+            }
+            return true;
+        });
+    })};
+
+    if (paused_future.wait_for(5s) != std::future_status::ready) {
+        resume_signing.set_value();
+        BOOST_FAIL("Timed out waiting for fee-bump signing pause");
+    }
+    {
+        TRY_LOCK(workload.wallet->cs_wallet, wallet_lock);
+        BOOST_CHECK(static_cast<bool>(wallet_lock));
+    }
+
+    resume_signing.set_value();
+    BOOST_CHECK_THROW(sign_future.get(), AbortBeforeCryptographicSigning);
+}
+
+BOOST_AUTO_TEST_CASE(commit_revalidates_fee_after_signing)
+{
+    CMutableTransaction funding;
+    funding.vout.emplace_back(10'000, CScript{} << OP_TRUE);
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(funding), TxStateInactive{}));
+
+    CMutableTransaction original;
+    original.vin.emplace_back(COutPoint{funding.GetHash(), 0});
+    original.vout.emplace_back(9'000, CScript{} << OP_TRUE);
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(original), TxStateInactive{}));
+
+    CMutableTransaction stale_replacement{original};
+    std::vector<bilingual_str> errors;
+    Txid bumped_txid;
+    BOOST_CHECK(CommitTransaction(m_wallet, original.GetHash(), std::move(stale_replacement), errors, bumped_txid) == Result::WALLET_ERROR);
+    BOOST_REQUIRE_EQUAL(errors.size(), 1U);
+    BOOST_CHECK_EQUAL(errors.front().original, "Replacement transaction fee is no longer higher than the original fee");
+    BOOST_CHECK(bumped_txid.IsNull());
+}
+
+BOOST_AUTO_TEST_CASE(commit_revalidates_competing_wallet_spend)
+{
+    CMutableTransaction funding;
+    funding.vout.emplace_back(10'000, CScript{} << OP_TRUE);
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(funding), TxStateInactive{}));
+
+    CMutableTransaction original;
+    original.vin.emplace_back(COutPoint{funding.GetHash(), 0});
+    original.vout.emplace_back(9'000, CScript{} << OP_TRUE);
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(original), TxStateInactive{}));
+
+    CMutableTransaction replacement{original};
+    replacement.vout.front().nValue = 8'900;
+
+    CMutableTransaction competing{original};
+    competing.nLockTime = 1;
+    competing.vout.front().nValue = 8'800;
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(competing), TxStateInactive{}));
+
+    std::vector<bilingual_str> errors;
+    Txid bumped_txid;
+    BOOST_CHECK(CommitTransaction(m_wallet, original.GetHash(), std::move(replacement), errors, bumped_txid) == Result::WALLET_ERROR);
+    BOOST_REQUIRE_EQUAL(errors.size(), 1U);
+    BOOST_CHECK(errors.front().original.find("is already spent by wallet transaction") != std::string::npos);
+    BOOST_CHECK(bumped_txid.IsNull());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -217,6 +217,40 @@ BOOST_AUTO_TEST_CASE(commit_allows_replacing_replacement_chain)
     BOOST_CHECK(bumped_txid == expected_bumped_txid);
 }
 
+BOOST_AUTO_TEST_CASE(commit_allows_replacement_with_missing_forward_lineage)
+{
+    m_wallet.SetBroadcastTransactions(false);
+
+    CMutableTransaction funding;
+    funding.vout.emplace_back(10'000, CScript{} << OP_TRUE);
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(funding), TxStateInactive{}));
+
+    CMutableTransaction original;
+    original.vin.emplace_back(COutPoint{funding.GetHash(), 0});
+    original.vout.emplace_back(9'000, CScript{} << OP_TRUE);
+
+    CMutableTransaction first_replacement{original};
+    first_replacement.vout.front().nValue = 8'900;
+
+    // Simulate reloading after the replacement was persisted but the
+    // reciprocal MarkReplaced update was not.
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(original), TxStateInactive{}));
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(first_replacement), TxStateInactive{}, [&](CWalletTx& wtx, bool) {
+        wtx.mapValue["replaces_txid"] = original.GetHash().ToString();
+        return true;
+    }));
+
+    CMutableTransaction second_replacement{original};
+    second_replacement.vout.front().nValue = 8'800;
+    const Txid expected_bumped_txid{second_replacement.GetHash()};
+    std::vector<bilingual_str> errors;
+    Txid bumped_txid;
+    const Result commit_result{CommitTransaction(m_wallet, first_replacement.GetHash(), std::move(second_replacement), errors, bumped_txid)};
+    BOOST_CHECK(commit_result == Result::OK);
+    BOOST_CHECK(errors.empty());
+    BOOST_CHECK(bumped_txid == expected_bumped_txid);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace feebumper
 } // namespace wallet

--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or https://www.opensource.org/licenses/mit-license.php.
 
 #include <consensus/validation.h>
+#include <node/context.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
@@ -11,6 +12,7 @@
 #include <wallet/test/util.h>
 #include <wallet/test/wallet_p2mr_test_util.h>
 #include <wallet/test/wallet_test_fixture.h>
+#include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -166,6 +168,42 @@ BOOST_AUTO_TEST_CASE(commit_revalidates_competing_wallet_spend)
     BOOST_REQUIRE_EQUAL(errors.size(), 1U);
     BOOST_CHECK(errors.front().original.find("is already spent by wallet transaction") != std::string::npos);
     BOOST_CHECK(bumped_txid.IsNull());
+}
+
+BOOST_AUTO_TEST_CASE(commit_revalidates_external_inputs_from_chain)
+{
+    m_wallet.SetBroadcastTransactions(false);
+
+    CMutableTransaction wallet_funding;
+    wallet_funding.vout.emplace_back(10'000, CScript{} << OP_TRUE);
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(wallet_funding), TxStateInactive{}));
+
+    CMutableTransaction external_funding;
+    external_funding.vout.emplace_back(5'000, CScript{} << OP_TRUE);
+    const COutPoint external_outpoint{external_funding.GetHash(), 0};
+    {
+        LOCK(cs_main);
+        m_node.chainman->ActiveChainstate().CoinsTip().AddCoin(
+            external_outpoint,
+            Coin{external_funding.vout.front(), /*nHeightIn=*/1, /*fCoinBaseIn=*/false},
+            /*possible_overwrite=*/false);
+    }
+
+    CMutableTransaction original;
+    original.vin.emplace_back(COutPoint{wallet_funding.GetHash(), 0});
+    original.vin.emplace_back(external_outpoint);
+    original.vout.emplace_back(13'000, CScript{} << OP_TRUE);
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(original), TxStateInactive{}));
+
+    CMutableTransaction replacement{original};
+    replacement.vout.front().nValue = 12'500;
+    const Txid expected_bumped_txid{replacement.GetHash()};
+    std::vector<bilingual_str> errors;
+    Txid bumped_txid;
+    const Result commit_result{CommitTransaction(m_wallet, original.GetHash(), std::move(replacement), errors, bumped_txid)};
+    BOOST_CHECK(commit_result == Result::OK);
+    BOOST_CHECK(errors.empty());
+    BOOST_CHECK(bumped_txid == expected_bumped_txid);
 }
 
 BOOST_AUTO_TEST_CASE(commit_allows_replacing_replacement_chain)

--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -155,6 +155,55 @@ BOOST_AUTO_TEST_CASE(commit_revalidates_competing_wallet_spend)
     BOOST_CHECK(bumped_txid.IsNull());
 }
 
+BOOST_AUTO_TEST_CASE(commit_allows_replacing_replacement_chain)
+{
+    m_wallet.SetBroadcastTransactions(false);
+
+    CMutableTransaction funding;
+    funding.vout.emplace_back(10'000, CScript{} << OP_TRUE);
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(funding), TxStateInactive{}));
+
+    CMutableTransaction original;
+    original.vin.emplace_back(COutPoint{funding.GetHash(), 0});
+    original.vout.emplace_back(9'000, CScript{} << OP_TRUE);
+
+    CMutableTransaction first_replacement{original};
+    first_replacement.vout.front().nValue = 8'900;
+
+    CMutableTransaction second_replacement{original};
+    second_replacement.vout.front().nValue = 8'800;
+
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(original), TxStateInactive{}, [&](CWalletTx& wtx, bool) {
+        wtx.mapValue["replaced_by_txid"] = first_replacement.GetHash().ToString();
+        return true;
+    }));
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(first_replacement), TxStateInactive{}, [&](CWalletTx& wtx, bool) {
+        wtx.mapValue["replaces_txid"] = original.GetHash().ToString();
+        wtx.mapValue["replaced_by_txid"] = second_replacement.GetHash().ToString();
+        return true;
+    }));
+    BOOST_REQUIRE(m_wallet.AddToWallet(MakeTransactionRef(second_replacement), TxStateInactive{}, [&](CWalletTx& wtx, bool) {
+        wtx.mapValue["replaces_txid"] = first_replacement.GetHash().ToString();
+        return true;
+    }));
+
+    {
+        LOCK(m_wallet.cs_wallet);
+        BOOST_CHECK(!m_wallet.mapWallet.at(original.GetHash()).isMempoolConflicted());
+        BOOST_CHECK(!m_wallet.mapWallet.at(first_replacement.GetHash()).isMempoolConflicted());
+    }
+
+    CMutableTransaction final_replacement{original};
+    final_replacement.vout.front().nValue = 8'700;
+    const Txid expected_bumped_txid{final_replacement.GetHash()};
+    std::vector<bilingual_str> errors;
+    Txid bumped_txid;
+    const Result commit_result{CommitTransaction(m_wallet, second_replacement.GetHash(), std::move(final_replacement), errors, bumped_txid)};
+    BOOST_CHECK(commit_result == Result::OK);
+    BOOST_CHECK(errors.empty());
+    BOOST_CHECK(bumped_txid == expected_bumped_txid);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 } // namespace feebumper
 } // namespace wallet

--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -56,6 +56,19 @@ BOOST_AUTO_TEST_CASE(external_max_weight_test)
     CheckMaxWeightComputation("", {"3042021f5c4c29e6b686aae5b6d0751e90208592ea96d26bc81d78b0d3871a94a21fa8021f74dc2f971e438ccece8699c8fd15704c41df219ab37b63264f2147d15c34d801", "01", "6321024cf55e52ec8af7866617dc4e7ff8433758e98799906d80e066c6f32033f685f967029000b275210214827893e2dcbe4ad6c20bd743288edad21100404eb7f52ccd6062fd0e7808f268ac"}, "002089e84892873c679b1129edea246e484fd914c2601f776d4f2f4a001eb8059703", 195);
 }
 
+BOOST_AUTO_TEST_CASE(external_signer_honors_cancellation_at_command_boundary)
+{
+    m_wallet.SetWalletFlag(WALLET_FLAG_EXTERNAL_SIGNER);
+    CMutableTransaction mtx;
+    int progress_calls{0};
+
+    BOOST_CHECK(!feebumper::SignTransaction(m_wallet, mtx, {}, [&](const SigningProgress& progress) {
+        ++progress_calls;
+        return progress.cancellable;
+    }));
+    BOOST_CHECK_EQUAL(progress_calls, 3);
+}
+
 BOOST_AUTO_TEST_CASE(p2mr_signing_releases_wallet_lock)
 {
     using namespace std::chrono_literals;

--- a/src/wallet/test/feebumper_tests.cpp
+++ b/src/wallet/test/feebumper_tests.cpp
@@ -71,15 +71,26 @@ BOOST_AUTO_TEST_CASE(external_signer_honors_cancellation_at_command_boundary)
     BOOST_CHECK_EQUAL(progress_calls, 3);
 }
 
-BOOST_AUTO_TEST_CASE(p2mr_signing_releases_wallet_lock)
+BOOST_AUTO_TEST_CASE(p2mr_parallel_signing_releases_wallet_lock_mid_batch)
 {
     using namespace std::chrono_literals;
     using namespace wallet_p2mr_test;
-    struct AbortBeforeCryptographicSigning {};
+
+    struct ResumeSigningGuard {
+        std::promise<void>& promise;
+        std::atomic_bool released{false};
+
+        void Release()
+        {
+            if (!released.exchange(true)) promise.set_value();
+        }
+
+        ~ResumeSigningGuard() { Release(); }
+    };
 
     m_node.args->ForceSetArg("-walletpqcparallel", "1");
     m_node.args->ForceSetArg("-walletpqcsignthreads", "1");
-    auto workload{MakeDistinctKeyP2MRSigningWorkload(*m_node.chain, /*input_count=*/1)};
+    auto workload{MakeDistinctKeyP2MRSigningWorkload(*m_node.chain, /*input_count=*/2)};
 
     CMutableTransaction funding_tx;
     funding_tx.vout.resize(workload.coins.size());
@@ -95,30 +106,39 @@ BOOST_AUTO_TEST_CASE(p2mr_signing_releases_wallet_lock)
     std::future<void> paused_future{signing_paused.get_future()};
     std::promise<void> resume_signing;
     std::shared_future<void> resume_future{resume_signing.get_future()};
+    ResumeSigningGuard resume_guard{resume_signing};
     std::atomic_bool pause_reported{false};
     auto sign_future{std::async(std::launch::async, [&] {
         return feebumper::SignTransaction(*workload.wallet, workload.spend_tx, {}, [&](const SigningProgress& progress) {
-            if (progress.phase == SigningProgressPhase::RESERVING_PQC_COUNTERS && !progress.cancellable &&
-                !pause_reported.exchange(true)) {
+            if (progress.phase == SigningProgressPhase::SIGNING_INPUTS && !progress.cancellable &&
+                progress.completed == 1 && progress.input_index.has_value() && !pause_reported.exchange(true)) {
                 signing_paused.set_value();
                 resume_future.wait();
-                throw AbortBeforeCryptographicSigning{};
             }
             return true;
         });
     })};
 
     if (paused_future.wait_for(5s) != std::future_status::ready) {
-        resume_signing.set_value();
+        resume_guard.Release();
         BOOST_FAIL("Timed out waiting for fee-bump signing pause");
+    }
+
+    BOOST_REQUIRE_EQUAL(workload.pubkeys.size(), 2U);
+    for (size_t input_index{0}; input_index < workload.pubkeys.size(); ++input_index) {
+        BOOST_CHECK_EQUAL(GetProviderPQCCounter(*workload.p2mr_spk_man, workload.pubkeys.at(input_index).descriptor_pubkey, workload.pubkeys.at(input_index).pqc_pubkey), 1U);
+        BOOST_CHECK(workload.spend_tx.vin.at(input_index).scriptWitness.IsNull());
     }
     {
         TRY_LOCK(workload.wallet->cs_wallet, wallet_lock);
         BOOST_CHECK(static_cast<bool>(wallet_lock));
     }
 
-    resume_signing.set_value();
-    BOOST_CHECK_THROW(sign_future.get(), AbortBeforeCryptographicSigning);
+    resume_guard.Release();
+    BOOST_REQUIRE(sign_future.get());
+    for (const CTxIn& input : workload.spend_tx.vin) {
+        BOOST_CHECK(!input.scriptWitness.IsNull());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(commit_revalidates_fee_after_signing)

--- a/src/wallet/test/wallet_p2mr_parallel_signing_tests.cpp
+++ b/src/wallet/test/wallet_p2mr_parallel_signing_tests.cpp
@@ -220,6 +220,38 @@ BOOST_AUTO_TEST_CASE(P2MRWalletParallelIgnoresCancelAfterCounterReservation)
     }
 }
 
+BOOST_AUTO_TEST_CASE(P2MRWalletParallelHonorsCancelAtCounterReservationBoundary)
+{
+    m_node.args->ForceSetArg("-walletpqcparallel", "1");
+    m_node.args->ForceSetArg("-walletpqcsignthreads", "1");
+
+    auto workload{MakeDistinctKeyP2MRSigningWorkload(*m_node.chain, /*input_count=*/1)};
+    bool saw_cancellable_reservation{false};
+    bool saw_reservation_boundary{false};
+    std::map<int, bilingual_str> input_errors;
+    const bool signed_ok{workload.wallet->SignTransaction(workload.spend_tx, workload.coins, SIGHASH_DEFAULT, input_errors,
+        {},
+        [&](const SigningProgress& progress) {
+            if (progress.phase != SigningProgressPhase::RESERVING_PQC_COUNTERS) return true;
+            if (progress.cancellable) {
+                saw_cancellable_reservation = true;
+                return true;
+            }
+            if (progress.completed == 0) {
+                saw_reservation_boundary = true;
+                return false;
+            }
+            return true;
+        })};
+
+    BOOST_CHECK(!signed_ok);
+    BOOST_CHECK(saw_cancellable_reservation);
+    BOOST_CHECK(saw_reservation_boundary);
+    BOOST_CHECK(!input_errors.empty());
+    BOOST_CHECK_EQUAL(GetProviderPQCCounter(*workload.p2mr_spk_man, workload.pubkeys.front().descriptor_pubkey, workload.pubkeys.front().pqc_pubkey), 0U);
+    BOOST_CHECK(workload.spend_tx.vin.front().scriptWitness.IsNull());
+}
+
 BOOST_AUTO_TEST_CASE(P2MRWalletSerialIgnoresCancelAfterPQCSigning)
 {
     static constexpr size_t INPUT_COUNT{2};
@@ -253,6 +285,31 @@ BOOST_AUTO_TEST_CASE(P2MRWalletSerialIgnoresCancelAfterPQCSigning)
         BOOST_CHECK_EQUAL(GetProviderPQCCounter(*workload.p2mr_spk_man, workload.pubkeys.at(input_index).descriptor_pubkey, workload.pubkeys.at(input_index).pqc_pubkey), 1U);
         BOOST_CHECK(!workload.spend_tx.vin.at(input_index).scriptWitness.IsNull());
     }
+}
+
+BOOST_AUTO_TEST_CASE(P2MRWalletSerialHonorsCancelAtCounterReservationBoundary)
+{
+    m_node.args->ForceSetArg("-walletpqcparallel", "0");
+
+    auto workload{MakeDistinctKeyP2MRSigningWorkload(*m_node.chain, /*input_count=*/1)};
+    bool saw_reservation_boundary{false};
+    std::map<int, bilingual_str> input_errors;
+    const bool signed_ok{workload.wallet->SignTransaction(workload.spend_tx, workload.coins, SIGHASH_DEFAULT, input_errors,
+        {},
+        [&](const SigningProgress& progress) {
+            if (progress.phase == SigningProgressPhase::RESERVING_PQC_COUNTERS &&
+                !progress.cancellable && progress.completed == 0) {
+                saw_reservation_boundary = true;
+                return false;
+            }
+            return true;
+        })};
+
+    BOOST_CHECK(!signed_ok);
+    BOOST_CHECK(saw_reservation_boundary);
+    BOOST_CHECK(!input_errors.empty());
+    BOOST_CHECK_EQUAL(GetProviderPQCCounter(*workload.p2mr_spk_man, workload.pubkeys.front().descriptor_pubkey, workload.pubkeys.front().pqc_pubkey), 0U);
+    BOOST_CHECK(workload.spend_tx.vin.front().scriptWitness.IsNull());
 }
 
 BOOST_AUTO_TEST_CASE(P2MRWalletParallelSkipsCompleteInputs)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2957,7 +2957,9 @@ void CWallet::CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::ve
 
     // Notify that old coins are spent
     for (const CTxIn& txin : tx->vin) {
-        CWalletTx &coin = mapWallet.at(txin.prevout.hash);
+        const auto coin_it{mapWallet.find(txin.prevout.hash)};
+        if (coin_it == mapWallet.end()) continue;
+        CWalletTx& coin{coin_it->second};
         coin.MarkDirty();
         NotifyTransactionChanged(coin.GetHash(), CT_UPDATED);
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -992,6 +992,17 @@ std::set<Txid> CWallet::GetConflicts(const Txid& txid) const
     return result;
 }
 
+std::set<Txid> CWallet::GetWalletSpenders(const COutPoint& outpoint) const
+{
+    AssertLockHeld(cs_wallet);
+    std::set<Txid> spenders;
+    const auto range{mapTxSpends.equal_range(outpoint)};
+    for (auto it{range.first}; it != range.second; ++it) {
+        spenders.insert(it->second);
+    }
+    return spenders;
+}
+
 bool CWallet::HasWalletSpend(const CTransactionRef& tx) const
 {
     AssertLockHeld(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -931,6 +931,9 @@ public:
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<Txid> GetConflicts(const Txid& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    //! Get wallet transactions that spend the given output
+    std::set<Txid> GetWalletSpenders(const COutPoint& outpoint) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     //! Check if a given transaction has any of its outputs spent by another transaction in the wallet
     bool HasWalletSpend(const CTransactionRef& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -17,7 +17,19 @@ from test_framework.address import (
     output_key_to_p2tr,
 )
 from test_framework.descriptors import descsum_create
+from test_framework.key import sign_schnorr, tweak_add_privkey
+from test_framework.messages import CTxOut, from_binary
+from test_framework.psbt import (
+    PSBT,
+    PSBT_IN_SIGHASH_TYPE,
+    PSBT_IN_TAP_KEY_SIG,
+    PSBT_IN_WITNESS_UTXO,
+)
 from test_framework.script import taproot_construct
+from test_framework.script import SIGHASH_DEFAULT, TaprootSignatureHash
+
+TAPROOT_RECEIVE_KEY = bytes.fromhex("b6f762e107af1dd4c73f7f1ce84298d71ec07a0a66fb8d8f24551f99435af082")
+TAPROOT_RECEIVE_INFO = taproot_construct(bytes.fromhex("c97dc3f4420402e01a113984311bf4a1b8de376cac0bdcfaf1b3ac81f13433c7"))
 
 def perform_pre_checks():
     mock_result_path = os.path.join(os.getcwd(), "mock_result")
@@ -73,6 +85,20 @@ def displayaddress(args):
 def signtx(args):
     if args.fingerprint != "00000001":
         return sys.stdout.write(json.dumps({"error": "Unexpected fingerprint", "fingerprint": args.fingerprint}))
+
+    if os.path.isfile(os.path.join(os.getcwd(), "mock_sign_taproot")):
+        psbt = PSBT.from_base64(args.psbt)
+        spent_outputs = [from_binary(CTxOut, tx_input.map[PSBT_IN_WITNESS_UTXO]) for tx_input in psbt.i]
+        tweaked_key = tweak_add_privkey(TAPROOT_RECEIVE_KEY, TAPROOT_RECEIVE_INFO.tweak)
+        for index in range(len(psbt.i)):
+            tx_input = psbt.i[index]
+            spent_output = spent_outputs[index]
+            if spent_output.scriptPubKey != TAPROOT_RECEIVE_INFO.scriptPubKey:
+                continue
+            hash_type = int.from_bytes(tx_input.map.get(PSBT_IN_SIGHASH_TYPE, SIGHASH_DEFAULT.to_bytes(4, "little")), "little")
+            sighash = TaprootSignatureHash(psbt.tx, spent_outputs, hash_type, index)
+            tx_input.map[PSBT_IN_TAP_KEY_SIG] = sign_schnorr(tweaked_key, sighash)
+        return sys.stdout.write(json.dumps({"psbt": psbt.to_base64(), "complete": True}))
 
     with open(os.path.join(os.getcwd(), "mock_psbt"), "r", encoding="utf8") as f:
         mock_psbt = f.read()

--- a/test/functional/mocks/signer.py
+++ b/test/functional/mocks/signer.py
@@ -21,6 +21,7 @@ from test_framework.key import sign_schnorr, tweak_add_privkey
 from test_framework.messages import CTxOut, from_binary
 from test_framework.psbt import (
     PSBT,
+    PSBT_GLOBAL_UNSIGNED_TX,
     PSBT_IN_SIGHASH_TYPE,
     PSBT_IN_TAP_KEY_SIG,
     PSBT_IN_WITNESS_UTXO,
@@ -86,8 +87,19 @@ def signtx(args):
     if args.fingerprint != "00000001":
         return sys.stdout.write(json.dumps({"error": "Unexpected fingerprint", "fingerprint": args.fingerprint}))
 
-    if os.path.isfile(os.path.join(os.getcwd(), "mock_sign_taproot")):
+    mock_sign_taproot = os.path.join(os.getcwd(), "mock_sign_taproot")
+    if os.path.isfile(mock_sign_taproot):
+        with open(mock_sign_taproot, "r", encoding="utf8") as f:
+            signer_mode = f.read()
+        assert signer_mode in {"", "output", "sequence"}
+
         psbt = PSBT.from_base64(args.psbt)
+        if signer_mode == "output":
+            psbt.tx.vout[0].nValue -= 1
+        elif signer_mode == "sequence":
+            psbt.tx.vin[0].nSequence ^= 1
+        psbt.g.map[PSBT_GLOBAL_UNSIGNED_TX] = psbt.tx.serialize_without_witness()
+
         spent_outputs = [from_binary(CTxOut, tx_input.map[PSBT_IN_WITNESS_UTXO]) for tx_input in psbt.i]
         tweaked_key = tweak_add_privkey(TAPROOT_RECEIVE_KEY, TAPROOT_RECEIVE_INFO.tweak)
         for index in range(len(psbt.i)):

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -201,18 +201,20 @@ class WalletSignerTest(BitcoinTestFramework):
 
         self.log.info('Prepare fee bumped mock PSBT')
 
-        # Now that the transaction is broadcast, bump fee in mock wallet:
         orig_tx_id = res["txid"]
-        mock_psbt_bumped = mock_wallet.psbtbumpfee(orig_tx_id)["psbt"]
-        mock_psbt_bumped_signed = mock_wallet.walletprocesspsbt(psbt=mock_psbt_bumped, sign=True, sighashtype="ALL", bip32derivs=True)
-
-        with open(os.path.join(self.nodes[1].cwd, "mock_psbt"), "w", encoding="utf8") as f:
-            f.write(mock_psbt_bumped_signed["psbt"])
+        mock_sign_taproot = os.path.join(self.nodes[1].cwd, "mock_sign_taproot")
+        with open(mock_sign_taproot, "w", encoding="utf8"):
+            pass
 
         self.log.info('Test bumpfee using hww1')
 
-        # Bump fee
-        res = hww.bumpfee(orig_tx_id)
+        # Sign the PSBT passed to the mock instead of returning a separately
+        # constructed replacement, which may have a different output order or
+        # locktime. This also exercises the transaction-integrity check.
+        try:
+            res = hww.bumpfee(orig_tx_id)
+        finally:
+            os.remove(mock_sign_taproot)
         assert_greater_than(res["fee"], res["origfee"])
         assert_equal(res["errors"], [])
 

--- a/test/functional/wallet_signer.py
+++ b/test/functional/wallet_signer.py
@@ -203,20 +203,48 @@ class WalletSignerTest(BitcoinTestFramework):
 
         orig_tx_id = res["txid"]
         mock_sign_taproot = os.path.join(self.nodes[1].cwd, "mock_sign_taproot")
+        baseline_mempool = set(self.nodes[1].getrawmempool())
+        baseline_tx_count = hww.getwalletinfo()["txcount"]
+        baseline_orig_tx = hww.gettransaction(orig_tx_id)
+        assert orig_tx_id in baseline_mempool
+        assert "replaced_by_txid" not in baseline_orig_tx
+
         with open(mock_sign_taproot, "w", encoding="utf8"):
             pass
-
-        self.log.info('Test bumpfee using hww1')
-
-        # Sign the PSBT passed to the mock instead of returning a separately
-        # constructed replacement, which may have a different output order or
-        # locktime. This also exercises the transaction-integrity check.
         try:
+            for signer_mode in ["output", "sequence"]:
+                self.log.info(f'Test bumpfee rejects external signer {signer_mode} mutation')
+                with open(mock_sign_taproot, "w", encoding="utf8") as f:
+                    f.write(signer_mode)
+
+                assert_raises_rpc_error(
+                    -4,
+                    "Transaction incomplete. Try psbtbumpfee instead.",
+                    hww.bumpfee,
+                    orig_tx_id,
+                )
+
+                assert_equal(set(self.nodes[1].getrawmempool()), baseline_mempool)
+                assert orig_tx_id in self.nodes[1].getrawmempool()
+                assert_equal(hww.getwalletinfo()["txcount"], baseline_tx_count)
+                orig_tx = hww.gettransaction(orig_tx_id)
+                assert "replaced_by_txid" not in orig_tx
+                assert_equal(orig_tx["walletconflicts"], baseline_orig_tx["walletconflicts"])
+                assert_equal(orig_tx["mempoolconflicts"], baseline_orig_tx["mempoolconflicts"])
+
+            self.log.info('Test bumpfee using hww1')
+
+            # Sign the exact PSBT passed to the mock after proving that signed
+            # transaction substitutions are rejected.
+            with open(mock_sign_taproot, "w", encoding="utf8"):
+                pass
             res = hww.bumpfee(orig_tx_id)
         finally:
             os.remove(mock_sign_taproot)
         assert_greater_than(res["fee"], res["origfee"])
         assert_equal(res["errors"], [])
+        assert res["txid"] in self.nodes[1].getrawmempool()
+        assert orig_tx_id not in self.nodes[1].getrawmempool()
 
 
     def test_disconnected_signer(self):


### PR DESCRIPTION
## Summary

Fixes #142.

Fee-bump preparation, signing, and commit previously ran synchronously on the Qt GUI thread, while `feebumper::SignTransaction()` held `cs_wallet` across the complete signing operation. P2MR cryptographic signing could therefore freeze the GUI and prevent other wallet work from acquiring the wallet lock.

This change:

- runs fee-bump preparation and signing/commit on a lifetime-safe cloned wallet interface;
- removes the fee-bumper's outer wallet lock so internal signing uses the existing snapshot-under-lock, sign-without-lock lifecycle;
- reports queued preparation, counter reservation, input signing, finalization, and commit progress;
- permits cancellation only before the durable PQC counter-reservation boundary;
- revalidates inputs, competing wallet spends, fees, current relay/mempool policy, standard weight, and chain limits before commit;
- rejects signer changes outside input signature and witness fields; and
- adds deterministic wallet-lock, GUI responsiveness, cancellation, revalidation, dialog/model destruction, external-signer, wallet-unload, and shutdown coverage.

Structured PQC usage data is preserved through the worker result, but user-facing usage presentation remains out of scope for #141.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason: All planned checks were run.

Commands and results:

- `cmake --build build -j6 --target bitcoin_wallet bitcoinqt test_bitcoin test_bitcoin-qt` — passed.
- `feebumper_tests/p2mr_signing_releases_wallet_lock` — passed with a deterministic post-reservation/pre-crypto latch proving another thread can acquire `cs_wallet`.
- `feebumper_tests/commit_revalidates_fee_after_signing` — passed.
- `feebumper_tests/commit_revalidates_competing_wallet_spend` — passed.
- `wallet_tests/sign_transaction_*` — four signing progress/cancellation tests passed.
- `wallet_p2mr_batch_reservation_tests` — three tests passed.
- `feebumper_tests/external_max_weight_test` — passed.
- `ulimit -n 1024 && build/test/functional/test_runner.py --jobs=2 wallet_bumpfee.py feature_rbf.py` — both passed.
- `ulimit -n 1024 && QT_QPA_PLATFORM=cocoa QTEST_FUNCTION_TIMEOUT=600000 build/bin/test_qbit-qt` — all wallet and application lifecycle suites passed; the binary still reports the unrelated existing `RPCNestedTests::rpcNestedTests` expected-hash mismatch in unchanged code.
- Repository Docker lint workflow — exited 0 with all checks passed.
- `git diff --check origin/1.x.x...HEAD` — passed.

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

Target: `1.x.x`.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes:

- Internal P2MR crypto no longer runs with the fee-bumper's outer `cs_wallet` lock held.
- External signing is off the GUI thread, but its internal `FillPSBT` path may retain `cs_wallet` while an external command runs.
- RPC `bumpfee` retains its existing caller-side wallet lock; this PR targets the Qt lifecycle from #142.
- Mempool state can still change between final revalidation and broadcast, so normal submission-time validation remains authoritative.

## Docs / Process Impact

Choose exactly one:

- [ ] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [x] No public docs update needed. Reason: This changes internal Qt threading, locking, and progress handling without changing the documented fee-bump interface.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches wallet fee-bump signing, PQC counter reservation cancellation, and Qt lifecycle/shutdown paths. Incorrect cancellation or revalidation could consume counters, commit stale replacements, or leave the GUI/wallet in a bad state.
> 
> **Overview**
> Moves Qt fee-bump **preparation, signing, and commit** off the GUI thread onto a cloned wallet worker, with a progress dialog and a new `feeBumped` completion signal.
> 
> Cancellation is cooperative only until the durable **PQC counter-reservation** or **external-signer command** boundary; after that the operation becomes irreversible and still completes through shutdown/teardown. Commit now **revalidates** inputs, competing spends, fees, and current relay/mempool policy, and rejects signer changes outside input signature/witness fields.
> 
> Adds broad Qt and wallet coverage for responsiveness, cancel races, revalidation failures, external-signer mutation rejection, and model/dialog destruction during an in-flight bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8989e36c928e39b50c5ab71f424c3eca499961a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786900105&installation_id=141183937&pr_number=146&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F146&signature=f7c880f2dc25026df490087e066ad661688e5a388a04e2167c339ed93c0c6c22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->