### PR TITLE
test: stabilize REST chaininfo comparison

### DIFF
--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -419,13 +419,17 @@ class RESTTest (BitcoinTestFramework):
         self.log.info("Test the /chaininfo URI")
 
         bb_hash = self.nodes[0].getbestblockhash()
+        tip_time = self.nodes[0].getblockheader(bb_hash)['time']
+        self.nodes[0].setmocktime(tip_time)
+        try:
+            json_obj = self.test_rest_request("/chaininfo")
+            assert_equal(json_obj['bestblockhash'], bb_hash)
 
-        json_obj = self.test_rest_request("/chaininfo")
-        assert_equal(json_obj['bestblockhash'], bb_hash)
-
-        # Compare with normal RPC getblockchaininfo response
-        blockchain_info = self.nodes[0].getblockchaininfo()
-        assert_equal(blockchain_info, json_obj)
+            # Compare with normal RPC getblockchaininfo response
+            blockchain_info = self.nodes[0].getblockchaininfo()
+            assert_equal(blockchain_info, json_obj)
+        finally:
+            self.nodes[0].setmocktime(0)
 
         # Test compatibility of deprecated and newer endpoints
         self.log.info("Test compatibility of deprecated and newer endpoints")


### PR DESCRIPTION
## Summary

- Freeze node 0's mock time to the current tip timestamp while comparing `/rest/chaininfo` with `getblockchaininfo()`.
- Restore real time unconditionally with `setmocktime(0)` in a `finally` block.

## Root cause

Both endpoints expose `future_block_time.next_block_max_time` and `next_block_time_headroom_seconds`, which are derived from the current clock. The test queried the endpoints sequentially, so crossing a one-second boundary could make otherwise equivalent responses differ by one second.

## Testing

- `interface_rest.py` — five complete runs passed.
- `git diff --check` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5cf752c0685b118933ebda926b32ef9b15bce4cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789137811&installation_model_id=424701&pr_number=149&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F149&signature=590dffe54d6d71e5c25588f33bbf4784cb630a208870701280911c1450d2aca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->