### PR TITLE
wallet: default -fallbackfee to the minimum relay fee

### DIFF
--- a/doc/man/qbit-qt.1
+++ b/doc/man/qbit-qt.1
@@ -491,7 +491,7 @@ limited by the fee estimate for the longest target
 .IP
 A fee rate (in QBT/kvB) that will be used when fee estimation has
 insufficient data. 0 to entirely disable the fallbackfee feature.
-(default: 0.00)
+(default: 0.0000025)
 .HP
 \fB\-keypool=\fR<n>
 .IP

--- a/doc/man/qbitd.1
+++ b/doc/man/qbitd.1
@@ -491,7 +491,7 @@ limited by the fee estimate for the longest target
 .IP
 A fee rate (in QBT/kvB) that will be used when fee estimation has
 insufficient data. 0 to entirely disable the fallbackfee feature.
-(default: 0.00)
+(default: 0.0000025)
 .HP
 \fB\-keypool=\fR<n>
 .IP

--- a/doc/release-notes-151.md
+++ b/doc/release-notes-151.md
@@ -1,0 +1,15 @@
+Wallet fallback fee enabled by default
+======================================
+
+The wallet's `-fallbackfee` now defaults to the minimum relay fee rate
+(250 sat/kvB, i.e. 0.0000025 QBT/kvB) instead of being disabled. Previously,
+when the fee estimator had no data — the normal state on a young chain with an
+empty mempool — transaction creation failed with "Fee estimation failed.
+Fallbackfee is disabled." Wallets now pay the relay floor in that case.
+
+The fallback is only used when no smart fee estimate is available; live
+estimates take precedence as soon as the estimator has observed confirming
+transactions. The final feerate is still clamped to at least the node's
+required and mempool minimum feerates, so the fallback can never underpay
+relay policy. Set `-fallbackfee=0` to restore the previous behavior of
+failing instead.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -14,6 +14,7 @@
 #include <logging.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
+#include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <primitives/transaction_identifier.h>
 #include <script/interpreter.h>
@@ -112,8 +113,14 @@ std::unique_ptr<WalletDatabase> MakeWalletDatabase(const std::string& name, cons
 
 //! -paytxfee default
 constexpr CAmount DEFAULT_PAY_TX_FEE = 0;
-//! -fallbackfee default
-static const CAmount DEFAULT_FALLBACK_FEE = 0;
+//! -fallbackfee default. Unlike Bitcoin Core (which disables the fallback fee
+//! on mainnet), qbit defaults to the minimum relay fee rate so that wallets can
+//! create transactions while the chain is young and the fee estimator has no
+//! data (an empty mempool yields no estimates, see GetMinimumFeeRate()). The
+//! required-fee clamp in GetMinimumFeeRate() ensures this can never underpay
+//! relay policy, and organic fee estimates take precedence once available.
+//! Set -fallbackfee=0 to restore the upstream behavior of failing instead.
+static const CAmount DEFAULT_FALLBACK_FEE = DEFAULT_MIN_RELAY_TX_FEE;
 //! -discardfee default
 static const CAmount DEFAULT_DISCARD_FEE = 10000;
 //! -mintxfee default


### PR DESCRIPTION
## Problem

On a default-configured mainnet node, sending funds fails with:

```
Transaction creation failed: Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.
```

The wallet's smart fee estimator (`CBlockPolicyEstimator`) only learns from transactions it observes entering the mempool and later confirming. On a young chain the mempool is usually empty, so `estimateSmartFee` returns no estimate, and the wallet falls through to `m_fallback_fee` (`src/wallet/fees.cpp`). Since we inherit Bitcoin Core's `DEFAULT_FALLBACK_FEE = 0` (disabled), transaction creation fails outright.

This is a chicken-and-egg problem: the estimator can't gather data until people send transactions, and default-configured wallets can't send transactions until the estimator has data. Bitcoin Core 30.x behaves identically — this isn't a node-misconfiguration issue, it's a default that doesn't fit an early-days chain.

## Change

Default `-fallbackfee` to `DEFAULT_MIN_RELAY_TX_FEE` (250 sat/kvB) instead of 0. When there is no fee market, the minimum relay rate *is* the correct rate to pay.

## Why this is safe

- **Can never underpay relay policy.** `GetMinimumFeeRate()` clamps the final rate to at least the required feerate (max of `-mintxfee` and the node's minrelay rate) and the mempool minimum fee, after applying the fallback.
- **Never overrides real estimates.** The fallback is used only when `estimateSmartFee` returns nothing; once the chain has organic fee traffic, smart estimates take precedence automatically.
- **Bitcoin Core's rationale doesn't apply.** Core disabled the mainnet fallback in v0.19 because its old default (20 sat/vB) was a stale guess at a *market* rate — on a congested chain that either overpays badly or strands transactions. Our fallback equals the relay floor, not a market guess, so neither failure mode applies. If qbit ever sustains congestion, a fallback-fee transaction simply pays minrelay and waits, like any other floor-rate transaction, and the estimator takes over within a few blocks of the wallet seeing traffic.
- **Opt-out preserved.** `-fallbackfee=0` restores the upstream fail-instead behavior. The existing GUI warning label still appears whenever the fallback rate is in use.

## Notes

- The `-fallbackfee` help text derives its default from the constant, so it updates automatically; the generated man pages are refreshed to match (`FormatMoney(250)` = 0.0000025 QBT/kvB).
- `test/functional/wallet_fallbackfee.py` passes unchanged — it pins `-fallbackfee` explicitly for both the enabled and disabled paths, and the test framework already writes `fallbackfee=0.0002` into regtest configs, so no test behavior changes.
- Built and ran `wallet_fallbackfee.py` locally: passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Qbit-Org/codesmith/qbit/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790174324&installation_model_id=424701&pr_number=151&repository=Qbit-Org%2Fqbit&return_to=https%3A%2F%2Fgithub.com%2FQbit-Org%2Fqbit%2Fpull%2F151&signature=9d261bb202abc0cb111dce996df23e77f9f5aa3d63b9f54680555d84dec1b36e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
