### PR TITLE
wallet: show fee-only change-only self-transfers

### DIFF
--- a/src/qt/test/CMakeLists.txt
+++ b/src/qt/test/CMakeLists.txt
@@ -33,6 +33,7 @@ if(ENABLE_WALLET)
     PRIVATE
       addressbooktests.cpp
       syntheticwallet.cpp
+      transactionrecordtests.cpp
       walletcontrollertests.cpp
       walletactivitytests.cpp
       wallettests.cpp

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -19,6 +19,7 @@
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
+#include <qt/test/transactionrecordtests.h>
 #include <qt/test/walletcontrollertests.h>
 #include <qt/test/walletactivitytests.h>
 #include <qt/test/wallettests.h>
@@ -101,6 +102,9 @@ int main(int argc, char* argv[])
         num_test_failures += QTest::qExec(&test3);
 
 #ifdef ENABLE_WALLET
+        TransactionRecordTests transaction_record_tests;
+        num_test_failures += QTest::qExec(&transaction_record_tests);
+
         WalletTests test5(app.node());
         num_test_failures += QTest::qExec(&test5);
 

--- a/src/qt/test/transactionrecordtests.cpp
+++ b/src/qt/test/transactionrecordtests.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/test/transactionrecordtests.h>
+
+#include <interfaces/wallet.h>
+#include <primitives/transaction.h>
+#include <qt/transactionrecord.h>
+#include <script/script.h>
+#include <uint256.h>
+
+#include <utility>
+#include <vector>
+
+#include <QTest>
+
+namespace {
+interfaces::WalletTx MakeWalletTx(const std::vector<CAmount>& output_amounts,
+                                  const std::vector<bool>& output_is_mine,
+                                  const std::vector<bool>& output_is_change,
+                                  CAmount debit)
+{
+    Q_ASSERT(output_amounts.size() == output_is_mine.size());
+    Q_ASSERT(output_amounts.size() == output_is_change.size());
+
+    CMutableTransaction tx;
+    tx.vin.emplace_back(COutPoint{Txid::FromUint256(uint256::ONE), 0});
+    for (const CAmount amount : output_amounts) {
+        tx.vout.emplace_back(amount, CScript{} << OP_TRUE);
+    }
+
+    interfaces::WalletTx wtx;
+    wtx.tx = MakeTransactionRef(std::move(tx));
+    wtx.txin_is_mine = {true};
+    wtx.txout_is_mine = output_is_mine;
+    wtx.txout_is_change = output_is_change;
+    wtx.txout_address.assign(output_amounts.size(), CNoDestination{});
+    wtx.txout_address_is_mine = output_is_mine;
+    wtx.credit = 0;
+    wtx.change = 0;
+    for (size_t i = 0; i < output_amounts.size(); ++i) {
+        if (output_is_mine[i]) wtx.credit += output_amounts[i];
+        if (output_is_change[i]) wtx.change += output_amounts[i];
+    }
+    wtx.debit = debit;
+    wtx.time = 1;
+    wtx.is_coinbase = false;
+    return wtx;
+}
+} // namespace
+
+void TransactionRecordTests::feeBearingChangeOnlyPayment()
+{
+    const interfaces::WalletTx wtx{MakeWalletTx(
+        /*output_amounts=*/{50, 49},
+        /*output_is_mine=*/{true, true},
+        /*output_is_change=*/{true, true},
+        /*debit=*/100)};
+
+    const QList<TransactionRecord> parts{TransactionRecord::decomposeTransaction(wtx)};
+
+    QCOMPARE(parts.size(), 1);
+    QCOMPARE(parts.front().type, TransactionRecord::PaymentToSelf);
+    QCOMPARE(parts.front().debit, -1);
+    QCOMPARE(parts.front().credit, 0);
+    QCOMPARE(parts.front().getOutputIndex(), -1);
+    QCOMPARE(parts.front().debit + parts.front().credit, wtx.credit - wtx.debit);
+}
+
+void TransactionRecordTests::ordinaryPaymentWithChange()
+{
+    const interfaces::WalletTx wtx{MakeWalletTx(
+        /*output_amounts=*/{30, 69},
+        /*output_is_mine=*/{false, true},
+        /*output_is_change=*/{false, true},
+        /*debit=*/100)};
+
+    const QList<TransactionRecord> parts{TransactionRecord::decomposeTransaction(wtx)};
+
+    QCOMPARE(parts.size(), 1);
+    QCOMPARE(parts.front().type, TransactionRecord::SendToOther);
+    QCOMPARE(parts.front().debit, -31);
+    QCOMPARE(parts.front().credit, 0);
+    QCOMPARE(parts.front().getOutputIndex(), 0);
+}
+
+void TransactionRecordTests::zeroFeeChangeOnlyPayment()
+{
+    const interfaces::WalletTx wtx{MakeWalletTx(
+        /*output_amounts=*/{100},
+        /*output_is_mine=*/{true},
+        /*output_is_change=*/{true},
+        /*debit=*/100)};
+
+    QVERIFY(TransactionRecord::decomposeTransaction(wtx).empty());
+}

--- a/src/qt/test/transactionrecordtests.h
+++ b/src/qt/test/transactionrecordtests.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2026-present The qbit developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef QBIT_QT_TEST_TRANSACTIONRECORDTESTS_H
+#define QBIT_QT_TEST_TRANSACTIONRECORDTESTS_H
+
+#include <QObject>
+
+class TransactionRecordTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void feeBearingChangeOnlyPayment();
+    void ordinaryPaymentWithChange();
+    void zeroFeeChangeOnlyPayment();
+};
+
+#endif // QBIT_QT_TEST_TRANSACTIONRECORDTESTS_H

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -281,7 +281,9 @@ QString TransactionDesc::toHTML(interfaces::Node& node, interfaces::Wallet& wall
     strHTML += "<b>" + tr("Transaction ID") + ":</b> " + rec->getTxHash() + "<br>";
     strHTML += "<b>" + tr("Transaction total size") + ":</b> " + QString::number(wtx.tx->GetTotalSize()) + " bytes<br>";
     strHTML += "<b>" + tr("Transaction virtual size") + ":</b> " + QString::number(GetVirtualTransactionSize(*wtx.tx)) + " bytes<br>";
-    strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
+    if (rec->getOutputIndex() >= 0) {
+        strHTML += "<b>" + tr("Output index") + ":</b> " + QString::number(rec->getOutputIndex()) + "<br>";
+    }
 
     // Message from normal bitcoin:URI (bitcoin:123...?message=example)
     for (const std::pair<std::string, std::string>& r : orderForm) {

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -123,6 +123,15 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 parts.append(sub);
             }
         }
+
+        // If every output was classified as change, no per-output record was
+        // created above. Preserve a fee-bearing payment to self as a
+        // transaction-level record so the history reconciles with the balance.
+        if (all_from_me && parts.empty() && nTxFee > 0) {
+            TransactionRecord sub(hash, nTime, TransactionRecord::PaymentToSelf, "", -nTxFee, 0);
+            sub.idx = -1;
+            parts.append(sub);
+        }
     } else {
         //
         // Mixed debit transaction, can't break down payees
@@ -144,6 +153,8 @@ void TransactionRecord::updateStatus(const interfaces::WalletTxStatus& wtx, cons
         typesort = 2; break;
     case RecvWithAddress: case RecvFromOther:
         typesort = 3; break;
+    case PaymentToSelf:
+        typesort = 4; break;
     default:
         typesort = 9;
     }

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -70,6 +70,7 @@ public:
         SendToOther,
         RecvWithAddress,
         RecvFromOther,
+        PaymentToSelf,
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -378,6 +378,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Sent to");
     case TransactionRecord::Generated:
         return tr("Mined");
+    case TransactionRecord::PaymentToSelf:
+        return tr("Payment to self");
     default:
         return QString();
     }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -85,7 +85,8 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     typeWidget->addItem(tr("Sent to"), TransactionFilterProxy::TYPE(TransactionRecord::SendToAddress) |
                                   TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
-    typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
+    typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other) |
+                                     TransactionFilterProxy::TYPE(TransactionRecord::PaymentToSelf));
 
     hlayout->addWidget(typeWidget);
 

--- a/src/wallet/rpc/transactions.cpp
+++ b/src/wallet/rpc/transactions.cpp
@@ -291,6 +291,32 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
     }
 }
 
+template <class Vec>
+static void PushSentTransaction(const CWallet& wallet, const CWalletTx& wtx, const COutputEntry* sent,
+                                CAmount fee, bool include_long, Vec& ret)
+    EXCLUSIVE_LOCKS_REQUIRED(wallet.cs_wallet)
+{
+    UniValue entry(UniValue::VOBJ);
+    if (sent) {
+        MaybePushAddress(entry, sent->destination);
+    }
+    entry.pushKV("category", "send");
+    entry.pushKV("amount", ValueFromAmount(sent ? -sent->amount : 0));
+    if (sent) {
+        const auto* address_book_entry = wallet.FindAddressBookEntry(sent->destination);
+        if (address_book_entry) {
+            entry.pushKV("label", address_book_entry->GetLabel());
+        }
+        entry.pushKV("vout", sent->vout);
+    }
+    entry.pushKV("fee", ValueFromAmount(-fee));
+    if (include_long) {
+        WalletTxToJSON(wallet, wtx, entry);
+    }
+    entry.pushKV("abandoned", wtx.isAbandoned());
+    ret.push_back(std::move(entry));
+}
+
 /**
  * List transactions based on the given criteria.
  *
@@ -318,20 +344,14 @@ static void ListTransactions(const CWallet& wallet, const CWalletTx& wtx, int nM
     {
         for (const COutputEntry& s : listSent)
         {
-            UniValue entry(UniValue::VOBJ);
-            MaybePushAddress(entry, s.destination);
-            entry.pushKV("category", "send");
-            entry.pushKV("amount", ValueFromAmount(-s.amount));
-            const auto* address_book_entry = wallet.FindAddressBookEntry(s.destination);
-            if (address_book_entry) {
-                entry.pushKV("label", address_book_entry->GetLabel());
-            }
-            entry.pushKV("vout", s.vout);
-            entry.pushKV("fee", ValueFromAmount(-nFee));
-            if (fLong)
-                WalletTxToJSON(wallet, wtx, entry);
-            entry.pushKV("abandoned", wtx.isAbandoned());
-            ret.push_back(std::move(entry));
+            PushSentTransaction(wallet, wtx, &s, nFee, fLong, ret);
+        }
+
+        // With change excluded, an all-inputs-owned transaction whose every
+        // output is change has no real sent entry to carry its fee. Add one
+        // transaction-level entry without pretending it corresponds to a vout.
+        if (!include_change && listSent.empty() && nFee > 0 && AllInputsMine(wallet, *wtx.tx)) {
+            PushSentTransaction(wallet, wtx, /*sent=*/nullptr, nFee, fLong, ret);
         }
     }
 
@@ -430,17 +450,17 @@ RPCHelpMan listtransactions()
                     {
                         {RPCResult::Type::OBJ, "", "", Cat(Cat<std::vector<RPCResult>>(
                         {
-                            {RPCResult::Type::STR, "address",  /*optional=*/true, "The qbit address of the transaction (not returned if the output does not have an address, e.g. OP_RETURN null data)."},
+                            {RPCResult::Type::STR, "address",  /*optional=*/true, "The qbit address of the transaction (not returned for a fee-only internal transfer or if the output does not have an address, e.g. OP_RETURN null data)."},
                             {RPCResult::Type::STR, "category", "The transaction category.\n"
                                 "\"send\"                  Transactions sent.\n"
                                 "\"receive\"               Non-coinbase transactions received.\n"
                                 "\"generate\"              Coinbase transactions received with more than 100 confirmations.\n"
                                 "\"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n"
                                 "\"orphan\"                Orphaned coinbase transactions received."},
-                            {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category, and is positive\n"
+                            {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category except a fee-only internal transfer, which is zero, and is positive\n"
                                 "for all other categories"},
                             {RPCResult::Type::STR, "label", /*optional=*/true, "A comment for the address/transaction, if any"},
-                            {RPCResult::Type::NUM, "vout", "the vout value"},
+                            {RPCResult::Type::NUM, "vout", /*optional=*/true, "The vout value. Not returned for a fee-only internal transfer."},
                             {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the\n"
                                  "'send' category of transactions."},
                         },
@@ -539,16 +559,16 @@ RPCHelpMan listsinceblock()
                         {
                             {RPCResult::Type::OBJ, "", "", Cat(Cat<std::vector<RPCResult>>(
                             {
-                                {RPCResult::Type::STR, "address",  /*optional=*/true, "The qbit address of the transaction (not returned if the output does not have an address, e.g. OP_RETURN null data)."},
+                                {RPCResult::Type::STR, "address",  /*optional=*/true, "The qbit address of the transaction (not returned for a fee-only internal transfer or if the output does not have an address, e.g. OP_RETURN null data)."},
                                 {RPCResult::Type::STR, "category", "The transaction category.\n"
                                     "\"send\"                  Transactions sent.\n"
                                     "\"receive\"               Non-coinbase transactions received.\n"
                                     "\"generate\"              Coinbase transactions received with more than 100 confirmations.\n"
                                     "\"immature\"              Coinbase transactions received with 100 or fewer confirmations.\n"
                                     "\"orphan\"                Orphaned coinbase transactions received."},
-                                {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category, and is positive\n"
+                                {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT + ". This is negative for the 'send' category except a fee-only internal transfer, which is zero, and is positive\n"
                                     "for all other categories"},
-                                {RPCResult::Type::NUM, "vout", "the vout value"},
+                                {RPCResult::Type::NUM, "vout", /*optional=*/true, "The vout value. Not returned for a fee-only internal transfer."},
                                 {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the\n"
                                      "'send' category of transactions."},
                             },
@@ -679,7 +699,7 @@ RPCHelpMan gettransaction()
                         {
                             {RPCResult::Type::OBJ, "", "",
                             {
-                                {RPCResult::Type::STR, "address", /*optional=*/true, "The qbit address involved in the transaction."},
+                                {RPCResult::Type::STR, "address", /*optional=*/true, "The qbit address involved in the transaction. Not returned for a fee-only internal transfer."},
                                 {RPCResult::Type::STR, "category", "The transaction category.\n"
                                     "\"send\"                  Transactions sent.\n"
                                     "\"receive\"               Non-coinbase transactions received.\n"
@@ -688,7 +708,7 @@ RPCHelpMan gettransaction()
                                     "\"orphan\"                Orphaned coinbase transactions received."},
                                 {RPCResult::Type::STR_AMOUNT, "amount", "The amount in " + CURRENCY_UNIT},
                                 {RPCResult::Type::STR, "label", /*optional=*/true, "A comment for the address/transaction, if any"},
-                                {RPCResult::Type::NUM, "vout", "the vout value"},
+                                {RPCResult::Type::NUM, "vout", /*optional=*/true, "The vout value. Not returned for a fee-only internal transfer."},
                                 {RPCResult::Type::STR_AMOUNT, "fee", /*optional=*/true, "The amount of the fee in " + CURRENCY_UNIT + ". This is negative and only available for the \n"
                                     "'send' category of transactions."},
                                 {RPCResult::Type::BOOL, "abandoned", "'true' if the transaction has been abandoned (inputs are respendable)."},

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -14,6 +14,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     wallet_importprivkey,
 )
+from test_framework.wallet import MiniWallet
 from test_framework.wallet_util import generate_keypair
 
 from decimal import Decimal
@@ -44,6 +45,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         self.test_targetconfirmations()
         self.test_desc()
         self.test_send_to_self()
+        self.test_watchonly_send_to_self()
         self.test_op_return()
         self.test_label()
 
@@ -452,25 +454,110 @@ class ListSinceBlockTest(BitcoinTestFramework):
         assert_equal(coin_b["parent_descs"][0], multi_b)
 
     def test_send_to_self(self):
-        """We can make listsinceblock output our change outputs."""
-        self.log.info("Test the inclusion of change outputs in the output.")
+        """Fee-bearing change-only transactions remain visible without listing change."""
+        self.log.info("Test fee-only history for a spendable wallet change-only transaction.")
 
         # Create a UTxO paying to one of our change addresses.
         block_hash = self.nodes[2].getbestblockhash()
+        balance_before = self.nodes[2].getbalance()
         addr = self.nodes[2].getrawchangeaddress()
-        self.nodes[2].sendtoaddress(addr, 1)
+        txid = self.nodes[2].sendtoaddress(addr, 1)
+        assert_equal(self.nodes[2].getbalance() - balance_before, self.nodes[2].gettransaction(txid)["fee"])
+        self.sync_mempools()
+        self.generate(self.nodes[0], 1)
 
-        # If we don't list change, we won't have an entry for it.
-        coins = self.nodes[2].listsinceblock(blockhash=block_hash)["transactions"]
-        assert not any(c["address"] == addr for c in coins)
+        self.assert_fee_only_history(
+            wallet=self.nodes[2],
+            txid=txid,
+            block_hash=block_hash,
+        )
+
+        # The fee-only entry is transaction-level and does not expose a change
+        # address, while the real output records remain available on request.
+        default_entries = self.nodes[2].listsinceblock(blockhash=block_hash)["transactions"]
+        assert not any(entry.get("address") == addr for entry in default_entries)
 
         # Now if we list change, we'll get both the send (to a change address) and
         # the actual change.
         res = self.nodes[2].listsinceblock(blockhash=block_hash, include_change=True)
-        coins = [entry for entry in res["transactions"] if entry["category"] == "receive"]
+        coins = [entry for entry in res["transactions"] if entry["txid"] == txid and entry["category"] == "receive"]
         assert_equal(len(coins), 2)
         assert any(c["address"] == addr for c in coins)
         assert all(self.nodes[2].getaddressinfo(c["address"])["ischange"] for c in coins)
+
+    def test_watchonly_send_to_self(self):
+        self.log.info("Test fee-only history for a watch-only change-only transaction.")
+
+        miniwallet = MiniWallet(self.nodes[2], tag_name="change-only-history")
+        self.nodes[2].createwallet(wallet_name="change_only_watch", disable_private_keys=True, blank=True)
+        watch_wallet = self.nodes[2].get_wallet_rpc("change_only_watch")
+        result = watch_wallet.importdescriptors([{
+            "desc": miniwallet.get_descriptor(),
+            "internal": True,
+            "timestamp": "now",
+        }])
+        assert_equal(result[0]["success"], True)
+
+        funding_wallet = self.nodes[2].get_wallet_rpc(self.default_wallet_name)
+        funding_wallet.sendtoaddress(miniwallet.get_address(), 1)
+        self.sync_mempools()
+        self.generate(self.nodes[0], 1)
+        self.nodes[2].syncwithvalidationinterfacequeue()
+        miniwallet.rescan_utxos()
+        assert_equal(watch_wallet.getbalance(), 1)
+
+        block_hash = self.nodes[2].getbestblockhash()
+        balance_before = watch_wallet.getbalance()
+        transfer = miniwallet.send_self_transfer(from_node=self.nodes[2], fee=Decimal("0.001"))
+        self.nodes[2].syncwithvalidationinterfacequeue()
+        assert_equal(watch_wallet.getbalance() - balance_before, watch_wallet.gettransaction(transfer["txid"])["fee"])
+        self.sync_mempools()
+        self.generate(self.nodes[0], 1)
+
+        self.assert_fee_only_history(
+            wallet=watch_wallet,
+            txid=transfer["txid"],
+            block_hash=block_hash,
+        )
+        self.nodes[2].unloadwallet("change_only_watch")
+
+    def assert_fee_only_history(self, *, wallet, txid, block_hash):
+        tx = wallet.gettransaction(txid=txid, verbose=True)
+        assert tx["fee"] < 0
+        assert_equal(tx["amount"], 0)
+
+        def check_entry(entry):
+            assert_equal(entry["category"], "send")
+            assert_equal(entry["amount"], 0)
+            assert_equal(entry["fee"], tx["fee"])
+            assert "address" not in entry
+            assert "label" not in entry
+            assert "vout" not in entry
+
+        details = tx["details"]
+        assert_equal(len(details), 1)
+        check_entry(details[0])
+
+        listed = [entry for entry in wallet.listtransactions("*", 1000) if entry["txid"] == txid]
+        assert_equal(len(listed), 1)
+        check_entry(listed[0])
+
+        since = [entry for entry in wallet.listsinceblock(blockhash=block_hash)["transactions"] if entry["txid"] == txid]
+        assert_equal(len(since), 1)
+        check_entry(since[0])
+
+        with_change = [
+            entry for entry in wallet.listsinceblock(blockhash=block_hash, include_change=True)["transactions"]
+            if entry["txid"] == txid
+        ]
+        sent = {entry["vout"]: entry for entry in with_change if entry["category"] == "send"}
+        received = {entry["vout"]: entry for entry in with_change if entry["category"] == "receive"}
+        assert_equal(len(sent), len(tx["decoded"]["vout"]))
+        assert_equal(set(sent), set(received))
+        for vout, sent_entry in sent.items():
+            assert_equal(sent_entry["amount"], -received[vout]["amount"])
+            assert "address" in sent_entry
+            assert wallet.getaddressinfo(sent_entry["address"])["ischange"]
 
     def test_op_return(self):
         """Test if OP_RETURN outputs will be displayed correctly."""


### PR DESCRIPTION
## Summary

Closes #147.

Fee-bearing self-transfers disappeared from default wallet history when every wallet-owned output was classified as change. This PR:

- emits a transaction-level **Payment to self** GUI row showing the net fee debit without a misleading output index;
- emits one fee-only `send` entry from `gettransaction`, `listtransactions`, and default `listsinceblock` output, with `amount: 0`, the negative fee, and no synthetic address, label, or vout;
- preserves the existing detailed send/receive output behavior when `include_change=true`;
- adds spendable and watch-only regression coverage plus focused Qt decomposition tests.

## Testing

- [x] Built locally.
- [x] Ran focused unit or functional tests for the changed area.
- [x] Ran lint or formatting checks relevant to this change.
- [ ] Not run. Reason: N/A; all relevant checks above were run.

Commands/checks:

- `cmake --build build --target test_bitcoin-qt qbitd qbit-cli -j8`
- `ctest --test-dir build -R '^test_qbit-qt$' --output-on-failure`
- `build/test/functional/test_runner.py wallet_listsinceblock.py --jobs=1`
- `cmake --build build --target rpcdocs -j8`
- Docker lint suite from `ci/lint_imagefile`

## Target Branch

- [x] This PR targets `main` or a maintainer-requested release branch such as `0.1.x`.

This PR targets the requested `1.x.x` maintenance branch.

## Risk / Review Notes

- [x] Consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.
- [ ] No consensus, script, crypto, wallet, P2P, release, CI, or security-sensitive behavior changed.

Notes: Wallet history presentation and RPC serialization change. Transaction construction, signing, coin selection, UTXO accounting, and balance calculation are unchanged.

## Docs / Process Impact

Choose exactly one:

- [x] I updated public docs because this PR changes user-visible behavior, integration guidance, release/process guidance, or expected validation.
- [ ] No public docs update needed. Reason:

RPC help now documents the fee-only entry and the optional output-level fields.

## libbitcoinpqc Subtree Checklist (if `src/libbitcoinpqc` changed)

Not applicable; `src/libbitcoinpqc` is unchanged.

- [ ] Source commit is reachable from an immutable release tag in `Qbit-Org/qbit-libbitcoinpqc`.
- [ ] qbit imports the tagged upstream tree directly without pruning or a curated subtree branch.
- [ ] Subtree import/update was performed with `contrib/devtools/update-libbitcoinpqc-subtree.sh`.
- [ ] `test/lint/libbitcoinpqc-subtree-check.sh` passes locally.
- [ ] Any default tag change in `contrib/devtools/update-libbitcoinpqc-subtree.sh` is intentional and matches `doc/subtrees/libbitcoinpqc.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8155f2b0bb7f1576f317c6194597978e63cfaea2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789140115&installation_model_id=424701&pr_number=150&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F150&signature=6c038081ddc4eb4ce6734f890e963a9ad43139e611f64b081292fed4ba36b05d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->